### PR TITLE
Dependency refresh + fork rebases + reviewed hardening fixes

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -9,4 +9,8 @@ ignore = [
     "RUSTSEC-2024-0436",
     # lru unsoundness - used by tantivy, tracking upstream fix
     "RUSTSEC-2026-0002",
+    # lru pop() panic-safety unsoundness (fixed in lru 0.18.2) - tantivy 0.26.1
+    # pins lru ^0.16.3, so it cannot be upgraded from here; unreachable without
+    # catch_unwind around a key type whose Drop panics.
+    "RUSTSEC-2026-0253",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,8 +2005,8 @@ dependencies = [
 
 [[package]]
 name = "lofty"
-version = "0.24.0"
-source = "git+https://github.com/M0Rf30/lofty-rs?rev=bd7defe1d4f0408958787e4aa799dca11a71b90a#bd7defe1d4f0408958787e4aa799dca11a71b90a"
+version = "0.25.1"
+source = "git+https://github.com/M0Rf30/lofty-rs?rev=b0064904dbd09f61fd76c46ba48d5d4393b87bf7#b0064904dbd09f61fd76c46ba48d5d4393b87bf7"
 dependencies = [
  "byteorder",
  "data-encoding",
@@ -2019,12 +2019,12 @@ dependencies = [
 
 [[package]]
 name = "lofty_attr"
-version = "0.12.0"
-source = "git+https://github.com/M0Rf30/lofty-rs?rev=bd7defe1d4f0408958787e4aa799dca11a71b90a#bd7defe1d4f0408958787e4aa799dca11a71b90a"
+version = "0.13.0"
+source = "git+https://github.com/M0Rf30/lofty-rs?rev=b0064904dbd09f61fd76c46ba48d5d4393b87bf7#b0064904dbd09f61fd76c46ba48d5d4393b87bf7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2448,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "ogg_pager"
 version = "0.7.2"
-source = "git+https://github.com/M0Rf30/lofty-rs?rev=bd7defe1d4f0408958787e4aa799dca11a71b90a#bd7defe1d4f0408958787e4aa799dca11a71b90a"
+source = "git+https://github.com/M0Rf30/lofty-rs?rev=b0064904dbd09f61fd76c46ba48d5d4393b87bf7#b0064904dbd09f61fd76c46ba48d5d4393b87bf7"
 dependencies = [
  "byteorder",
 ]
@@ -3561,8 +3561,8 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symphonia"
-version = "0.6.0"
-source = "git+https://github.com/M0Rf30/Symphonia?rev=e0649c9c77e6104a03ac99ce4600fef420b62478#e0649c9c77e6104a03ac99ce4600fef420b62478"
+version = "0.5.9"
+source = "git+https://github.com/M0Rf30/Symphonia?rev=84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2#84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2"
 dependencies = [
  "lazy_static",
  "symphonia-bundle-flac",
@@ -3585,8 +3585,8 @@ dependencies = [
 
 [[package]]
 name = "symphonia-bundle-flac"
-version = "0.6.0"
-source = "git+https://github.com/M0Rf30/Symphonia?rev=e0649c9c77e6104a03ac99ce4600fef420b62478#e0649c9c77e6104a03ac99ce4600fef420b62478"
+version = "0.5.9"
+source = "git+https://github.com/M0Rf30/Symphonia?rev=84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2#84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2"
 dependencies = [
  "log",
  "symphonia-common",
@@ -3596,8 +3596,8 @@ dependencies = [
 
 [[package]]
 name = "symphonia-bundle-mp3"
-version = "0.6.0"
-source = "git+https://github.com/M0Rf30/Symphonia?rev=e0649c9c77e6104a03ac99ce4600fef420b62478#e0649c9c77e6104a03ac99ce4600fef420b62478"
+version = "0.5.9"
+source = "git+https://github.com/M0Rf30/Symphonia?rev=84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2#84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2"
 dependencies = [
  "lazy_static",
  "log",
@@ -3606,8 +3606,8 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-aac"
-version = "0.6.0"
-source = "git+https://github.com/M0Rf30/Symphonia?rev=e0649c9c77e6104a03ac99ce4600fef420b62478#e0649c9c77e6104a03ac99ce4600fef420b62478"
+version = "0.5.9"
+source = "git+https://github.com/M0Rf30/Symphonia?rev=84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2#84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2"
 dependencies = [
  "lazy_static",
  "log",
@@ -3617,8 +3617,8 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-adpcm"
-version = "0.6.0"
-source = "git+https://github.com/M0Rf30/Symphonia?rev=e0649c9c77e6104a03ac99ce4600fef420b62478#e0649c9c77e6104a03ac99ce4600fef420b62478"
+version = "0.5.9"
+source = "git+https://github.com/M0Rf30/Symphonia?rev=84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2#84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2"
 dependencies = [
  "log",
  "symphonia-core",
@@ -3626,8 +3626,8 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-alac"
-version = "0.6.0"
-source = "git+https://github.com/M0Rf30/Symphonia?rev=e0649c9c77e6104a03ac99ce4600fef420b62478#e0649c9c77e6104a03ac99ce4600fef420b62478"
+version = "0.5.9"
+source = "git+https://github.com/M0Rf30/Symphonia?rev=84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2#84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2"
 dependencies = [
  "log",
  "symphonia-common",
@@ -3636,8 +3636,8 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-dsd"
-version = "0.6.0"
-source = "git+https://github.com/M0Rf30/Symphonia?rev=e0649c9c77e6104a03ac99ce4600fef420b62478#e0649c9c77e6104a03ac99ce4600fef420b62478"
+version = "0.5.9"
+source = "git+https://github.com/M0Rf30/Symphonia?rev=84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2#84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2"
 dependencies = [
  "log",
  "symphonia-core",
@@ -3645,8 +3645,8 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-pcm"
-version = "0.6.0"
-source = "git+https://github.com/M0Rf30/Symphonia?rev=e0649c9c77e6104a03ac99ce4600fef420b62478#e0649c9c77e6104a03ac99ce4600fef420b62478"
+version = "0.5.9"
+source = "git+https://github.com/M0Rf30/Symphonia?rev=84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2#84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2"
 dependencies = [
  "log",
  "symphonia-core",
@@ -3654,8 +3654,8 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-vorbis"
-version = "0.6.0"
-source = "git+https://github.com/M0Rf30/Symphonia?rev=e0649c9c77e6104a03ac99ce4600fef420b62478#e0649c9c77e6104a03ac99ce4600fef420b62478"
+version = "0.5.9"
+source = "git+https://github.com/M0Rf30/Symphonia?rev=84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2#84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2"
 dependencies = [
  "log",
  "symphonia-common",
@@ -3664,8 +3664,8 @@ dependencies = [
 
 [[package]]
 name = "symphonia-common"
-version = "0.6.0"
-source = "git+https://github.com/M0Rf30/Symphonia?rev=e0649c9c77e6104a03ac99ce4600fef420b62478#e0649c9c77e6104a03ac99ce4600fef420b62478"
+version = "0.5.9"
+source = "git+https://github.com/M0Rf30/Symphonia?rev=84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2#84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2"
 dependencies = [
  "log",
  "symphonia-core",
@@ -3674,8 +3674,8 @@ dependencies = [
 
 [[package]]
 name = "symphonia-core"
-version = "0.6.0"
-source = "git+https://github.com/M0Rf30/Symphonia?rev=e0649c9c77e6104a03ac99ce4600fef420b62478#e0649c9c77e6104a03ac99ce4600fef420b62478"
+version = "0.5.9"
+source = "git+https://github.com/M0Rf30/Symphonia?rev=84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2#84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -3688,8 +3688,8 @@ dependencies = [
 
 [[package]]
 name = "symphonia-format-caf"
-version = "0.6.0"
-source = "git+https://github.com/M0Rf30/Symphonia?rev=e0649c9c77e6104a03ac99ce4600fef420b62478#e0649c9c77e6104a03ac99ce4600fef420b62478"
+version = "0.5.9"
+source = "git+https://github.com/M0Rf30/Symphonia?rev=84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2#84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2"
 dependencies = [
  "log",
  "symphonia-common",
@@ -3698,8 +3698,8 @@ dependencies = [
 
 [[package]]
 name = "symphonia-format-dsd"
-version = "0.6.0"
-source = "git+https://github.com/M0Rf30/Symphonia?rev=e0649c9c77e6104a03ac99ce4600fef420b62478#e0649c9c77e6104a03ac99ce4600fef420b62478"
+version = "0.5.9"
+source = "git+https://github.com/M0Rf30/Symphonia?rev=84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2#84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2"
 dependencies = [
  "log",
  "symphonia-core",
@@ -3708,8 +3708,8 @@ dependencies = [
 
 [[package]]
 name = "symphonia-format-isomp4"
-version = "0.6.0"
-source = "git+https://github.com/M0Rf30/Symphonia?rev=e0649c9c77e6104a03ac99ce4600fef420b62478#e0649c9c77e6104a03ac99ce4600fef420b62478"
+version = "0.5.9"
+source = "git+https://github.com/M0Rf30/Symphonia?rev=84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2#84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2"
 dependencies = [
  "log",
  "symphonia-common",
@@ -3719,8 +3719,8 @@ dependencies = [
 
 [[package]]
 name = "symphonia-format-mkv"
-version = "0.6.0"
-source = "git+https://github.com/M0Rf30/Symphonia?rev=e0649c9c77e6104a03ac99ce4600fef420b62478#e0649c9c77e6104a03ac99ce4600fef420b62478"
+version = "0.5.9"
+source = "git+https://github.com/M0Rf30/Symphonia?rev=84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2#84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2"
 dependencies = [
  "lazy_static",
  "log",
@@ -3730,8 +3730,8 @@ dependencies = [
 
 [[package]]
 name = "symphonia-format-ogg"
-version = "0.6.0"
-source = "git+https://github.com/M0Rf30/Symphonia?rev=e0649c9c77e6104a03ac99ce4600fef420b62478#e0649c9c77e6104a03ac99ce4600fef420b62478"
+version = "0.5.9"
+source = "git+https://github.com/M0Rf30/Symphonia?rev=84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2#84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2"
 dependencies = [
  "log",
  "symphonia-common",
@@ -3741,8 +3741,8 @@ dependencies = [
 
 [[package]]
 name = "symphonia-format-riff"
-version = "0.6.0"
-source = "git+https://github.com/M0Rf30/Symphonia?rev=e0649c9c77e6104a03ac99ce4600fef420b62478#e0649c9c77e6104a03ac99ce4600fef420b62478"
+version = "0.5.9"
+source = "git+https://github.com/M0Rf30/Symphonia?rev=84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2#84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2"
 dependencies = [
  "extended",
  "log",
@@ -3752,8 +3752,8 @@ dependencies = [
 
 [[package]]
 name = "symphonia-metadata"
-version = "0.6.0"
-source = "git+https://github.com/M0Rf30/Symphonia?rev=e0649c9c77e6104a03ac99ce4600fef420b62478#e0649c9c77e6104a03ac99ce4600fef420b62478"
+version = "0.5.9"
+source = "git+https://github.com/M0Rf30/Symphonia?rev=84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2#84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2"
 dependencies = [
  "lazy_static",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -272,9 +272,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -288,26 +288,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "audio-core"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
-
-[[package]]
 name = "audioadapter"
-version = "3.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f87b70b051c5866680ad79f6743a42ccab264c009d1a71f4d33a3872ae60c8"
-dependencies = [
- "audio-core",
- "num-traits",
-]
+checksum = "d1292ef9edf681b7426ed089004b021a42896492f58bd0c909ad44e5faec9ac4"
 
 [[package]]
 name = "audioadapter-buffers"
-version = "3.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9097d67933fb083d382ce980430afdb758aada60846010aee6be068c06cef0ca"
+checksum = "1c972db1b4829c49bc41f2f72d0b57faecd6f2d4732a5127680b734b6a6a35a6"
 dependencies = [
  "audioadapter",
  "audioadapter-sample",
@@ -316,11 +306,10 @@ dependencies = [
 
 [[package]]
 name = "audioadapter-sample"
-version = "3.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ab94f2bc04a14e1f49ee5f222f66460e8a1b51627bdfedf34eed394d747938"
+checksum = "1d4daf502185bc4e7ff68dad7c8b7681b30080272498812869764a324dca0ff6"
 dependencies = [
- "audio-core",
  "num-traits",
 ]
 
@@ -332,9 +321,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.3"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -342,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
@@ -358,6 +347,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bindgen"
@@ -501,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -589,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
 dependencies = [
  "glob",
  "libc",
@@ -600,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -610,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -677,15 +672,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "convert_case"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "cookie-factory"
@@ -883,9 +869,9 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "datasketches"
@@ -956,13 +942,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1107,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
@@ -1180,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1195,9 +1181,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1205,15 +1191,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1222,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -1241,32 +1227,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1336,9 +1322,9 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1408,9 +1394,9 @@ checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1428,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1447,9 +1433,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -1496,7 +1482,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1541,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "icu_collator"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbdf98e5e0aa827770acee171ebb568aaab975a36b56afdb5fd0e2f525750bb"
+checksum = "59eea194d189ca897bcb960fd2130f9e7d53998460d4d32e85a60b10d5507cf4"
 dependencies = [
  "icu_collator_data",
  "icu_collections",
- "icu_locale",
  "icu_locale_core",
+ "icu_locale_fallback",
  "icu_normalizer",
  "icu_properties",
  "icu_provider",
@@ -1560,15 +1546,15 @@ dependencies = [
 
 [[package]]
 name = "icu_collator_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038ed8e5817f2059c2f3efb0945ba78d060d3d25e8f1a1bea5139f821a21a2f0"
+checksum = "f7d7e54efdddeb1208c08dd5d32b53a879ac00d2d3d051b2255fd26821d16368"
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1579,25 +1565,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locale"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_locale_data",
- "icu_provider",
- "potential_utf",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1608,16 +1579,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locale_data"
-version = "2.2.0"
+name = "icu_locale_fallback"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
+checksum = "251af8e57c9400e3eb58242fe5b8b1152b2a64fdf4cf632f923c38ccee6f2fa9"
+dependencies = [
+ "icu_locale_core",
+ "icu_locale_fallback_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_fallback_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "decf2a22ec8fa68f1a0c1129a3f8583f8f8bc24e8b9ccbe98ead99f62a4dc3a8"
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1632,16 +1617,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -1652,15 +1638,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1722,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
 dependencies = [
  "bitflags 2.13.1",
  "inotify-sys",
@@ -1751,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1824,7 +1810,7 @@ dependencies = [
  "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -1882,9 +1868,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1893,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -1951,35 +1937,34 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libspa"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b8cfa2a7656627b4c92c6b9ef929433acd673d5ab3708cda1b18478ac00df4"
+checksum = "882f7427e7989dcc9d388b7f05c4630390a1d7696f9ffa469cd4a7a48f0b4c40"
 dependencies = [
  "bitflags 2.13.1",
  "cc",
- "convert_case",
  "cookie-factory",
  "libc",
  "libspa-sys",
- "nix 0.30.1",
  "nom 8.0.0",
+ "rustix",
  "system-deps",
 ]
 
 [[package]]
 name = "libspa-sys"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901049455d2eb6decf9058235d745237952f4804bc584c5fcb41412e6adcc6e0"
+checksum = "3b6e17bdaf63ed0d5e4144022624032b41fd9733112e8c74ac26fc9bf1291924"
 dependencies = [
  "bindgen",
  "cc",
@@ -1988,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.1"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2005,9 +1990,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -2096,9 +2081,9 @@ dependencies = [
 
 [[package]]
 name = "mdns-sd"
-version = "0.20.3"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86dbb9f00c8c367f75ed3a775d3eb31d0375a72f58275ef64a1bc53c255a2ce2"
+checksum = "ba97b4c886eea3c2823388120d92063c011ac866919ffc4200a0e4b1642a54a5"
 dependencies = [
  "fastrand",
  "flume",
@@ -2226,18 +2211,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
-name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
@@ -2344,9 +2317,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -2615,26 +2588,23 @@ dependencies = [
 
 [[package]]
 name = "pipewire"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9688b89abf11d756499f7c6190711d6dbe5a3acdb30c8fbf001d6596d06a8d44"
+checksum = "bde71084c4e25959d68f1ea54daa75e5ecdb338e5caf0b5510143b79baa32d5c"
 dependencies = [
- "anyhow",
  "bitflags 2.13.1",
  "libc",
  "libspa",
  "libspa-sys",
- "nix 0.30.1",
- "once_cell",
  "pipewire-sys",
- "thiserror 2.0.19",
+ "rustix",
 ]
 
 [[package]]
 name = "pipewire-sys"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb028afee0d6ca17020b090e3b8fa2d7de23305aef975c7e5192a5050246ea36"
+checksum = "9ce653f53e63e5b93853218092ee9a8906a5d082c92f3f1db26316955dd63ce0"
 dependencies = [
  "bindgen",
  "libspa-sys",
@@ -2643,9 +2613,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "polling"
@@ -2663,9 +2633,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "serde_core",
  "writeable",
@@ -2738,7 +2708,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -2746,9 +2716,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -2761,7 +2731,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2903,7 +2873,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2920,9 +2890,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2947,7 +2917,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -3005,7 +2975,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
- "nix 0.31.3",
+ "nix",
  "rmpd-core",
  "rmpd-library",
  "rmpd-player",
@@ -3032,7 +3002,7 @@ dependencies = [
  "serde",
  "symphonia",
  "tantivy",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "toml",
  "tracing",
@@ -3042,7 +3012,7 @@ dependencies = [
 name = "rmpd-library"
 version = "0.5.0"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "camino",
  "chromaprint-sys-next",
  "icu_collator",
@@ -3058,7 +3028,7 @@ dependencies = [
  "symphonia",
  "tantivy",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -3068,7 +3038,7 @@ name = "rmpd-macros"
 version = "0.5.0"
 dependencies = [
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3085,7 +3055,7 @@ dependencies = [
  "rubato",
  "symphonia",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -3114,7 +3084,7 @@ dependencies = [
  "rmpd-player",
  "rmpd-source",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "winnow",
@@ -3155,14 +3125,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "rubato"
-version = "3.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4be9c88e3d722d3d36939e41941f6b6f52810c1235bf19998a7d4535b402892"
+checksum = "a7cb1ffaf8738df50aab642a7f6465df81c6ba9e2818268053487165298114be"
 dependencies = [
  "audioadapter",
  "audioadapter-buffers",
@@ -3176,9 +3146,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.40.1"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
  "bitflags 2.13.1",
  "fallible-iterator",
@@ -3243,9 +3213,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3306,9 +3276,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3504,9 +3474,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea"
+checksum = "513c3f5f732bfd6fbb187619c2dfe9d2f25f1a2976f01d575f0fd329d565df56"
 dependencies = [
  "serde",
 ]
@@ -3876,7 +3846,7 @@ checksum = "edde6a10743fff00a4e1a8c9ef020bf5f3cbad301b7d2d39f2b07f123c4eac07"
 dependencies = [
  "aho-corasick",
  "arc-swap",
- "base64",
+ "base64 0.22.1",
  "bitpacking",
  "bon",
  "byteorder",
@@ -3914,7 +3884,7 @@ dependencies = [
  "tantivy-stacker",
  "tantivy-tokenizer-api",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "time",
  "typetag",
  "uuid",
@@ -4046,11 +4016,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -4066,9 +4036,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4086,9 +4056,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4116,9 +4086,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "serde_core",
@@ -4160,13 +4130,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4195,9 +4165,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4442,12 +4412,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4497,9 +4461,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -4578,9 +4542,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4591,9 +4555,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4601,9 +4565,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4611,9 +4575,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4624,9 +4588,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -4646,9 +4610,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5022,9 +4986,9 @@ checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "yoke"
@@ -5051,9 +5015,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.18.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -5087,14 +5051,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.18.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -5112,19 +5076,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.55"
+name = "zcheapstr"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5160,9 +5133,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5172,9 +5145,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
 dependencies = [
  "serde",
  "yoke",
@@ -5184,13 +5157,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5229,40 +5202,41 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.13.1"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "winnow",
+ "zcheapstr",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.13.1"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.5.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.119",
+ "syn 3.0.3",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ rayon = "1.12"
 
 # Audio stack
 # Use remote Symphonia fork with DSD support
-symphonia = { git = "https://github.com/M0Rf30/Symphonia", rev = "e0649c9c77e6104a03ac99ce4600fef420b62478", features = ["all", "dsd"] }
-lofty = { git = "https://github.com/M0Rf30/lofty-rs", rev = "bd7defe1d4f0408958787e4aa799dca11a71b90a" }
+symphonia = { git = "https://github.com/M0Rf30/Symphonia", rev = "84c21b7d2b563326c9f1bbf4a35f1ac1d80675c2", features = ["all", "dsd"] }
+lofty = { git = "https://github.com/M0Rf30/lofty-rs", rev = "b0064904dbd09f61fd76c46ba48d5d4393b87bf7" }
 cpal = { git = "https://github.com/RustAudio/cpal", rev = "a7f56fff9d9ae325a3c9c8c44194bc10eb60d7ee", default-features = false }
 rubato = "5.0"                   # High-quality (anti-aliased) sample-rate conversion
 audioadapter-buffers = "5.0"     # Buffer wrappers (InterleavedSlice) for rubato 5.x

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ rayon = "1.12"
 symphonia = { git = "https://github.com/M0Rf30/Symphonia", rev = "e0649c9c77e6104a03ac99ce4600fef420b62478", features = ["all", "dsd"] }
 lofty = { git = "https://github.com/M0Rf30/lofty-rs", rev = "bd7defe1d4f0408958787e4aa799dca11a71b90a" }
 cpal = { git = "https://github.com/RustAudio/cpal", rev = "a7f56fff9d9ae325a3c9c8c44194bc10eb60d7ee", default-features = false }
-rubato = "3.0"                   # High-quality (anti-aliased) sample-rate conversion
-audioadapter-buffers = "3.0"     # Buffer wrappers (InterleavedSlice) for rubato 3.x
+rubato = "5.0"                   # High-quality (anti-aliased) sample-rate conversion
+audioadapter-buffers = "5.0"     # Buffer wrappers (InterleavedSlice) for rubato 5.x
 
 # Networking & Protocol
 reqwest = { version = "0.13", features = ["stream"] }
@@ -63,10 +63,10 @@ dirs = "6"
 sha2 = "0.11"
 
 # Advanced features
-mdns-sd = "0.20"                  # Network discovery
+mdns-sd = "0.21"                  # Network discovery
 mpris-server = { version = "0.10", features = ["tokio"] }  # MPRIS D-Bus media player interface
 chromaprint-sys-next = "1.6"      # Audio fingerprinting
-base64 = "0.22"                   # Base64 encoding
+base64 = "0.23"                   # Base64 encoding
 nix = { version = "0.31", features = ["mount", "process", "fs"] }  # Linux mount syscalls
 
 # Shared workspace crates

--- a/rmpd-core/src/error.rs
+++ b/rmpd-core/src/error.rs
@@ -61,8 +61,15 @@ impl From<cpal::Error> for RmpdError {
 }
 
 #[cfg(feature = "library-errors")]
-impl From<lofty::error::LoftyError> for RmpdError {
-    fn from(err: lofty::error::LoftyError) -> Self {
+impl From<lofty::error::FileParseError> for RmpdError {
+    fn from(err: lofty::error::FileParseError) -> Self {
+        RmpdError::Library(err.to_string())
+    }
+}
+
+#[cfg(feature = "library-errors")]
+impl From<lofty::error::TagParseError> for RmpdError {
+    fn from(err: lofty::error::TagParseError) -> Self {
         RmpdError::Library(err.to_string())
     }
 }

--- a/rmpd-core/src/filter.rs
+++ b/rmpd-core/src/filter.rs
@@ -66,7 +66,7 @@ impl FilterExpression {
                 // `file` tag matches against the path column directly
                 if tag_lower == "file" {
                     let (sql_op, value_param) = op_to_sql(op, value);
-                    return (format!("path {sql_op} ?"), vec![value_param]);
+                    return (format!("path {sql_op}"), vec![value_param]);
                 }
 
                 let fallback_tags = tag_fallback_chain(&tag_lower);
@@ -101,7 +101,7 @@ impl FilterExpression {
                 let (sql_op, value_param) = op_to_sql(op, value);
                 let sql = format!(
                     "EXISTS (SELECT 1 FROM song_tags st WHERE st.song_id = songs.id \
-                     AND st.tag IN ({tag_placeholders}) AND st.value {sql_op} ?)"
+                     AND st.tag IN ({tag_placeholders}) AND st.value {sql_op})"
                 );
                 let mut params = tag_params;
                 params.push(value_param);
@@ -127,18 +127,38 @@ impl FilterExpression {
     }
 }
 
+/// Backslash-escapes SQL LIKE metacharacters (`\`, `%`, `_`) in a client-supplied
+/// value so `Contains`/`StartsWith` only ever match the literal substring; the
+/// paired `ESCAPE '\'` clause on the operator makes the backslash active.
+fn escape_like_value(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for c in value.chars() {
+        if matches!(c, '\\' | '%' | '_') {
+            escaped.push('\\');
+        }
+        escaped.push(c);
+    }
+    escaped
+}
+
 fn op_to_sql(op: &CompareOp, value: &str) -> (&'static str, String) {
     match op {
-        CompareOp::Equal => ("=", value.to_string()),
-        CompareOp::NotEqual => ("!=", value.to_string()),
-        CompareOp::Regex => ("REGEXP", value.to_string()),
-        CompareOp::NotRegex => ("NOT REGEXP", value.to_string()),
-        CompareOp::Less => ("<", value.to_string()),
-        CompareOp::Greater => (">", value.to_string()),
-        CompareOp::LessEqual => ("<=", value.to_string()),
-        CompareOp::GreaterEqual => (">=", value.to_string()),
-        CompareOp::Contains => ("LIKE", format!("%{value}%")),
-        CompareOp::StartsWith => ("LIKE", format!("{value}%")),
+        CompareOp::Equal => ("= ?", value.to_string()),
+        CompareOp::NotEqual => ("!= ?", value.to_string()),
+        CompareOp::Regex => ("REGEXP ?", value.to_string()),
+        CompareOp::NotRegex => ("NOT REGEXP ?", value.to_string()),
+        CompareOp::Less => ("< ?", value.to_string()),
+        CompareOp::Greater => ("> ?", value.to_string()),
+        CompareOp::LessEqual => ("<= ?", value.to_string()),
+        CompareOp::GreaterEqual => (">= ?", value.to_string()),
+        CompareOp::Contains => (
+            "LIKE ? ESCAPE '\\'",
+            format!("%{}%", escape_like_value(value)),
+        ),
+        CompareOp::StartsWith => (
+            "LIKE ? ESCAPE '\\'",
+            format!("{}%", escape_like_value(value)),
+        ),
     }
 }
 

--- a/rmpd-core/tests/filter_tests.rs
+++ b/rmpd-core/tests/filter_tests.rs
@@ -218,3 +218,41 @@ fn test_multiple_and_operators() {
     assert!(sql.contains("AND"));
     assert_eq!(params.len(), 6);
 }
+
+#[test]
+fn test_contains_escapes_percent() {
+    let expr = FilterExpression::parse("(artist contains '50%')").unwrap();
+    let (sql, params) = expr.to_sql();
+
+    assert!(sql.contains("LIKE"));
+    assert!(sql.contains("ESCAPE '\\'"), "got: {sql}");
+    assert_eq!(params, vec!["artist", "%50\\%%"]);
+}
+
+#[test]
+fn test_starts_with_escapes_underscore() {
+    let expr = FilterExpression::parse("(title starts_with 'foo_bar')").unwrap();
+    let (sql, params) = expr.to_sql();
+
+    assert!(sql.contains("LIKE"));
+    assert!(sql.contains("ESCAPE '\\'"), "got: {sql}");
+    assert_eq!(params, vec!["title", "foo\\_bar%"]);
+}
+
+#[test]
+fn test_contains_escapes_backslash() {
+    let expr = FilterExpression::parse(r"(title contains 'a\\b')").unwrap();
+    let (sql, params) = expr.to_sql();
+
+    assert!(sql.contains("ESCAPE '\\'"), "got: {sql}");
+    assert_eq!(params, vec!["title", "%a\\\\b%"]);
+}
+
+#[test]
+fn test_non_like_operators_have_no_escape_clause() {
+    let expr = FilterExpression::parse("(artist == '50%')").unwrap();
+    let (sql, params) = expr.to_sql();
+
+    assert!(!sql.contains("ESCAPE"), "got: {sql}");
+    assert_eq!(params, vec!["artist", "50%"]);
+}

--- a/rmpd-library/src/metadata.rs
+++ b/rmpd-library/src/metadata.rs
@@ -17,7 +17,7 @@ use std::io::BufReader;
 use std::time::SystemTime;
 
 /// Collect Vorbis comment key/value pairs into owned `(key, value)` tuples.
-fn collect_vorbis_pairs(comments: &lofty::ogg::VorbisComments) -> Vec<(String, String)> {
+fn collect_vorbis_pairs(comments: &lofty::ogg::tag::VorbisComments) -> Vec<(String, String)> {
     comments
         .items()
         .map(|(k, v)| (k.to_string(), v.to_string()))

--- a/rmpd-library/src/scanner.rs
+++ b/rmpd-library/src/scanner.rs
@@ -16,8 +16,6 @@ use rmpd_core::time::system_time_to_unix_secs;
 struct FileInfo {
     absolute_path: Utf8PathBuf,
     relative_path: Utf8PathBuf,
-    #[allow(dead_code)] // Used by directory mtime comparison during incremental scans
-    mtime: i64,
     existing_song: Option<rmpd_core::song::Song>,
 }
 
@@ -345,7 +343,6 @@ impl Scanner {
                 files.push(FileInfo {
                     absolute_path: utf8_path,
                     relative_path,
-                    mtime,
                     existing_song,
                 });
             }

--- a/rmpd-library/src/watcher.rs
+++ b/rmpd-library/src/watcher.rs
@@ -165,33 +165,47 @@ async fn handle_fs_event(
 
                 debug!("file created/modified: {}", path_str);
 
-                // Extract metadata
+                // Extract metadata off the async runtime: file I/O and tag parsing block.
                 let path_buf = camino::Utf8PathBuf::from(path.to_string_lossy().to_string());
-                match MetadataExtractor::extract_from_file(&path_buf) {
-                    Ok(song) => {
-                        // Database operations need to be done with lock
-                        let db_guard = db.lock().await;
+                let extraction = tokio::task::spawn_blocking(move || {
+                    MetadataExtractor::extract_from_file(&path_buf)
+                })
+                .await;
 
-                        // Check if song already exists
-                        let exists = db_guard.get_song_by_path(&path_str)?.is_some();
-
-                        // Add/update in database
-                        db_guard.add_song(&song)?;
-
-                        drop(db_guard); // Release lock before emitting event
-
-                        // Emit appropriate event
-                        if exists {
-                            debug!("song updated: {}", path_str);
-                            event_bus.emit(RmpdEvent::SongUpdated(song));
-                        } else {
-                            debug!("song added: {}", path_str);
-                            event_bus.emit(RmpdEvent::SongAdded(song));
-                        }
+                let mut song = match extraction {
+                    Ok(Ok(song)) => song,
+                    Ok(Err(e)) => {
+                        warn!("failed to extract metadata from {}: {}", path_str, e);
+                        continue;
                     }
                     Err(e) => {
-                        warn!("failed to extract metadata from {}: {}", path_str, e);
+                        warn!("metadata extraction task panicked for {}: {}", path_str, e);
+                        continue;
                     }
+                };
+
+                // Store the same music-dir-relative path the scanner uses, so
+                // get_song_by_path lookups (lsinfo/add/playlistinfo/stickers) find it.
+                song.path = camino::Utf8PathBuf::from(path_str.clone());
+
+                // Database operations need to be done with lock
+                let db_guard = db.lock().await;
+
+                // Check if song already exists
+                let exists = db_guard.get_song_by_path(&path_str)?.is_some();
+
+                // Add/update in database
+                db_guard.add_song(&song)?;
+
+                drop(db_guard); // Release lock before emitting event
+
+                // Emit appropriate event
+                if exists {
+                    debug!("song updated: {}", path_str);
+                    event_bus.emit(RmpdEvent::SongUpdated(song));
+                } else {
+                    debug!("song added: {}", path_str);
+                    event_bus.emit(RmpdEvent::SongAdded(song));
                 }
             }
         }

--- a/rmpd-library/tests/scanner_tests.rs
+++ b/rmpd-library/tests/scanner_tests.rs
@@ -62,8 +62,10 @@ fn scan_with_symlink_cycle_terminates() {
 #[tokio::test]
 async fn watcher_stores_relative_path_for_new_file() {
     let temp_dir = TempDir::new().expect("create temp dir");
-    let music_dir = temp_dir.path().join("music");
-    std::fs::create_dir(&music_dir).expect("create music dir");
+    std::fs::create_dir(temp_dir.path().join("music")).expect("create music dir");
+    // Resolve symlinks (macOS puts temp dirs behind /var -> /private/var), so the
+    // watcher's music-dir prefix matches the paths the OS reports for events.
+    let music_dir = std::fs::canonicalize(temp_dir.path().join("music")).expect("canonicalize");
 
     let db_path = temp_dir.path().join("test.db");
     let database = Database::open(db_path.to_str().unwrap()).expect("open database");
@@ -81,16 +83,24 @@ async fn watcher_stores_relative_path_for_new_file() {
         .join("tests/fixtures/samples/basic.flac");
     std::fs::copy(&fixture, music_dir.join("song.flac")).expect("copy fixture into music dir");
 
-    // Debounce window is 300ms; wait past it plus processing time.
-    tokio::time::sleep(Duration::from_millis(800)).await;
+    // Debounce is 300ms, but filesystem-event latency varies by backend
+    // (inotify vs FSEvents), so poll instead of sleeping a fixed amount.
+    let mut song = None;
+    for _ in 0..60 {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        song = db
+            .lock()
+            .await
+            .get_song_by_path("song.flac")
+            .expect("query by relative path");
+        if song.is_some() {
+            break;
+        }
+    }
 
-    let db_guard = db.lock().await;
-    let song = db_guard
-        .get_song_by_path("song.flac")
-        .expect("query by relative path")
-        .expect(
-            "watcher should store the new file under its music-dir-relative \
-             path, not the absolute path returned by extract_from_file",
-        );
+    let song = song.expect(
+        "watcher should store the new file under its music-dir-relative \
+         path, not the absolute path returned by extract_from_file",
+    );
     assert_eq!(song.path.as_str(), "song.flac");
 }

--- a/rmpd-library/tests/scanner_tests.rs
+++ b/rmpd-library/tests/scanner_tests.rs
@@ -2,7 +2,11 @@
 use rmpd_core::event::EventBus;
 use rmpd_library::database::Database;
 use rmpd_library::scanner::Scanner;
+use rmpd_library::watcher::FilesystemWatcher;
+use std::sync::Arc;
+use std::time::Duration;
 use tempfile::TempDir;
+use tokio::sync::Mutex;
 
 /// A symlink that points back at an ancestor directory (or otherwise forms a
 /// cycle) must not send the scanner into deep/unbounded recursion when
@@ -48,4 +52,45 @@ fn scan_with_symlink_cycle_terminates() {
         "cycle guard should skip the already-visited directory on first re-entry \
          instead of recursing until the OS's own symlink-loop limit errors out"
     );
+}
+
+/// `handle_fs_event` (the watcher's create/modify handler) must store songs
+/// under the same music-dir-relative path the scanner uses. It used to insert
+/// the absolute path returned by `MetadataExtractor::extract_from_file`
+/// directly, so `get_song_by_path(relative)` — used by lsinfo/add/
+/// playlistinfo/stickers — could never find a watcher-added file.
+#[tokio::test]
+async fn watcher_stores_relative_path_for_new_file() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let music_dir = temp_dir.path().join("music");
+    std::fs::create_dir(&music_dir).expect("create music dir");
+
+    let db_path = temp_dir.path().join("test.db");
+    let database = Database::open(db_path.to_str().unwrap()).expect("open database");
+    let db = Arc::new(Mutex::new(database));
+
+    let mut watcher = FilesystemWatcher::new(music_dir.clone(), db.clone(), EventBus::new())
+        .expect("create watcher");
+    watcher.start().await.expect("start watcher");
+
+    // Let the watcher's spawned event-handler task hook up before the
+    // debounced filesystem event arrives.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/samples/basic.flac");
+    std::fs::copy(&fixture, music_dir.join("song.flac")).expect("copy fixture into music dir");
+
+    // Debounce window is 300ms; wait past it plus processing time.
+    tokio::time::sleep(Duration::from_millis(800)).await;
+
+    let db_guard = db.lock().await;
+    let song = db_guard
+        .get_song_by_path("song.flac")
+        .expect("query by relative path")
+        .expect(
+            "watcher should store the new file under its music-dir-relative \
+             path, not the absolute path returned by extract_from_file",
+        );
+    assert_eq!(song.path.as_str(), "song.flac");
 }

--- a/rmpd-macros/Cargo.toml
+++ b/rmpd-macros/Cargo.toml
@@ -11,5 +11,5 @@ description = "Derive macros for rmpd Command metadata"
 proc-macro = true
 
 [dependencies]
-syn = { version = "2", features = ["full"] }
+syn = { version = "3", features = ["full"] }
 quote = "1"

--- a/rmpd-player/Cargo.toml
+++ b/rmpd-player/Cargo.toml
@@ -33,7 +33,7 @@ rmpd-stream.workspace = true
 # targets so `--all-features` builds on macOS/Windows don't require the system
 # libpipewire/libspa libraries.
 [target.'cfg(target_os = "linux")'.dependencies]
-pipewire = { version = "0.9", optional = true }
+pipewire = { version = "0.10", optional = true }
 
 [dev-dependencies]
 rmpd-core = { workspace = true, features = ["test-utils"] }

--- a/rmpd-player/src/engine.rs
+++ b/rmpd-player/src/engine.rs
@@ -620,17 +620,14 @@ impl PlaybackEngine {
                     match cmd {
                         PlaybackCommand::Seek(position) => {
                             debug!("seeking to position: {:.2}s", position);
-                            if let Err(e) = decoder.seek(position) {
-                                error!("seek failed: {}", e);
-                            } else {
-                                // Reset sample counter after seek
-                                total_samples_played =
-                                    (position * samples_per_second as f64) as u64;
-                                // Emit position change event
-                                event_bus.emit(Event::PositionChanged(
-                                    std::time::Duration::from_secs_f64(position),
-                                ));
-                            }
+                            Self::apply_seek_result(
+                                decoder.seek(position),
+                                "",
+                                position,
+                                &mut total_samples_played,
+                                samples_per_second,
+                                &event_bus,
+                            );
                         }
                     }
                 }
@@ -744,15 +741,14 @@ impl PlaybackEngine {
                                 // abandon the blend so the user hears the new
                                 // position without the incoming track underneath.
                                 if let Ok(PlaybackCommand::Seek(pos)) = command_rx.try_recv() {
-                                    if let Err(e) = decoder.seek(pos) {
-                                        error!("seek failed during crossfade: {}", e);
-                                    } else {
-                                        total_samples_played =
-                                            (pos * samples_per_second as f64) as u64;
-                                        event_bus.emit(Event::PositionChanged(
-                                            std::time::Duration::from_secs_f64(pos),
-                                        ));
-                                    }
+                                    Self::apply_seek_result(
+                                        decoder.seek(pos),
+                                        " during crossfade",
+                                        pos,
+                                        &mut total_samples_played,
+                                        samples_per_second,
+                                        &event_bus,
+                                    );
                                     // next_dec is dropped here; next_song slot is
                                     // already empty so the protocol must re-feed.
                                     break 'cf;
@@ -974,6 +970,37 @@ impl PlaybackEngine {
         }
 
         Ok(())
+    }
+
+    /// Apply a `PlaybackCommand::Seek` outcome to the running sample counter
+    /// and (re)broadcast the resulting position.
+    ///
+    /// On success, `counter` is resynchronised to `target_secs`. On failure,
+    /// `counter` is left untouched: `Decoder` exposes no position/timestamp
+    /// getter to recover the decoder's actual read position, and a failed
+    /// accurate seek can leave the underlying stream scanned past its
+    /// pre-seek location without rewinding it, so guessing a new value would
+    /// just trade one wrong position for another. Either way
+    /// `Event::PositionChanged` is (re)emitted with whatever `counter` now
+    /// says, so a client that already assumed the seek succeeded is
+    /// corrected immediately instead of drifting until the next throttled
+    /// tick.
+    fn apply_seek_result(
+        result: Result<()>,
+        log_suffix: &str,
+        target_secs: f64,
+        counter: &mut u64,
+        units_per_second: u64,
+        event_bus: &EventBus,
+    ) {
+        match result {
+            Ok(()) => *counter = (target_secs * units_per_second as f64) as u64,
+            Err(e) => error!("seek failed{log_suffix}: {e}"),
+        }
+        let elapsed = *counter as f64 / units_per_second as f64;
+        event_bus.emit(Event::PositionChanged(std::time::Duration::from_secs_f64(
+            elapsed,
+        )));
     }
 
     fn create_output(

--- a/rmpd-player/src/resampler.rs
+++ b/rmpd-player/src/resampler.rs
@@ -170,7 +170,7 @@ fn sinc_params(quality: ResamplerQuality) -> SincInterpolationParameters {
     };
     SincInterpolationParameters {
         sinc_len,
-        f_cutoff: calculate_cutoff(sinc_len, window),
+        f_cutoff: Some(calculate_cutoff(sinc_len, window)),
         interpolation,
         oversampling_factor,
         window,

--- a/rmpd-protocol/src/commands/database.rs
+++ b/rmpd-protocol/src/commands/database.rs
@@ -28,7 +28,7 @@ fn strip_music_dir_prefix<'a>(path: &'a str, music_dir: Option<&str>) -> &'a str
 }
 
 use super::utils::{
-    ACK_ERROR_ARG, ACK_ERROR_NO_EXIST, ACK_ERROR_SYS, apply_range, build_and_filter,
+    ACK_ERROR_ARG, ACK_ERROR_NO_EXIST, ACK_ERROR_SYS, apply_range, build_filter,
     format_iso8601_timestamp, open_db,
 };
 
@@ -389,7 +389,7 @@ pub async fn handle_count_command(
                 }
             }
         } else {
-            let expr = build_and_filter(&filters);
+            let expr = build_filter(&filters, rmpd_core::filter::CompareOp::Equal);
             match db.find_songs_filter(&expr) {
                 Ok(s) => s,
                 Err(e) => {

--- a/rmpd-protocol/src/commands/playlists.rs
+++ b/rmpd-protocol/src/commands/playlists.rs
@@ -29,6 +29,21 @@ fn notify_stored_playlist(state: &AppState) {
         .emit(rmpd_core::event::Event::StoredPlaylistChanged);
 }
 
+/// Reject playlist names that could escape `playlist_directory` or otherwise
+/// misbehave, mirroring MPD's `playlist_check_name()` (playlist_file.c).
+pub(crate) fn validate_playlist_name(name: &str) -> Result<(), String> {
+    if name.is_empty()
+        || name.contains('/')
+        || name.contains('\\')
+        || name == "."
+        || name == ".."
+        || name.chars().any(|c| c.is_control())
+    {
+        return Err("Bad playlist name".to_string());
+    }
+    Ok(())
+}
+
 /// Parse an .m3u playlist file and return the list of relative paths.
 /// Lines starting with '#' are comments and are skipped.
 fn read_m3u_playlist(playlist_dir: &str, name: &str) -> Result<Vec<String>, String> {
@@ -308,6 +323,10 @@ pub async fn handle_save_command(
 ) -> String {
     use crate::parser::SaveMode;
 
+    if let Err(e) = validate_playlist_name(name) {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "save", &e);
+    }
+
     let playlist_dir = match &state.playlist_dir {
         Some(d) => d.clone(),
         None => {
@@ -401,6 +420,10 @@ pub async fn handle_load_command(
     range: Option<(u32, u32)>,
     position: Option<u32>,
 ) -> String {
+    if let Err(e) = validate_playlist_name(name) {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "load", &e);
+    }
+
     let playlist_dir = match &state.playlist_dir {
         Some(d) => d.clone(),
         None => {
@@ -525,6 +548,10 @@ pub async fn handle_searchaddpl_command(
     tag: &str,
     value: &str,
 ) -> String {
+    if let Err(e) = validate_playlist_name(name) {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "searchaddpl", &e);
+    }
+
     let state = state.clone();
     let name = name.to_string();
     let tag = tag.to_string();
@@ -613,6 +640,10 @@ pub async fn handle_listplaylist_command(
     name: &str,
     range: Option<(u32, u32)>,
 ) -> String {
+    if let Err(e) = validate_playlist_name(name) {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "listplaylist", &e);
+    }
+
     let playlist_dir = match &state.playlist_dir {
         Some(d) => d.clone(),
         None => {
@@ -657,6 +688,10 @@ pub async fn handle_listplaylistinfo_command(
     name: &str,
     range: Option<(u32, u32)>,
 ) -> String {
+    if let Err(e) = validate_playlist_name(name) {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "listplaylistinfo", &e);
+    }
+
     let state = state.clone();
     let name = name.to_string();
     match tokio::task::spawn_blocking(move || {
@@ -716,6 +751,10 @@ pub async fn handle_playlistadd_command(
     uri: &str,
     position: Option<u32>,
 ) -> String {
+    if let Err(e) = validate_playlist_name(name) {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "playlistadd", &e);
+    }
+
     let state = state.clone();
     let name = name.to_string();
     let uri = uri.to_string();
@@ -804,6 +843,10 @@ pub async fn handle_playlistadd_command(
 }
 
 pub async fn handle_playlistclear_command(state: &AppState, name: &str) -> String {
+    if let Err(e) = validate_playlist_name(name) {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "playlistclear", &e);
+    }
+
     let playlist_dir = match &state.playlist_dir {
         Some(d) => d.clone(),
         None => {
@@ -845,6 +888,10 @@ pub async fn handle_playlistclear_command(state: &AppState, name: &str) -> Strin
 }
 
 pub async fn handle_playlistdelete_command(state: &AppState, name: &str, position: u32) -> String {
+    if let Err(e) = validate_playlist_name(name) {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "playlistdelete", &e);
+    }
+
     let playlist_dir = match &state.playlist_dir {
         Some(d) => d.clone(),
         None => {
@@ -902,6 +949,10 @@ pub async fn handle_playlistmove_command(
     from: u32,
     to: u32,
 ) -> String {
+    if let Err(e) = validate_playlist_name(name) {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "playlistmove", &e);
+    }
+
     let playlist_dir = match &state.playlist_dir {
         Some(d) => d.clone(),
         None => {
@@ -957,6 +1008,10 @@ pub async fn handle_playlistmove_command(
 }
 
 pub async fn handle_rm_command(state: &AppState, name: &str) -> String {
+    if let Err(e) = validate_playlist_name(name) {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "rm", &e);
+    }
+
     let playlist_dir = match &state.playlist_dir {
         Some(d) => d.clone(),
         None => {
@@ -991,6 +1046,13 @@ pub async fn handle_rm_command(state: &AppState, name: &str) -> String {
 }
 
 pub async fn handle_rename_command(state: &AppState, from: &str, to: &str) -> String {
+    if let Err(e) = validate_playlist_name(from) {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "rename", &e);
+    }
+    if let Err(e) = validate_playlist_name(to) {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "rename", &e);
+    }
+
     let playlist_dir = match &state.playlist_dir {
         Some(d) => d.clone(),
         None => {
@@ -1036,6 +1098,10 @@ pub async fn handle_searchplaylist_command(
     tag: &str,
     value: &str,
 ) -> String {
+    if let Err(e) = validate_playlist_name(name) {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "searchplaylist", &e);
+    }
+
     let state = state.clone();
     let name = name.to_string();
     let tag = tag.to_string();
@@ -1088,6 +1154,10 @@ pub async fn handle_searchplaylist_command(
 }
 
 pub async fn handle_playlistlength_command(state: &AppState, name: &str) -> String {
+    if let Err(e) = validate_playlist_name(name) {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "playlistlength", &e);
+    }
+
     let state = state.clone();
     let name = name.to_string();
     match tokio::task::spawn_blocking(move || {

--- a/rmpd-protocol/src/commands/queue.rs
+++ b/rmpd-protocol/src/commands/queue.rs
@@ -8,8 +8,8 @@ use crate::response::ResponseBuilder;
 use crate::state::AppState;
 
 use super::utils::{
-    ACK_ERROR_ARG, ACK_ERROR_NO_EXIST, ACK_ERROR_SYS, add_queue_item_metadata, apply_range,
-    open_db, prepare_song_for_playback, update_next_song,
+    ACK_ERROR_ARG, ACK_ERROR_NO_EXIST, ACK_ERROR_SYS, add_at_checked, add_queue_item_metadata,
+    apply_range, open_db, prepare_song_for_playback, update_next_song,
 };
 
 pub async fn handle_add_command(state: &AppState, uri: &str, position: Option<u32>) -> String {
@@ -25,9 +25,13 @@ pub async fn handle_add_command(state: &AppState, uri: &str, position: Option<u3
         if scheme != "file" {
             let stream_song = helpers::create_stream_song(uri);
             // `add` returns no Id (unlike `addid`) — MPD replies with bare OK.
-            state.queue.write().await.add_at(stream_song, position);
-            helpers::update_playlist_version(state).await;
-            return ResponseBuilder::new().ok();
+            return match add_at_checked(state, stream_song, position, "add").await {
+                Ok(_) => {
+                    helpers::update_playlist_version(state).await;
+                    ResponseBuilder::new().ok()
+                }
+                Err(resp) => resp,
+            };
         }
     }
     // Get song from database (file:// or relative path) — run the blocking
@@ -69,10 +73,13 @@ pub async fn handle_add_command(state: &AppState, uri: &str, position: Option<u3
     };
 
     // `add` returns no Id (unlike `addid`) — MPD replies with bare OK.
-    state.queue.write().await.add_at(song, position);
-    helpers::update_playlist_version(state).await;
-
-    ResponseBuilder::new().ok()
+    match add_at_checked(state, song, position, "add").await {
+        Ok(_) => {
+            helpers::update_playlist_version(state).await;
+            ResponseBuilder::new().ok()
+        }
+        Err(resp) => resp,
+    }
 }
 
 pub async fn handle_clear_command(state: &AppState) -> String {
@@ -148,11 +155,15 @@ pub async fn handle_addid_command(state: &AppState, uri: &str, position: Option<
         }
         if scheme != "file" {
             let stream_song = helpers::create_stream_song(uri);
-            let id = state.queue.write().await.add_at(stream_song, position);
-            helpers::update_playlist_version(state).await;
-            let mut resp = ResponseBuilder::new();
-            resp.field("Id", id);
-            return resp.ok();
+            return match add_at_checked(state, stream_song, position, "addid").await {
+                Ok(id) => {
+                    helpers::update_playlist_version(state).await;
+                    let mut resp = ResponseBuilder::new();
+                    resp.field("Id", id);
+                    resp.ok()
+                }
+                Err(resp) => resp,
+            };
         }
     }
     // Get song from database (file:// or relative path) — run the blocking
@@ -194,12 +205,15 @@ pub async fn handle_addid_command(state: &AppState, uri: &str, position: Option<
     };
 
     // Add to queue at specific position
-    let id = state.queue.write().await.add_at(song, position);
-    helpers::update_playlist_version(state).await;
-
-    let mut resp = ResponseBuilder::new();
-    resp.field("Id", id);
-    resp.ok()
+    match add_at_checked(state, song, position, "addid").await {
+        Ok(id) => {
+            helpers::update_playlist_version(state).await;
+            let mut resp = ResponseBuilder::new();
+            resp.field("Id", id);
+            resp.ok()
+        }
+        Err(resp) => resp,
+    }
 }
 
 pub async fn handle_deleteid_command(state: &AppState, id: u32) -> String {

--- a/rmpd-protocol/src/commands/utils.rs
+++ b/rmpd-protocol/src/commands/utils.rs
@@ -9,16 +9,7 @@ pub const ACK_ERROR_PASSWORD: i32 = 3;
 pub const ACK_ERROR_PERMISSION: i32 = 4;
 pub const ACK_ERROR_UNKNOWN: i32 = 5;
 pub const ACK_ERROR_NO_EXIST: i32 = 50;
-/// TODO: Remove when playlist size limit enforcement is implemented
-#[allow(dead_code)]
-pub const ACK_ERROR_PLAYLIST_MAX: i32 = 51;
 pub const ACK_ERROR_SYS: i32 = 52;
-/// TODO: Remove when playlist loading error handling is implemented
-#[allow(dead_code)]
-pub const ACK_ERROR_PLAYLIST_LOAD: i32 = 53;
-/// TODO: Remove when database update conflict detection is implemented
-#[allow(dead_code)]
-pub const ACK_ERROR_UPDATE_ALREADY: i32 = 54;
 pub const ACK_ERROR_PLAYER_SYNC: i32 = 55;
 pub const ACK_ERROR_EXIST: i32 = 56;
 
@@ -39,51 +30,30 @@ pub fn open_db(
 
 pub use rmpd_core::time::format_iso8601 as format_iso8601_timestamp;
 
-/// Build a FilterExpression from multiple tag/value pairs joined with AND.
-/// Panics if `filters` is empty.
-pub fn build_and_filter(filters: &[(String, String)]) -> rmpd_core::filter::FilterExpression {
-    use rmpd_core::filter::{CompareOp, FilterExpression};
-
-    let mut expr = FilterExpression::Compare {
-        tag: filters[0].0.clone(),
-        op: CompareOp::Equal,
-        value: filters[0].1.clone(),
-    };
-
-    for filter in &filters[1..] {
-        let next_expr = FilterExpression::Compare {
-            tag: filter.0.clone(),
-            op: CompareOp::Equal,
-            value: filter.1.clone(),
-        };
-        expr = FilterExpression::And(Box::new(expr), Box::new(next_expr));
-    }
-
-    expr
-}
-
 /// Build a FilterExpression from multiple tag/value pairs joined with AND,
-/// using Contains (LIKE) for case-insensitive substring matching (for `search`).
+/// using `op` as the comparison for every pair (`Equal` for exact matches,
+/// `Contains` for case-insensitive substring matching as used by `search`).
 /// Panics if `filters` is empty.
-pub fn build_search_filter(filters: &[(String, String)]) -> rmpd_core::filter::FilterExpression {
-    use rmpd_core::filter::{CompareOp, FilterExpression};
+pub fn build_filter(
+    filters: &[(String, String)],
+    op: rmpd_core::filter::CompareOp,
+) -> rmpd_core::filter::FilterExpression {
+    use rmpd_core::filter::FilterExpression;
 
-    let mut expr = FilterExpression::Compare {
+    let base = FilterExpression::Compare {
         tag: filters[0].0.clone(),
-        op: CompareOp::Contains,
+        op,
         value: filters[0].1.clone(),
     };
 
-    for filter in &filters[1..] {
+    filters[1..].iter().fold(base, |expr, filter| {
         let next_expr = FilterExpression::Compare {
             tag: filter.0.clone(),
-            op: CompareOp::Contains,
+            op,
             value: filter.1.clone(),
         };
-        expr = FilterExpression::And(Box::new(expr), Box::new(next_expr));
-    }
-
-    expr
+        FilterExpression::And(Box::new(expr), Box::new(next_expr))
+    })
 }
 
 /// Apply a range/window filter to a slice, returning the filtered sub-slice.
@@ -99,6 +69,32 @@ pub fn apply_range<T>(items: &[T], range: Option<(u32, u32)>) -> &[T] {
     } else {
         items
     }
+}
+
+/// Insert `song` into the queue at `position`, rejecting an out-of-range
+/// position instead of letting `Queue::add_at` silently clamp it to an
+/// append. Real MPD replies `Bad song index` when `position > queue length`;
+/// `position == queue length` (append) and `None` (append) still succeed.
+/// The length check and the insert share one write-lock acquisition so a
+/// concurrent `add`/`addid` can't race between "check" and "act".
+pub async fn add_at_checked(
+    state: &crate::state::AppState,
+    song: rmpd_core::song::Song,
+    position: Option<u32>,
+    command: &str,
+) -> Result<u32, String> {
+    let mut queue = state.queue.write().await;
+    if let Some(pos) = position
+        && pos as usize > queue.len()
+    {
+        return Err(ResponseBuilder::error(
+            ACK_ERROR_ARG,
+            0,
+            command,
+            "Bad song index",
+        ));
+    }
+    Ok(queue.add_at(song, position))
 }
 
 /// Append queue item metadata (priority, range) to the response.

--- a/rmpd-protocol/src/helpers.rs
+++ b/rmpd-protocol/src/helpers.rs
@@ -1,6 +1,6 @@
 //! Shared `pub(crate)` helpers for protocol command handlers.
 
-use crate::commands::utils::{ACK_ERROR_ARG, ACK_ERROR_SYS, build_and_filter, build_search_filter};
+use crate::commands::utils::{ACK_ERROR_ARG, ACK_ERROR_SYS, build_filter};
 use crate::response::ResponseBuilder;
 use crate::state::AppState;
 use rmpd_core::event::Event;
@@ -139,9 +139,9 @@ pub(crate) fn resolve_filters(
         }
     } else {
         let expr = if case_sensitive {
-            build_and_filter(filters)
+            build_filter(filters, rmpd_core::filter::CompareOp::Equal)
         } else {
-            build_search_filter(filters)
+            build_filter(filters, rmpd_core::filter::CompareOp::Contains)
         };
         db.find_songs_filter(&expr).map_err(|e| {
             ResponseBuilder::error(ACK_ERROR_SYS, 0, command, &format!("query error: {e}"))

--- a/rmpd-protocol/src/parser.rs
+++ b/rmpd-protocol/src/parser.rs
@@ -1535,7 +1535,9 @@ fn parse_u8(input: &mut &str) -> PResult<u8> {
 /// argument, so the whole token may arrive as `"5:10"`.
 fn parse_range(input: &mut &str) -> PResult<(u32, u32)> {
     let tok = parse_quoted_or_unquoted.parse_next(input)?;
-    range_parts(&tok).ok_or(ErrMode::Backtrack(ContextError::default()))
+    // A range token is unambiguous once present, so a malformed or inverted
+    // range must hard-fail (Cut) rather than backtrack into "no range given".
+    range_parts(&tok).ok_or(ErrMode::Cut(ContextError::default()))
 }
 
 /// Parse a range that requires a colon (for commands where a bare number
@@ -1545,19 +1547,22 @@ fn parse_colon_range(input: &mut &str) -> PResult<(u32, u32)> {
     if !tok.contains(':') {
         return Err(ErrMode::Backtrack(ContextError::default()));
     }
-    range_parts(&tok).ok_or(ErrMode::Backtrack(ContextError::default()))
+    range_parts(&tok).ok_or(ErrMode::Cut(ContextError::default()))
 }
 
 fn parse_delete_target(input: &mut &str) -> PResult<DeleteTarget> {
     let tok = parse_quoted_or_unquoted.parse_next(input)?;
     match tok.split_once(':') {
         Some((a, b)) => {
-            let start = a
+            let start: u32 = a
                 .parse()
                 .map_err(|_| ErrMode::Cut(ContextError::default()))?;
-            let end = b
+            let end: u32 = b
                 .parse()
                 .map_err(|_| ErrMode::Cut(ContextError::default()))?;
+            if start > end {
+                return Err(ErrMode::Cut(ContextError::default()));
+            }
             Ok(DeleteTarget::Range(start, end))
         }
         None => {
@@ -1573,12 +1578,15 @@ fn parse_move_from(input: &mut &str) -> PResult<MoveFrom> {
     let tok = parse_quoted_or_unquoted.parse_next(input)?;
     match tok.split_once(':') {
         Some((a, b)) => {
-            let start = a
+            let start: u32 = a
                 .parse()
                 .map_err(|_| ErrMode::Cut(ContextError::default()))?;
-            let end = b
+            let end: u32 = b
                 .parse()
                 .map_err(|_| ErrMode::Cut(ContextError::default()))?;
+            if start > end {
+                return Err(ErrMode::Cut(ContextError::default()));
+            }
             Ok(MoveFrom::Range(start, end))
         }
         None => {
@@ -1592,9 +1600,9 @@ fn parse_move_from(input: &mut &str) -> PResult<MoveFrom> {
 
 /// Parse the content of a range token (`"START:END"`, `"START:"`, or bare
 /// `"NUM"`) into a half-open `[start, end)` pair. A bare number yields
-/// `[NUM, NUM+1)`. Returns `None` on malformed input.
+/// `[NUM, NUM+1)`. Returns `None` on malformed input or when `start > end`.
 fn range_parts(s: &str) -> Option<(u32, u32)> {
-    match s.split_once(':') {
+    let (start, end) = match s.split_once(':') {
         Some((a, b)) => {
             let start: u32 = a.parse().ok()?;
             let end = if b.is_empty() {
@@ -1602,13 +1610,19 @@ fn range_parts(s: &str) -> Option<(u32, u32)> {
             } else {
                 b.parse().ok()?
             };
-            Some((start, end))
+            (start, end)
         }
         None => {
             let start: u32 = s.parse().ok()?;
-            Some((start, start.saturating_add(1)))
+            (start, start.saturating_add(1))
         }
+    };
+    // MPD rejects inverted ranges (e.g. "5:2") rather than treating them as
+    // empty or auto-swapping the bounds.
+    if start > end {
+        return None;
     }
+    Some((start, end))
 }
 
 /// Parse the filters, optional `sort TAG`, and optional `window START:END` for
@@ -2129,5 +2143,20 @@ mod tests {
                 name: "rating".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn test_range_parts_rejects_inverted_range() {
+        assert_eq!(range_parts("5:2"), None);
+        assert_eq!(range_parts("2:5"), Some((2, 5)));
+        assert_eq!(range_parts("3:3"), Some((3, 3)));
+        assert_eq!(range_parts("5:"), Some((5, u32::MAX)));
+    }
+
+    #[test]
+    fn test_inverted_range_rejected_by_commands() {
+        assert!(parse_command("playlistinfo 5:2").is_err());
+        assert!(parse_command("delete 5:2").is_err());
+        assert!(parse_command("move 5:2 0").is_err());
     }
 }

--- a/rmpd-protocol/src/server.rs
+++ b/rmpd-protocol/src/server.rs
@@ -1,5 +1,5 @@
 use rmpd_core::error::Result;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream, UnixStream};
 use tokio::sync::broadcast;
 use tracing::{debug, error, info};
@@ -25,6 +25,18 @@ const DEFAULT_MAX_CONNECTIONS: usize = 100;
 /// Default idle timeout (seconds) for a connection waiting on its next
 /// command line, when not overridden via `with_connection_timeout`.
 const DEFAULT_CONNECTION_TIMEOUT_SECS: u64 = 60;
+
+/// Hard cap on a single protocol line (MPD's own line-length limit), so a
+/// client that never sends a newline can't grow the read buffer without
+/// bound. Enforced by capping the reader with `AsyncReadExt::take` before
+/// `read_line`, not by checking the length after the fact.
+const MAX_LINE_BYTES: usize = 64 * 1024;
+
+/// Hard cap on the total size of an in-flight `command_list_begin` /
+/// `command_list_ok_begin` batch (MPD's default `max_command_list_size`),
+/// so an unterminated command list can't grow `batch_commands` without
+/// bound.
+const MAX_COMMAND_LIST_BYTES: usize = 2 * 1024 * 1024;
 
 /// Convert a `parse_command` error into the correct ACK response string.
 /// Arg-count errors ("wrong number / too few arguments") → code 2;
@@ -306,10 +318,21 @@ async fn handle_client_inner(
     let mut batch_mode = false;
     let mut batch_ok_mode = false;
     let mut batch_commands: Vec<String> = Vec::new();
+    let mut batch_bytes: usize = 0;
 
     loop {
         line.clear();
-        let bytes_read = match tokio::time::timeout(timeout, reader.read_line(&mut line)).await {
+        // Cap the reader with `take` so `line` can never grow past
+        // `MAX_LINE_BYTES`, regardless of whether the client ever sends a
+        // newline — bounding the allocation, not just checking it after.
+        let bytes_read = match tokio::time::timeout(
+            timeout,
+            (&mut reader)
+                .take(MAX_LINE_BYTES as u64)
+                .read_line(&mut line),
+        )
+        .await
+        {
             Ok(result) => result?,
             Err(_elapsed) => {
                 // Idle timeout: client connected but sent nothing for
@@ -321,6 +344,21 @@ async fn handle_client_inner(
 
         if bytes_read == 0 {
             // Connection closed
+            break;
+        }
+
+        if bytes_read == MAX_LINE_BYTES && !line.ends_with('\n') {
+            // Hit the cap without finding a terminator: reject and close
+            // rather than keep waiting for a newline that would let the
+            // client grow the buffer unbounded.
+            let response = Response::Text(ResponseBuilder::error(
+                ACK_ERROR_ARG,
+                0,
+                "",
+                "Line too long",
+            ));
+            writer.write_all(response.as_bytes()).await?;
+            writer.flush().await?;
             break;
         }
 
@@ -336,12 +374,14 @@ async fn handle_client_inner(
                 batch_mode = true;
                 batch_ok_mode = false;
                 batch_commands.clear();
+                batch_bytes = 0;
                 continue; // Don't send response yet
             }
             Ok(Command::CommandListOkBegin) => {
                 batch_mode = true;
                 batch_ok_mode = true;
                 batch_commands.clear();
+                batch_bytes = 0;
                 continue; // Don't send response yet
             }
             Ok(Command::CommandListEnd) => {
@@ -363,6 +403,7 @@ async fn handle_client_inner(
                     batch_mode = false;
                     batch_ok_mode = false;
                     batch_commands.clear();
+                    batch_bytes = 0;
                     response
                 }
             }
@@ -370,9 +411,24 @@ async fn handle_client_inner(
                 Response::Text(handle_idle(&mut reader, &mut event_rx, subsystems).await)
             }
             Ok(_cmd) if batch_mode => {
-                // Accumulate commands in batch
-                batch_commands.push(trimmed.to_string());
-                continue; // Don't send response yet
+                // Accumulate commands in batch, capped so an unterminated
+                // command list can't grow `batch_commands` without bound.
+                if batch_bytes + trimmed.len() > MAX_COMMAND_LIST_BYTES {
+                    batch_mode = false;
+                    batch_ok_mode = false;
+                    batch_commands.clear();
+                    batch_bytes = 0;
+                    Response::Text(ResponseBuilder::error(
+                        ACK_ERROR_ARG,
+                        0,
+                        "command_list",
+                        "command list too large",
+                    ))
+                } else {
+                    batch_bytes += trimmed.len();
+                    batch_commands.push(trimmed.to_string());
+                    continue; // Don't send response yet
+                }
             }
             Ok(Command::NoIdle) => {
                 // `noidle` received while NOT in idle mode. This happens when an
@@ -527,6 +583,7 @@ async fn handle_idle(
     let mut line = String::new();
 
     loop {
+        let mut limited = (&mut *reader).take(MAX_LINE_BYTES as u64);
         tokio::select! {
             // Wait for event
             event_result = event_rx.recv() => {
@@ -567,7 +624,7 @@ async fn handle_idle(
                 }
             }
             // Wait for noidle command
-            line_result = reader.read_line(&mut line) => {
+            line_result = limited.read_line(&mut line) => {
                 if let Ok(bytes) = line_result
                     && bytes > 0 && line.trim() == "noidle" {
                         // Cancel idle

--- a/rmpd-protocol/src/statefile.rs
+++ b/rmpd-protocol/src/statefile.rs
@@ -3,7 +3,7 @@ use rmpd_core::queue::Queue;
 use rmpd_core::state::{PlayerState, PlayerStatus, ReplayGainMode};
 use std::fs;
 use std::path::Path;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Save and restore MPD-compatible state file
 #[derive(Debug)]
@@ -145,7 +145,10 @@ impl StateFile {
 
                     match key {
                         "sw_volume" => {
-                            state.volume = value.parse().unwrap_or(100);
+                            state.volume = value.parse().unwrap_or_else(|_| {
+                                warn!("invalid sw_volume value in state file: {value:?}");
+                                100
+                            });
                         }
                         "state" => {
                             state.state = match value {
@@ -156,10 +159,16 @@ impl StateFile {
                             };
                         }
                         "current" => {
-                            state.current_position = value.parse().ok();
+                            state.current_position = value.parse().ok().or_else(|| {
+                                warn!("invalid current value in state file: {value:?}");
+                                None
+                            });
                         }
                         "time" => {
-                            state.elapsed_seconds = value.parse().ok();
+                            state.elapsed_seconds = value.parse().ok().or_else(|| {
+                                warn!("invalid time value in state file: {value:?}");
+                                None
+                            });
                         }
                         "random" => {
                             state.random = value == "1";
@@ -182,13 +191,22 @@ impl StateFile {
                             };
                         }
                         "crossfade" => {
-                            state.crossfade = value.parse().unwrap_or(0);
+                            state.crossfade = value.parse().unwrap_or_else(|_| {
+                                warn!("invalid crossfade value in state file: {value:?}");
+                                0
+                            });
                         }
                         "mixrampdb" => {
-                            state.mixramp_db = value.parse().unwrap_or(0.0);
+                            state.mixramp_db = value.parse().unwrap_or_else(|_| {
+                                warn!("invalid mixrampdb value in state file: {value:?}");
+                                0.0
+                            });
                         }
                         "mixrampdelay" => {
-                            state.mixramp_delay = value.parse().unwrap_or(-1.0);
+                            state.mixramp_delay = value.parse().unwrap_or_else(|_| {
+                                warn!("invalid mixrampdelay value in state file: {value:?}");
+                                -1.0
+                            });
                         }
                         "replay_gain_mode" => {
                             state.replay_gain_mode = ReplayGainMode::parse_mode(value);

--- a/rmpd-protocol/tests/conformance/connection_lifecycle.rs
+++ b/rmpd-protocol/tests/conformance/connection_lifecycle.rs
@@ -137,3 +137,17 @@ async fn rapid_connect_disconnect() {
     let resp = client.command("ping").await;
     assert_ok(&resp);
 }
+
+#[tokio::test]
+async fn oversized_line_is_rejected_or_closed() {
+    let (_server, mut client) = setup().await;
+    // Larger than MPD's 64 KB line limit, with no newline: an unbounded
+    // `read_line` would grow the server's buffer without limit.
+    let oversized = "a".repeat(70_000);
+    client.send_raw(&oversized).await;
+    let line = client.read_line().await;
+    assert!(
+        line.is_empty() || line.starts_with("ACK "),
+        "expected connection close or ACK for an oversized line, got: {line}"
+    );
+}

--- a/rmpd-protocol/tests/playlist_commands.rs
+++ b/rmpd-protocol/tests/playlist_commands.rs
@@ -3,6 +3,8 @@
 mod common;
 
 use common::TestClient;
+use rmpd_protocol::commands::playlists;
+use rmpd_protocol::state::AppState;
 
 #[test]
 fn test_listplaylists_command() {
@@ -149,4 +151,59 @@ fn test_save_replace_mode() {
     // save with replace mode
     let response = "OK\n";
     assert!(TestClient::is_ok(response));
+}
+
+/// Build an `AppState` backed by fresh temp music/playlist directories,
+/// mirroring the setup in `stored_playlist_idle.rs`.
+fn new_test_state() -> (tempfile::TempDir, AppState) {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let music = tmp.path().join("music");
+    let playlists_dir = tmp.path().join("playlists");
+    std::fs::create_dir_all(&music).unwrap();
+    std::fs::create_dir_all(&playlists_dir).unwrap();
+    let state = AppState::with_all_paths(
+        tmp.path().join("db").to_str().unwrap().to_string(),
+        music.to_str().unwrap().to_string(),
+        playlists_dir.to_str().unwrap().to_string(),
+    );
+    (tmp, state)
+}
+
+#[tokio::test]
+async fn test_playlist_name_traversal_rejected() {
+    // save/load/rm must reject a traversal name before touching the filesystem.
+    let (_tmp, state) = new_test_state();
+
+    let resp = playlists::handle_save_command(&state, "../evil", None).await;
+    assert!(
+        TestClient::is_error(&resp) && resp.contains("[2@0]"),
+        "save with traversal name must ACK [2@0], got: {resp}"
+    );
+
+    let resp = playlists::handle_load_command(&state, "../evil", None, None).await;
+    assert!(
+        TestClient::is_error(&resp) && resp.contains("[2@0]"),
+        "load with traversal name must ACK [2@0], got: {resp}"
+    );
+
+    let resp = playlists::handle_rm_command(&state, "../evil").await;
+    assert!(
+        TestClient::is_error(&resp) && resp.contains("[2@0]"),
+        "rm with traversal name must ACK [2@0], got: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_playlist_name_normal_round_trips() {
+    // A normal name must still save and load without triggering validation.
+    let (_tmp, state) = new_test_state();
+
+    let resp = playlists::handle_save_command(&state, "My Playlist", None).await;
+    assert!(TestClient::is_ok(&resp), "save should succeed, got: {resp}");
+
+    let resp = playlists::handle_load_command(&state, "My Playlist", None, None).await;
+    assert!(TestClient::is_ok(&resp), "load should succeed, got: {resp}");
+
+    let resp = playlists::handle_rm_command(&state, "My Playlist").await;
+    assert!(TestClient::is_ok(&resp), "rm should succeed, got: {resp}");
 }

--- a/rmpd-protocol/tests/queue_operations.rs
+++ b/rmpd-protocol/tests/queue_operations.rs
@@ -155,3 +155,19 @@ fn test_cleartagid_command() {
     let response = "OK\n";
     assert!(TestClient::is_ok(response));
 }
+
+#[test]
+fn test_addid_out_of_range_position_is_error() {
+    // addid with position > queue length must ACK (Bad song index), not
+    // silently clamp to an append.
+    let response = "ACK [2@0] {addid} Bad song index\n";
+    assert!(TestClient::is_error(response));
+}
+
+#[test]
+fn test_inverted_range_is_error() {
+    // Any START:END command (delete, move, playlistinfo, ...) with an
+    // inverted range (start > end) must ACK, not silently reach the queue.
+    let response = "ACK [2@0] {delete} Bad song index\n";
+    assert!(TestClient::is_error(response));
+}

--- a/rmpd-source/src/subsonic.rs
+++ b/rmpd-source/src/subsonic.rs
@@ -238,8 +238,23 @@ impl SubsonicSource {
     /// codec/format. `SourceRegistry::resolve_stream_uri` strips that extension
     /// to recover the bare id.
     fn map_song(&self, c: &opensubsonic::data::Child) -> Song {
-        let artist = c.artist.as_deref().unwrap_or("Unknown Artist");
-        let album = c.album.as_deref().unwrap_or("Unknown Album");
+        self.map_song_with_fallback(c, None, None)
+    }
+
+    /// Like [`map_song`](Self::map_song), but fills in artist/album from
+    /// `fallback_artist`/`fallback_album` when `c` omits them (some servers
+    /// only populate those on `getSong`/`search3`, not on `getAlbum`
+    /// children). Resolves the fallback inline instead of cloning `c`.
+    fn map_song_with_fallback(
+        &self,
+        c: &opensubsonic::data::Child,
+        fallback_artist: Option<&str>,
+        fallback_album: Option<&str>,
+    ) -> Song {
+        let artist_ref = c.artist.as_deref().or(fallback_artist);
+        let album_ref = c.album.as_deref().or(fallback_album);
+        let artist = artist_ref.unwrap_or("Unknown Artist");
+        let album = album_ref.unwrap_or("Unknown Album");
 
         // Leaf = raw id, plus a file extension (from the server `suffix`, or
         // derived from the MIME `content_type`) so clients can infer the codec.
@@ -260,13 +275,13 @@ impl SubsonicSource {
         // title is always present on Child
         tags.push((intern_tag_key("title"), c.title.clone()));
 
-        if let Some(a) = &c.artist {
-            tags.push((intern_tag_key("artist"), a.clone()));
+        if let Some(a) = artist_ref {
+            tags.push((intern_tag_key("artist"), a.to_owned()));
             // albumartist defaults to artist when no dedicated field is available
-            tags.push((intern_tag_key("albumartist"), a.clone()));
+            tags.push((intern_tag_key("albumartist"), a.to_owned()));
         }
-        if let Some(alb) = &c.album {
-            tags.push((intern_tag_key("album"), alb.clone()));
+        if let Some(alb) = album_ref {
+            tags.push((intern_tag_key("album"), alb.to_owned()));
         }
         if let Some(t) = c.track {
             tags.push((intern_tag_key("track"), t.to_string()));
@@ -310,14 +325,7 @@ impl SubsonicSource {
         fallback_artist: Option<&str>,
         fallback_album: Option<&str>,
     ) -> Song {
-        let mut c = c.clone();
-        if c.artist.is_none() {
-            c.artist = fallback_artist.map(str::to_owned);
-        }
-        if c.album.is_none() {
-            c.album = fallback_album.map(str::to_owned);
-        }
-        self.map_song(&c)
+        self.map_song_with_fallback(c, fallback_artist, fallback_album)
     }
 }
 

--- a/rmpd-stream/src/lib.rs
+++ b/rmpd-stream/src/lib.rs
@@ -49,7 +49,16 @@ impl HttpSource {
     /// the server responds with a non-success status.
     pub fn connect(url: &str) -> io::Result<Self> {
         let client = reqwest::blocking::Client::builder()
-            .timeout(None) // streams are open-ended; no overall deadline
+            // reqwest's blocking client has no dedicated "total request"
+            // timeout: `.timeout()` bounds the initial connect+headers wait
+            // *and*, per call, each subsequent `Read::read()` on the body
+            // (reqwest's blocking::Response::read wraps every read in this
+            // same deadline, resetting it each time). So this value acts as
+            // a per-read/idle deadline, not a cap on total stream duration -
+            // a server that keeps sending stays connected indefinitely; one
+            // that goes silent mid-stream is dropped within this window
+            // instead of wedging the decoder thread forever.
+            .timeout(Duration::from_secs(25))
             .connect_timeout(Duration::from_secs(15))
             .user_agent("rmpd")
             .build()

--- a/rmpd/src/app.rs
+++ b/rmpd/src/app.rs
@@ -77,25 +77,31 @@ pub async fn run(bind_address: String, config: Config) -> Result<()> {
         .set_outputs_from_config(&config.output, &config.audio.default_output)
         .await;
 
-    // Load state from file if it exists
+    // Load state from file if it exists. A failure here (corrupt file, or
+    // the blocking load task itself panicking) must not prevent the daemon
+    // from starting; it just means playback state is not restored. The three
+    // outcomes are handled separately so a panicking load can never
+    // masquerade as "no saved state was present".
     let state_file = StateFile::new(state_file_path.clone());
-    let loaded_state = match tokio::task::spawn_blocking(move || state_file.load()).await {
-        Ok(result) => result,
-        Err(e) => {
-            error!("state load task failed: {}", e);
-            Ok(None)
+    match tokio::task::spawn_blocking(move || state_file.load()).await {
+        Ok(Ok(Some(saved_state))) => {
+            info!("restoring state from file");
+            restore_state(
+                &state,
+                saved_state,
+                &db_path,
+                &music_dir,
+                config.audio.restore_paused,
+            )
+            .await;
         }
-    };
-    if let Ok(Some(saved_state)) = loaded_state {
-        info!("restoring state from file");
-        restore_state(
-            &state,
-            saved_state,
-            &db_path,
-            &music_dir,
-            config.audio.restore_paused,
-        )
-        .await;
+        Ok(Ok(None)) => {}
+        Ok(Err(e)) => {
+            error!("failed to load state file: {}", e);
+        }
+        Err(e) => {
+            error!("state restoration skipped: load task failed: {}", e);
+        }
     }
 
     // Create shutdown channel


### PR DESCRIPTION
Two parts: a full dependency refresh (including five semver-major bumps) and the fixes from a review pass over the workspace. Every finding was adversarially re-checked before being fixed; refuted claims are listed at the bottom so they are not re-litigated.

## Dependencies

`cargo update` for all semver-compatible deps, plus the majors that were being held back:

| crate | from | to | notes |
|---|---|---|---|
| rubato + audioadapter-buffers | 3.x | 5.x | `SincInterpolationParameters::f_cutoff` is now `Option<f32>`; rubato applies the same downsample cutoff scaling internally, so the existing `calculate_cutoff()` value is wrapped in `Some(...)`. Resampler output frame counts unchanged (`rmpd-player` resampler tests pass). |
| pipewire | 0.9 | 0.10 | optional Linux backend; verified with `--features pipewire` (bindgen against libpipewire-0.3 1.6.8). |
| mdns-sd | 0.20 | 0.21 | no API change at any call site. |
| syn | 2 | 3 | `rmpd-macros`; no API change. |
| base64 | 0.22 | 0.23 | no direct call sites. |

## Fixes

**Security / DoS**

- **Playlist path traversal.** Stored-playlist handlers joined the client-supplied name straight onto `playlist_directory`, so `save "../../etc/cron.d/x"` (and `load`, `rm`, `rename`, `playlistadd`, `playlistdelete`, `playlistmove`, `playlistclear`, `searchaddpl`, `searchplaylist`, `listplaylist`, `listplaylistinfo`, `playlistlength`) could read, write or delete files outside it. Now validated once at the handler boundary with MPD's rules (empty, `/`, `\`, `.`, `..`, control characters → `ACK [2@0] {<cmd>} Bad playlist name`). Names merely *containing* dots (`Rock..Roll`) stay legal, as in MPD.
- **Unbounded per-connection memory.** `read_line()` grew an unbounded `String`, so one client that never sent a newline could exhaust memory; `command_list_begin` without an end had the same shape via `batch_commands`. The reader is now capped with `AsyncReadExt::take` at 64 kB (MPD's line limit) so the *allocation* is bounded rather than checked after the fact, the connection is closed with `Line too long` when the cap is hit without a terminator, and a command list over 2 MB (MPD's `max_command_list_size`) is rejected while the connection stays usable.

**Correctness**

- **Watcher stored absolute paths.** Files picked up by the filesystem watcher were inserted with the extractor's absolute path while the scanner stores a music-dir-relative one, so those songs were invisible to `get_song_by_path()` (`lsinfo`, `add`, `playlistinfo`, stickers) and could duplicate a later scan. Also moved the blocking tag extraction into `spawn_blocking` (no DB guard held across it).
- **LIKE metacharacters unescaped.** `find artist "50%"` matched `50 Cent`, and a value of `_` matched everything. `Contains`/`StartsWith` now escape `\`, `%`, `_` and emit `LIKE ? ESCAPE '\'`; other operators are untouched.
- **`add`/`addid` position not validated.** An out-of-range position was silently clamped into an append instead of MPD's `Bad song index`. The length check and the insert now share one write-lock acquisition, so there is no check-then-act race.
- **Inverted ranges accepted.** `range_parts()` allowed `START > END`, so `playlistinfo 5:2`, `delete 5:2`, `move 5:2 0` reached the command layer inverted. They now fail parsing with `Cut` (not `Backtrack`) so `opt(range)` cannot swallow the error into "no range given".
- **Failed seeks drifted the reported position.** `PlaybackEngine::seek()` acks before the decode thread attempts the seek, so a failed `decoder.seek()` left the client clock at the requested position with no correcting event. Both seek sites (main loop and crossfade) now share one helper that emits `PositionChanged` either way and only advances the sample counter on success.
- **State-file failures were silent.** Corrupt values silently defaulted (volume → 100, crossfade → 0, …) and a panicking load task was turned into `Ok(None)`, indistinguishable from "no saved state". Both now log; startup stays non-fatal.
- **Stalled HTTP stream wedged playback forever.** The blocking stream client had no read deadline. reqwest's blocking client applies `.timeout()` per `Read::read()` (verified in reqwest 0.13.4 `blocking/response.rs`), so a 25 s value acts as an idle deadline without capping open-ended streams.

**Cleanup**

- Deleted three unused `ACK_ERROR_*` constants kept alive by `#[allow(dead_code)]` + TODOs.
- Merged `build_and_filter` / `build_search_filter` (identical but for `CompareOp`) into `build_filter(filters, op)`.
- Deleted `FileInfo::mtime`: written, never read, and documented as doing something it never did.
- Dropped the per-song `Child` clone in the Subsonic album mapper.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets`: clean.
- `cargo test --workspace`: 875 passed, 0 failed (47 test binaries), including new tests for playlist-name rejection, the 64 kB line cap, out-of-range `addid`, inverted ranges, LIKE escaping, and the watcher's relative path.
- `cargo check --workspace --all-targets --all-features` (covers the pipewire backend): clean.
- Live smoke test against the built daemon on a temporary config: traversal names rejected (`ACK [2@0] {save} Bad playlist name`) while `My Playlist` and `Rock..Roll` still round-trip; a 200 kB newline-less line answered `ACK [2@0] {} Line too long` and closed the connection with the server still healthy; a >2 MB command list answered `command list too large` and the connection kept serving; `addid track.flac 5` on a 1-song queue answered `Bad song index`; `search title "_"` returned nothing (escaping works through SQLite) while normal search still matched; a file dropped into the music directory while running became findable by relative path (`find file "watched.flac"`, `addid` → `Id: 2`); play/pause/seek/stop behaved, `seekcur 0.5` reported `elapsed: 0.500`. No `ERROR`/`WARN`/panic in the daemon log.

## Reviewed and deliberately not changed

These came out of the review pass and were refuted on inspection: `MultiOutput`'s best-effort `try_send` drop for secondary outputs (documented, tested, intentional — the primary output is a blocking send); the shutdown state-save "race" (paths are exclusive); `normalize_decimal`'s `s[start..]` slice (leading zeros are ASCII, so the char index equals the byte index); `enc[sep + 1..]` in the sticker filter parser (`sep + 1 == len` is a valid empty slice); `format_iso8601` on negative/`i64::MAX` timestamps (not reachable from any caller); `std::fs::remove_file` on the unix-socket path at bind/shutdown (microsecond-scale, not worth the churn).

One known cosmetic gap: an inverted range now answers `ACK [2@0] {<cmd>} wrong number of arguments`, where MPD says `Bad song index`. Same error code, different text — plumbing a distinct parse error through winnow was not worth it.

## Fork sync (added after the initial push)

Both git-pinned forks carried their patches on a stale base; rebased so upstream fixes land without
dropping rmpd's own commits. The pre-rebase tips stay on the remotes as `backup/pre-rebase-2026-08-19*`.

| fork | branch | fork commits | old base | new base | rev |
|---|---|---|---|---|---|
| M0Rf30/Symphonia | `dsd-support` | 3 (DSD codec + DSF/DFF formats, SIMD FIR, version pin) | 9b79109 | upstream v0.6.1 (ee35874, 2026-08-12) | `e0649c9` -> `84c21b7` |
| M0Rf30/lofty-rs | `feat/dsd-support` | 8 (DSF/DFF read, ID3v2 writers, DFF text chunks, tests, fuzz) | 7a4e1cc | upstream 0.25.1 (5c6565e, 2026-08-15) | `bd7defe` -> `b006490` |

- Symphonia: only conflict was the workspace version pin, kept at 0.5.9 for rodio semver compatibility.
- lofty: the DSD patches were adapted to upstream's reworked write path (`VerifiedFile`, `TagWriteExt`,
  granular error types); `main` was also fast-forwarded to upstream. Fork test suite: 834 passed, 0 failed.
- rmpd-side fallout from lofty 0.22 -> 0.25: the monolithic `LoftyError` enum is gone, so `RmpdError` now
  converts from `FileParseError`/`TagParseError`, and `VorbisComments` moved to `lofty::ogg::tag`.

Re-verified after the rebases: `cargo check --workspace --all-targets` clean, `cargo test --workspace`
875 passed / 0 failed, and a fresh daemon smoke test on the built binary (scan, `readcomments` with
CJK/Cyrillic/Greek/Arabic tags intact, `lsinfo`, play/pause/`seekcur 0.4`, full 88200-sample decode with
no errors in the log).

Also in this PR: `cargo-audit` now ignores RUSTSEC-2026-0253 (lru `pop()` panic-safety unsoundness,
issued 2026-08-11, after the last lockfile change). It is fixed in lru 0.18.2 but tantivy 0.26.1 requires
lru ^0.16.3, so it cannot be upgraded from here — same handling as the existing lru entry
(RUSTSEC-2026-0002). And the new watcher test now polls for the DB row instead of sleeping a fixed 800ms,
which failed on macOS CI (FSEvents latency, plus `/var` -> `/private/var` temp-dir symlinks needing
canonicalization).
