### PR TITLE
MPD 0.24 protocol compliance: 27 divergences fixed, verified against the real MPD binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3078,6 +3078,7 @@ dependencies = [
  "mdns-sd",
  "mpris-server",
  "rand 0.10.2",
+ "regex",
  "rmpd-core",
  "rmpd-library",
  "rmpd-macros",

--- a/rmpd-core/src/event.rs
+++ b/rmpd-core/src/event.rs
@@ -45,6 +45,12 @@ pub enum Event {
     // Output events
     OutputsChanged,
 
+    // Partition events
+    PartitionsChanged,
+
+    // Mount events
+    MountsChanged,
+
     // Filesystem watcher events
     FilesystemWatchStarted,
     FilesystemWatchStopped,
@@ -53,6 +59,16 @@ pub enum Event {
     SongDeleted {
         path: String,
     },
+
+    // Sticker events
+    /// A sticker was set, incremented/decremented, or deleted.
+    StickerChanged,
+
+    // Client-to-client messaging events
+    /// A client subscribed to or unsubscribed from a channel.
+    SubscriptionChanged,
+    /// A message was delivered to at least one subscriber.
+    MessageReceived,
 }
 
 /// Maps to MPD's idle subsystems
@@ -97,7 +113,11 @@ impl Event {
                 &[Subsystem::Database]
             }
             Event::OutputsChanged => &[Subsystem::Output],
-            Event::FilesystemWatchStarted | Event::FilesystemWatchStopped => &[],
+            Event::PartitionsChanged => &[Subsystem::Partition],
+            Event::MountsChanged => &[Subsystem::Mount],
+            Event::StickerChanged => &[Subsystem::Sticker],
+            Event::SubscriptionChanged => &[Subsystem::Subscription],
+            Event::MessageReceived => &[Subsystem::Message],
             _ => &[],
         }
     }

--- a/rmpd-core/src/filter.rs
+++ b/rmpd-core/src/filter.rs
@@ -1,111 +1,372 @@
-/// MPD filter expression parsing and evaluation
-/// Implements the filter syntax introduced in MPD 0.21+
-///
-/// Grammar:
-/// EXPRESSION := (EXPRESSION)
-///            | (EXPRESSION) AND (EXPRESSION)
-///            | (EXPRESSION) OR (EXPRESSION)
-///            | ! EXPRESSION
-///            | TAG OPERATOR VALUE
-/// OPERATOR := == | != | =~ | !~ | < | > | <= | >=
+//! MPD filter expression parsing and evaluation.
+//!
+//! Mirrors `src/song/Filter.cxx` in upstream MPD (0.21+ grammar) plus the
+//! explicit case-sensitivity operators added in 0.24. MPD only supports
+//! `AND` (no `OR`) at the expression level; negation always wraps a fully
+//! parenthesized group.
+//!
+//! ```text
+//! GROUP  := '(' GROUP ')'
+//!         | '(' GROUP ('AND' GROUP)+ ')'
+//!         | '(' '!' GROUP ')'
+//!         | '(' TERM ')'
+//! TERM   := ('any' | 'file' | 'filename' | TAG) STROP QUOTED
+//!         | 'base' QUOTED
+//!         | 'modified-since' QUOTED
+//!         | 'added-since' QUOTED
+//!         | 'AudioFormat' ('==' | '=~') QUOTED
+//!         | 'prio' '>=' NUMBER
+//! STROP  := '==' | '!=' | '=~' | '!~'
+//!         | 'contains' | '!contains' | 'starts_with' | '!starts_with'
+//!         | 'eq_cs' | 'eq_ci' | '!eq_cs' | '!eq_ci'
+//!         | 'contains_cs' | 'contains_ci' | '!contains_cs' | '!contains_ci'
+//!         | 'starts_with_cs' | 'starts_with_ci' | '!starts_with_cs' | '!starts_with_ci'
+//! ```
+//!
+//! The legacy pre-0.21 syntax (`find TAG VALUE [TAG VALUE ...]`) is handled
+//! by [`FilterExpression::from_pairs`], which mirrors `SongFilter::Parse`'s
+//! per-pair dispatch (same special tag names, AND-combined).
 use crate::error::{Result, RmpdError};
+use crate::path::uri_safe_local;
+use crate::song::canonical_tag_name;
 use crate::tag::tag_fallback_chain;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum FilterExpression {
-    /// Tag comparison: tag, operator, value
+    /// Tag (or `any`/`file`) comparison.
     Compare {
         tag: String,
         op: CompareOp,
         value: String,
+        case_sensitive: bool,
+        negated: bool,
     },
-    /// Logical AND
+    /// `(base "URI")`: restrict to songs under the given directory.
+    Base(String),
+    /// `(modified-since "TIMESTAMP")`, stored as a Unix timestamp.
+    ModifiedSince(i64),
+    /// `(added-since "TIMESTAMP")`, stored as a Unix timestamp.
+    AddedSince(i64),
+    /// `(AudioFormat == 'SAMPLERATE:BITS:CHANNELS')` (or `=~` for a mask;
+    /// `None` components are wildcards).
+    AudioFormat {
+        sample_rate: Option<u32>,
+        bits: Option<u16>,
+        channels: Option<u8>,
+    },
+    /// `(prio >= N)`. Database songs are never queued, so this only matches
+    /// when `N == 0` (MPD's default song priority).
+    Priority(u8),
     And(Box<FilterExpression>, Box<FilterExpression>),
-    /// Logical OR
-    Or(Box<FilterExpression>, Box<FilterExpression>),
-    /// Logical NOT
     Not(Box<FilterExpression>),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompareOp {
-    Equal,        // ==
-    NotEqual,     // !=
-    Regex,        // =~
-    NotRegex,     // !~
-    Less,         // <
-    Greater,      // >
-    LessEqual,    // <=
-    GreaterEqual, // >=
-    Contains,     // contains
-    StartsWith,   // starts_with
+    Equal,      // == / eq_cs / eq_ci
+    Contains,   // contains / contains_cs / contains_ci
+    StartsWith, // starts_with / starts_with_cs / starts_with_ci
+    Regex,      // =~
+}
+
+/// Classification of a filter term's leading identifier, mirroring
+/// `locate_parse_type()` in MPD's Filter.cxx. Note the mixed case rules: MPD
+/// checks `file`/`filename`/`any`/`AudioFormat`/`prio` case-insensitively but
+/// `base`/`modified-since`/`added-since` with exact-case `strcmp`.
+enum FilterKeyword {
+    File,
+    Any,
+    Base,
+    ModifiedSince,
+    AddedSince,
+    AudioFormat,
+    Priority,
+    Tag(String),
+}
+
+fn classify_filter_keyword(name: &str) -> FilterKeyword {
+    if name.eq_ignore_ascii_case("file") || name.eq_ignore_ascii_case("filename") {
+        FilterKeyword::File
+    } else if name.eq_ignore_ascii_case("any") {
+        FilterKeyword::Any
+    } else if name == "base" {
+        FilterKeyword::Base
+    } else if name == "modified-since" {
+        FilterKeyword::ModifiedSince
+    } else if name == "added-since" {
+        FilterKeyword::AddedSince
+    } else if name.eq_ignore_ascii_case("audioformat") {
+        FilterKeyword::AudioFormat
+    } else if name.eq_ignore_ascii_case("prio") {
+        FilterKeyword::Priority
+    } else {
+        FilterKeyword::Tag(name.to_lowercase())
+    }
+}
+
+fn is_known_tag(tag_lower: &str) -> bool {
+    canonical_tag_name(tag_lower) != "Unknown"
+}
+
+// `uri_safe_local` (only the legacy 2-arg `base` form is checked this way;
+// the modern `(base "...")` expression form accepts any value, including "")
+// lives in `crate::path`, shared with `update`/`rescan`'s path validation.
+
+/// Parse an MPD-style timestamp: ISO 8601 (`YYYY-MM-DD[THH:MM[:SS]][Z|±HHMM]`
+/// or the month-only form `YYYY-MM`), falling back to a plain Unix timestamp.
+/// Mirrors `ParseTimeStamp()` in MPD's Filter.cxx.
+fn parse_timestamp(s: &str) -> Result<i64> {
+    if let Some(ts) = parse_iso8601(s) {
+        return Ok(ts);
+    }
+    s.trim()
+        .parse::<i64>()
+        .map_err(|_| RmpdError::ParseError(format!("Failed to parse timestamp: {s}")))
+}
+
+/// Days since the Unix epoch for a given proleptic-Gregorian date (Howard
+/// Hinnant's `days_from_civil` algorithm).
+fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = (if y >= 0 { y } else { y - 399 }) / 400;
+    let yoe = y - era * 400;
+    let mp = if m > 2 { m - 3 } else { m + 9 };
+    let doy = (153 * mp + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146097 + doe - 719468
+}
+
+fn parse_iso8601(s: &str) -> Option<i64> {
+    let s = s.trim();
+    if s.len() < 7 || s.as_bytes()[4] != b'-' {
+        return None;
+    }
+    let year: i64 = s.get(0..4)?.parse().ok()?;
+    let month: i64 = s.get(5..7)?.parse().ok()?;
+    let rest = &s[7..];
+    if rest.is_empty() {
+        // "YYYY-MM" (month-only)
+        return Some(days_from_civil(year, month, 1) * 86400);
+    }
+    let rest = rest.strip_prefix('-')?;
+    let day: i64 = rest.get(0..2)?.parse().ok()?;
+    let mut rest = &rest[2..];
+
+    let mut secs_of_day = 0i64;
+    if let Some(after_t) = rest.strip_prefix('T') {
+        let hh: i64 = after_t.get(0..2)?.parse().ok()?;
+        let mut r = &after_t[2..];
+        let mut mm = 0i64;
+        let mut ss = 0i64;
+        if let Some(after_colon) = r.strip_prefix(':') {
+            mm = after_colon.get(0..2)?.parse().ok()?;
+            r = &after_colon[2..];
+            if let Some(after_colon2) = r.strip_prefix(':') {
+                ss = after_colon2.get(0..2)?.parse().ok()?;
+                r = &after_colon2[2..];
+            }
+        }
+        secs_of_day = hh * 3600 + mm * 60 + ss;
+        rest = r;
+    }
+
+    let mut ts = days_from_civil(year, month, day) * 86400 + secs_of_day;
+    if rest.is_empty() || rest == "Z" {
+        // UTC (or unspecified, treated as UTC).
+        return Some(ts);
+    }
+    let sign = match rest.as_bytes()[0] {
+        b'+' => 1,
+        b'-' => -1,
+        _ => return None,
+    };
+    let off = &rest[1..];
+    let (oh, om): (i64, i64) = if let Some((h, m)) = off.split_once(':') {
+        (h.parse().ok()?, m.parse().ok()?)
+    } else if off.len() == 4 {
+        (off.get(0..2)?.parse().ok()?, off.get(2..4)?.parse().ok()?)
+    } else {
+        (off.parse().ok()?, 0)
+    };
+    ts -= sign * (oh * 3600 + om * 60);
+    Some(ts)
+}
+
+fn parse_audio_format_component<T: std::str::FromStr>(s: &str, mask: bool) -> Result<Option<T>> {
+    if s == "*" {
+        if mask {
+            return Ok(None);
+        }
+        return Err(RmpdError::ParseError(
+            "'*' is only allowed with the '=~' operator".to_string(),
+        ));
+    }
+    s.parse::<T>()
+        .map(Some)
+        .map_err(|_| RmpdError::ParseError(format!("Failed to parse audio format: {s}")))
+}
+
+/// Parse `SAMPLERATE:BITS:CHANNELS`, matching MPD's `ParseAudioFormat()`.
+/// `*` components are only valid in mask mode (`=~`).
+fn parse_audio_format(s: &str, mask: bool) -> Result<(Option<u32>, Option<u16>, Option<u8>)> {
+    let mut parts = s.split(':');
+    let (Some(sr), Some(bits), Some(ch), None) =
+        (parts.next(), parts.next(), parts.next(), parts.next())
+    else {
+        return Err(RmpdError::ParseError(format!(
+            "Failed to parse audio format: {s}"
+        )));
+    };
+    let sample_rate: Option<u32> = parse_audio_format_component(sr, mask)?;
+    let bits: Option<u16> = parse_audio_format_component(bits, mask)?;
+    let channels: Option<u8> = parse_audio_format_component(ch, mask)?;
+    Ok((sample_rate, bits, channels))
 }
 
 impl FilterExpression {
-    /// Parse a filter expression string
-    pub fn parse(input: &str) -> Result<Self> {
-        let input = input.trim();
+    /// Parse a modern `(...)` filter expression. `fold_case` is the
+    /// command's default case sensitivity (`true` for `search`-family
+    /// commands, `false` for `find`-family), overridable per-term by the
+    /// explicit `_cs`/`_ci` operator suffixes.
+    pub fn parse(input: &str, fold_case: bool) -> Result<Self> {
+        let mut parser = Parser::new(input.trim());
+        let expr = parser.parse_group(fold_case)?;
+        parser.skip_ws();
+        if parser.pos != parser.input.len() {
+            return Err(RmpdError::ParseError(
+                "Unparsed garbage after expression".to_string(),
+            ));
+        }
+        Ok(expr)
+    }
 
-        // Remove outer parentheses if present
-        let input = if input.starts_with('(') && input.ends_with(')') {
-            &input[1..input.len() - 1]
-        } else {
-            input
+    /// Build a filter from legacy `find`/`search` pairs (`TAG VALUE [TAG
+    /// VALUE ...]`), AND-combined, mirroring `SongFilter::Parse(args, ...)`.
+    pub fn from_pairs(pairs: &[(String, String)], fold_case: bool) -> Result<Self> {
+        let mut iter = pairs.iter();
+        let Some((tag0, val0)) = iter.next() else {
+            return Err(RmpdError::ParseError(
+                "Incorrect number of filter arguments".to_string(),
+            ));
         };
+        let mut expr = Self::from_pair(tag0, val0, fold_case)?;
+        for (tag, val) in iter {
+            expr = FilterExpression::And(
+                Box::new(expr),
+                Box::new(Self::from_pair(tag, val, fold_case)?),
+            );
+        }
+        Ok(expr)
+    }
 
-        Parser::new(input).parse_expression()
+    /// Mirrors `SongFilter::Parse(tag_string, value, fold_case, ...)`.
+    fn from_pair(tag: &str, value: &str, fold_case: bool) -> Result<Self> {
+        match classify_filter_keyword(tag) {
+            FilterKeyword::Base => {
+                if !uri_safe_local(value) {
+                    return Err(RmpdError::ParseError("Bad URI".to_string()));
+                }
+                Ok(FilterExpression::Base(value.to_string()))
+            }
+            FilterKeyword::ModifiedSince => {
+                Ok(FilterExpression::ModifiedSince(parse_timestamp(value)?))
+            }
+            FilterKeyword::AddedSince => Ok(FilterExpression::AddedSince(parse_timestamp(value)?)),
+            FilterKeyword::File => Ok(Self::legacy_compare("file", value, fold_case)),
+            FilterKeyword::Any => Ok(Self::legacy_compare("any", value, fold_case)),
+            // MPD's own 2-arg `SongFilter::Parse` has no case for AudioFormat/prio:
+            // they fall into the generic `default:` branch and get cast to an
+            // out-of-range `TagType` — undefined behaviour in the C++
+            // implementation, not a real feature. Reject as an unknown tag
+            // instead of replicating that.
+            FilterKeyword::AudioFormat | FilterKeyword::Priority => {
+                Err(RmpdError::ParseError("Unknown filter type".to_string()))
+            }
+            FilterKeyword::Tag(tag_lower) => {
+                if !is_known_tag(&tag_lower) {
+                    return Err(RmpdError::ParseError("Unknown filter type".to_string()));
+                }
+                Ok(Self::legacy_compare(&tag_lower, value, fold_case))
+            }
+        }
+    }
+
+    /// For compatibility with MPD 0.20 and older, `fold_case` also switches
+    /// on substring matching (not just case-insensitivity).
+    fn legacy_compare(tag: &str, value: &str, fold_case: bool) -> Self {
+        FilterExpression::Compare {
+            tag: tag.to_string(),
+            op: if fold_case {
+                CompareOp::Contains
+            } else {
+                CompareOp::Equal
+            },
+            value: value.to_string(),
+            case_sensitive: !fold_case,
+            negated: false,
+        }
     }
 
     /// Convert filter expression to SQL WHERE clause using EXISTS subqueries on song_tags.
     /// The songs table is referenced as `songs` (no alias).
     pub fn to_sql(&self) -> (String, Vec<String>) {
         match self {
-            FilterExpression::Compare { tag, op, value } => {
-                let tag_lower = tag.to_lowercase();
-
-                // `file` tag matches against the path column directly
-                if tag_lower == "file" {
-                    let (sql_op, value_param) = op_to_sql(op, value);
-                    return (format!("path {sql_op}"), vec![value_param]);
+            FilterExpression::Compare {
+                tag,
+                op,
+                value,
+                case_sensitive,
+                negated,
+            } => Self::compare_to_sql(tag, *op, value, *case_sensitive, *negated),
+            FilterExpression::Base(value) => {
+                if value.is_empty() {
+                    // Mirrors `uri_is_child_or_same("", child)`: matches any
+                    // non-empty path (i.e. every real song).
+                    ("path != ''".to_string(), Vec::new())
+                } else {
+                    (
+                        "(path = ? OR path LIKE ? ESCAPE '\\')".to_string(),
+                        vec![value.clone(), format!("{}/%", escape_like_value(value))],
+                    )
                 }
-
-                let fallback_tags = tag_fallback_chain(&tag_lower);
-                // Tag names are client-controlled (unrecognized tags pass through
-                // `tag_fallback_chain` verbatim), so they must be bound as
-                // parameters rather than interpolated into the SQL text.
-                let tag_placeholders = fallback_tags
-                    .iter()
-                    .map(|_| "?")
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                let tag_params: Vec<String> = fallback_tags.iter().map(|t| t.to_string()).collect();
-
-                // MPD treats a missing tag as an empty value, so comparing a tag
-                // (or its fallback chain) against the empty string must also match
-                // songs that have no row at all for those tags. A plain
-                // `value = ''` EXISTS check would miss them, leaving e.g. the empty
-                // AlbumArtist group (shown by `list`) unreachable via `find`/`count`
-                // — which traps browsers like rmpc in a re-query loop.
-                if value.is_empty() && matches!(op, CompareOp::Equal | CompareOp::NotEqual) {
-                    let has_nonempty = format!(
-                        "EXISTS (SELECT 1 FROM song_tags st WHERE st.song_id = songs.id \
-                         AND st.tag IN ({tag_placeholders}) AND st.value != '')"
-                    );
-                    let sql = match op {
-                        CompareOp::Equal => format!("NOT {has_nonempty}"),
-                        _ => has_nonempty,
-                    };
-                    return (sql, tag_params);
+            }
+            FilterExpression::ModifiedSince(ts) => {
+                ("last_modified >= ?".to_string(), vec![ts.to_string()])
+            }
+            FilterExpression::AddedSince(ts) => ("added_at >= ?".to_string(), vec![ts.to_string()]),
+            FilterExpression::AudioFormat {
+                sample_rate,
+                bits,
+                channels,
+            } => {
+                let mut conds = vec![
+                    "sample_rate IS NOT NULL".to_string(),
+                    "channels IS NOT NULL".to_string(),
+                    "bits_per_sample IS NOT NULL".to_string(),
+                ];
+                let mut params = Vec::new();
+                if let Some(v) = sample_rate {
+                    conds.push("sample_rate = ?".to_string());
+                    params.push(v.to_string());
                 }
-
-                let (sql_op, value_param) = op_to_sql(op, value);
-                let sql = format!(
-                    "EXISTS (SELECT 1 FROM song_tags st WHERE st.song_id = songs.id \
-                     AND st.tag IN ({tag_placeholders}) AND st.value {sql_op})"
-                );
-                let mut params = tag_params;
-                params.push(value_param);
-                (sql, params)
+                if let Some(v) = bits {
+                    conds.push("bits_per_sample = ?".to_string());
+                    params.push(v.to_string());
+                }
+                if let Some(v) = channels {
+                    conds.push("channels = ?".to_string());
+                    params.push(v.to_string());
+                }
+                (format!("({})", conds.join(" AND ")), params)
+            }
+            // Database songs are never queued, so their implicit priority is
+            // always 0 (MPD's default `LightSong::priority`).
+            FilterExpression::Priority(n) => {
+                if *n == 0 {
+                    ("1".to_string(), Vec::new())
+                } else {
+                    ("0".to_string(), Vec::new())
+                }
             }
             FilterExpression::And(left, right) => {
                 let (left_sql, mut left_params) = left.to_sql();
@@ -113,16 +374,73 @@ impl FilterExpression {
                 left_params.extend(right_params);
                 (format!("({left_sql} AND {right_sql})"), left_params)
             }
-            FilterExpression::Or(left, right) => {
-                let (left_sql, mut left_params) = left.to_sql();
-                let (right_sql, right_params) = right.to_sql();
-                left_params.extend(right_params);
-                (format!("({left_sql} OR {right_sql})"), left_params)
-            }
             FilterExpression::Not(expr) => {
                 let (sql, params) = expr.to_sql();
                 (format!("NOT ({sql})"), params)
             }
+        }
+    }
+
+    fn compare_to_sql(
+        tag: &str,
+        op: CompareOp,
+        value: &str,
+        case_sensitive: bool,
+        negated: bool,
+    ) -> (String, Vec<String>) {
+        let tag_lower = tag.to_lowercase();
+
+        if tag_lower == "file" {
+            let (cond, params) = compare_sql("path", op, value, case_sensitive);
+            return if negated {
+                (format!("NOT ({cond})"), params)
+            } else {
+                (cond, params)
+            };
+        }
+
+        let any = tag_lower == "any";
+        let fallback_tags: Vec<&str> = if any {
+            Vec::new()
+        } else {
+            tag_fallback_chain(&tag_lower)
+        };
+        let tag_restriction = if any {
+            String::new()
+        } else {
+            let placeholders = fallback_tags
+                .iter()
+                .map(|_| "?")
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(" AND st.tag IN ({placeholders})")
+        };
+        let tag_params: Vec<String> = fallback_tags.iter().map(|t| t.to_string()).collect();
+
+        // MPD treats a missing tag as an empty value, so comparing a tag (or
+        // its fallback chain) against the empty string must also match songs
+        // that have no row at all for those tags.
+        if value.is_empty() && op == CompareOp::Equal {
+            let has_nonempty = format!(
+                "EXISTS (SELECT 1 FROM song_tags st WHERE st.song_id = songs.id{tag_restriction} AND st.value != '')"
+            );
+            return if negated {
+                (has_nonempty, tag_params)
+            } else {
+                (format!("NOT {has_nonempty}"), tag_params)
+            };
+        }
+
+        let (cmp_cond, cmp_params) = compare_sql("st.value", op, value, case_sensitive);
+        let mut params = tag_params;
+        params.extend(cmp_params);
+        let sql = format!(
+            "EXISTS (SELECT 1 FROM song_tags st WHERE st.song_id = songs.id{tag_restriction} AND {cmp_cond})"
+        );
+        if negated {
+            (format!("NOT ({sql})"), params)
+        } else {
+            (sql, params)
         }
     }
 }
@@ -141,24 +459,47 @@ fn escape_like_value(value: &str) -> String {
     escaped
 }
 
-fn op_to_sql(op: &CompareOp, value: &str) -> (&'static str, String) {
+/// Build the SQL fragment for one string comparison against `column`
+/// (case-insensitive variants rely on SQLite's default ASCII-only case
+/// folding for `LIKE`/`COLLATE NOCASE` — matching the rest of rmpd's search
+/// paths, which have the same limitation).
+fn compare_sql(
+    column: &str,
+    op: CompareOp,
+    value: &str,
+    case_sensitive: bool,
+) -> (String, Vec<String>) {
     match op {
-        CompareOp::Equal => ("= ?", value.to_string()),
-        CompareOp::NotEqual => ("!= ?", value.to_string()),
-        CompareOp::Regex => ("REGEXP ?", value.to_string()),
-        CompareOp::NotRegex => ("NOT REGEXP ?", value.to_string()),
-        CompareOp::Less => ("< ?", value.to_string()),
-        CompareOp::Greater => ("> ?", value.to_string()),
-        CompareOp::LessEqual => ("<= ?", value.to_string()),
-        CompareOp::GreaterEqual => (">= ?", value.to_string()),
+        CompareOp::Equal if case_sensitive => (format!("{column} = ?"), vec![value.to_string()]),
+        CompareOp::Equal => (
+            format!("{column} = ? COLLATE NOCASE"),
+            vec![value.to_string()],
+        ),
+        CompareOp::Contains if case_sensitive => {
+            (format!("INSTR({column}, ?) > 0"), vec![value.to_string()])
+        }
         CompareOp::Contains => (
-            "LIKE ? ESCAPE '\\'",
-            format!("%{}%", escape_like_value(value)),
+            format!("{column} LIKE ? ESCAPE '\\'"),
+            vec![format!("%{}%", escape_like_value(value))],
+        ),
+        CompareOp::StartsWith if case_sensitive => (
+            format!("SUBSTR({column}, 1, LENGTH(?)) = ?"),
+            vec![value.to_string(), value.to_string()],
         ),
         CompareOp::StartsWith => (
-            "LIKE ? ESCAPE '\\'",
-            format!("{}%", escape_like_value(value)),
+            format!("{column} LIKE ? ESCAPE '\\'"),
+            vec![format!("{}%", escape_like_value(value))],
         ),
+        CompareOp::Regex => {
+            // No per-row case-sensitivity flag on the custom `regexp()`
+            // SQLite function, so fold case via an inline regex flag instead.
+            let pattern = if case_sensitive {
+                value.to_string()
+            } else {
+                format!("(?i){value}")
+            };
+            (format!("{column} REGEXP ?"), vec![pattern])
+        }
     }
 }
 
@@ -172,189 +513,300 @@ impl<'a> Parser<'a> {
         Self { input, pos: 0 }
     }
 
-    fn peek_char(&self) -> Result<char> {
-        self.input.chars().nth(self.pos).ok_or_else(|| {
-            RmpdError::ParseError(format!("Unexpected end of input at position {}", self.pos))
-        })
+    fn peek(&self) -> Option<char> {
+        self.input[self.pos..].chars().next()
     }
 
-    fn parse_expression(&mut self) -> Result<FilterExpression> {
-        self.parse_or_expression()
-    }
-
-    fn parse_or_expression(&mut self) -> Result<FilterExpression> {
-        let mut left = self.parse_and_expression()?;
-
-        self.skip_whitespace();
-        while self.peek_keyword("OR") {
-            self.consume_str("OR")?;
-            self.skip_whitespace();
-            let right = self.parse_and_expression()?;
-            left = FilterExpression::Or(Box::new(left), Box::new(right));
-            self.skip_whitespace();
-        }
-
-        Ok(left)
-    }
-
-    fn parse_and_expression(&mut self) -> Result<FilterExpression> {
-        let mut left = self.parse_primary()?;
-
-        self.skip_whitespace();
-        while self.peek_keyword("AND") {
-            self.consume_str("AND")?;
-            self.skip_whitespace();
-            let right = self.parse_primary()?;
-            left = FilterExpression::And(Box::new(left), Box::new(right));
-            self.skip_whitespace();
-        }
-
-        Ok(left)
-    }
-
-    fn parse_primary(&mut self) -> Result<FilterExpression> {
-        self.skip_whitespace();
-
-        if self.peek_str("(") {
-            let _ = self.consume_str("(");
-            let expr = self.parse_or_expression()?;
-            self.skip_whitespace();
-            self.consume_str(")")?;
-            return Ok(expr);
-        }
-
-        if self.peek_str("!") {
-            let _ = self.consume_str("!");
-            self.skip_whitespace();
-            let expr = self.parse_primary()?;
-            return Ok(FilterExpression::Not(Box::new(expr)));
-        }
-
-        self.parse_comparison()
-    }
-
-    fn parse_comparison(&mut self) -> Result<FilterExpression> {
-        self.skip_whitespace();
-
-        let tag = self.parse_identifier()?;
-        self.skip_whitespace();
-
-        let op = self.parse_operator()?;
-        self.skip_whitespace();
-
-        let value = self.parse_quoted_value()?;
-
-        Ok(FilterExpression::Compare { tag, op, value })
-    }
-
-    fn parse_identifier(&mut self) -> Result<String> {
-        let start = self.pos;
-        while self.pos < self.input.len() {
-            let ch = self.peek_char()?;
-            if ch.is_alphanumeric() || ch == '_' || ch == '-' {
-                self.pos += 1;
-            } else {
-                break;
-            }
-        }
-        if start == self.pos {
-            return Err(RmpdError::ParseError("Expected identifier".to_owned()));
-        }
-        Ok(self.input[start..self.pos].to_string())
-    }
-
-    fn parse_operator(&mut self) -> Result<CompareOp> {
-        if self.consume_str("starts_with").is_ok() {
-            Ok(CompareOp::StartsWith)
-        } else if self.consume_str("contains").is_ok() {
-            Ok(CompareOp::Contains)
-        } else if self.consume_str("==").is_ok() {
-            Ok(CompareOp::Equal)
-        } else if self.consume_str("!=").is_ok() {
-            Ok(CompareOp::NotEqual)
-        } else if self.consume_str("=~").is_ok() {
-            Ok(CompareOp::Regex)
-        } else if self.consume_str("!~").is_ok() {
-            Ok(CompareOp::NotRegex)
-        } else if self.consume_str("<=").is_ok() {
-            Ok(CompareOp::LessEqual)
-        } else if self.consume_str(">=").is_ok() {
-            Ok(CompareOp::GreaterEqual)
-        } else if self.consume_str("<").is_ok() {
-            Ok(CompareOp::Less)
-        } else if self.consume_str(">").is_ok() {
-            Ok(CompareOp::Greater)
-        } else {
-            Err(RmpdError::ParseError("Expected operator".to_owned()))
+    fn advance_char(&mut self) {
+        if let Some(c) = self.peek() {
+            self.pos += c.len_utf8();
         }
     }
 
-    fn parse_quoted_value(&mut self) -> Result<String> {
-        let quote_char = self.peek_char()?;
-        if quote_char != '\'' && quote_char != '"' {
-            return Err(RmpdError::ParseError("Quoted string expected".to_owned()));
-        }
-        self.pos += 1;
-
-        let mut result = String::new();
-        while self.pos < self.input.len() {
-            let ch = self.peek_char()?;
-            if ch == quote_char {
-                self.pos += 1;
-                return Ok(result);
-            } else if ch == '\\' && self.pos + 1 < self.input.len() {
-                self.pos += 1;
-                let escaped = self.peek_char()?;
-                result.push(escaped);
-                self.pos += 1;
-            } else {
-                result.push(ch);
-                self.pos += ch.len_utf8();
-            }
-        }
-        Err(RmpdError::ParseError("Unterminated string".to_owned()))
-    }
-
-    fn skip_whitespace(&mut self) {
-        while self.pos < self.input.len() {
-            if let Ok(ch) = self.peek_char() {
-                if ch.is_whitespace() {
-                    self.pos += 1;
-                } else {
-                    break;
-                }
-            } else {
-                break;
-            }
+    fn skip_ws(&mut self) {
+        while matches!(self.peek(), Some(c) if c.is_whitespace()) {
+            self.advance_char();
         }
     }
 
-    fn peek_str(&self, s: &str) -> bool {
-        self.input[self.pos..].starts_with(s)
-    }
-
-    fn peek_keyword(&self, keyword: &str) -> bool {
-        let rest = &self.input[self.pos..];
-        if !rest.starts_with(keyword) {
-            return false;
-        }
-        if rest.len() == keyword.len() {
-            return true;
-        }
-        if let Some(next_ch) = rest.chars().nth(keyword.len()) {
-            next_ch.is_whitespace() || next_ch == ')' || next_ch == '('
+    /// Matches a literal token with no boundary requirement (for symbolic
+    /// operators like `==`/`=~`, which MPD allows directly against a quote).
+    fn consume_literal(&mut self, lit: &str) -> bool {
+        if self.input[self.pos..].starts_with(lit) {
+            self.pos += lit.len();
+            true
         } else {
             false
         }
     }
 
-    fn consume_str(&mut self, s: &str) -> Result<()> {
-        if self.input[self.pos..].starts_with(s) {
-            self.pos += s.len();
-            Ok(())
-        } else {
-            Err(RmpdError::ParseError(format!("Expected '{s}'")))
+    /// Matches a keyword token that must be followed by whitespace (or EOF),
+    /// so e.g. `contains` doesn't spuriously match a `contains_cs` prefix.
+    fn consume_word(&mut self, word: &str) -> bool {
+        let rest = &self.input[self.pos..];
+        if !rest.starts_with(word) {
+            return false;
         }
+        match rest.as_bytes().get(word.len()) {
+            Some(b) if !b.is_ascii_whitespace() => false,
+            _ => {
+                self.pos += word.len();
+                true
+            }
+        }
+    }
+
+    /// Reads a tag-name identifier (`IsTagNameChar`: ASCII alpha, `_`, `-`).
+    fn expect_word(&mut self) -> Result<String> {
+        let start = self.pos;
+        while matches!(self.peek(), Some(c) if c.is_ascii_alphabetic() || c == '_' || c == '-') {
+            self.advance_char();
+        }
+        if self.pos == start {
+            return Err(RmpdError::ParseError("Word expected".to_string()));
+        }
+        let word = self.input[start..self.pos].to_string();
+        self.skip_ws();
+        Ok(word)
+    }
+
+    fn expect_and_keyword(&mut self) -> Result<()> {
+        if self.expect_word()? != "AND" {
+            return Err(RmpdError::ParseError("'AND' expected".to_string()));
+        }
+        Ok(())
+    }
+
+    fn expect_byte(&mut self, expected: char, message: &str) -> Result<()> {
+        if self.peek() != Some(expected) {
+            return Err(RmpdError::ParseError(message.to_string()));
+        }
+        self.advance_char();
+        self.skip_ws();
+        Ok(())
+    }
+
+    fn expect_quoted(&mut self) -> Result<String> {
+        let quote = self
+            .peek()
+            .ok_or_else(|| RmpdError::ParseError("Quoted string expected".to_string()))?;
+        if quote != '\'' && quote != '"' {
+            return Err(RmpdError::ParseError("Quoted string expected".to_string()));
+        }
+        self.advance_char();
+
+        let mut result = String::new();
+        loop {
+            let ch = self
+                .peek()
+                .ok_or_else(|| RmpdError::ParseError("Closing quote not found".to_string()))?;
+            if ch == quote {
+                self.advance_char();
+                break;
+            }
+            if ch == '\\' {
+                self.advance_char();
+                let escaped = self
+                    .peek()
+                    .ok_or_else(|| RmpdError::ParseError("Closing quote not found".to_string()))?;
+                result.push(escaped);
+                self.advance_char();
+            } else {
+                result.push(ch);
+                self.advance_char();
+            }
+        }
+        self.skip_ws();
+        Ok(result)
+    }
+
+    /// Mirrors `ParseStringFilter()`: order matters — explicit `_cs`/`_ci`
+    /// variants must be tried before their bare counterparts.
+    fn parse_string_operator(&mut self) -> Result<(CompareOp, Option<bool>, bool)> {
+        const VARIANTS: &[(&str, CompareOp, bool, bool)] = &[
+            ("contains_cs", CompareOp::Contains, true, false),
+            ("!contains_cs", CompareOp::Contains, true, true),
+            ("contains_ci", CompareOp::Contains, false, false),
+            ("!contains_ci", CompareOp::Contains, false, true),
+            ("starts_with_cs", CompareOp::StartsWith, true, false),
+            ("!starts_with_cs", CompareOp::StartsWith, true, true),
+            ("starts_with_ci", CompareOp::StartsWith, false, false),
+            ("!starts_with_ci", CompareOp::StartsWith, false, true),
+            ("eq_cs", CompareOp::Equal, true, false),
+            ("!eq_cs", CompareOp::Equal, true, true),
+            ("eq_ci", CompareOp::Equal, false, false),
+            ("!eq_ci", CompareOp::Equal, false, true),
+        ];
+        for (word, op, cs, neg) in VARIANTS {
+            if self.consume_word(word) {
+                self.skip_ws();
+                return Ok((*op, Some(*cs), *neg));
+            }
+        }
+        if self.consume_word("!contains") {
+            self.skip_ws();
+            return Ok((CompareOp::Contains, None, true));
+        }
+        if self.consume_word("contains") {
+            self.skip_ws();
+            return Ok((CompareOp::Contains, None, false));
+        }
+        if self.consume_word("!starts_with") {
+            self.skip_ws();
+            return Ok((CompareOp::StartsWith, None, true));
+        }
+        if self.consume_word("starts_with") {
+            self.skip_ws();
+            return Ok((CompareOp::StartsWith, None, false));
+        }
+        if self.consume_literal("!~") {
+            self.skip_ws();
+            return Ok((CompareOp::Regex, None, true));
+        }
+        if self.consume_literal("=~") {
+            self.skip_ws();
+            return Ok((CompareOp::Regex, None, false));
+        }
+        if self.consume_literal("!=") {
+            self.skip_ws();
+            return Ok((CompareOp::Equal, None, true));
+        }
+        if self.consume_literal("==") {
+            self.skip_ws();
+            return Ok((CompareOp::Equal, None, false));
+        }
+        Err(RmpdError::ParseError(format!(
+            "Unknown filter operator: {}",
+            &self.input[self.pos..]
+        )))
+    }
+
+    /// Parses one `(...)` group. `fold_case` is the command's default case
+    /// sensitivity, threaded down for terms that don't specify `_cs`/`_ci`.
+    fn parse_group(&mut self, fold_case: bool) -> Result<FilterExpression> {
+        self.expect_byte('(', "'(' expected")?;
+
+        if self.peek() == Some('(') {
+            let mut expr = self.parse_group(fold_case)?;
+            self.skip_ws();
+            if self.peek() == Some(')') {
+                self.advance_char();
+                self.skip_ws();
+                return Ok(expr);
+            }
+            self.expect_and_keyword()?;
+            self.skip_ws();
+            loop {
+                let next = self.parse_group(fold_case)?;
+                expr = FilterExpression::And(Box::new(expr), Box::new(next));
+                self.skip_ws();
+                if self.peek() == Some(')') {
+                    self.advance_char();
+                    self.skip_ws();
+                    return Ok(expr);
+                }
+                self.expect_and_keyword()?;
+                self.skip_ws();
+            }
+        }
+
+        if self.peek() == Some('!') {
+            self.advance_char();
+            self.skip_ws();
+            if self.peek() != Some('(') {
+                return Err(RmpdError::ParseError("'(' expected".to_string()));
+            }
+            let inner = self.parse_group(fold_case)?;
+            self.skip_ws();
+            if self.peek() != Some(')') {
+                return Err(RmpdError::ParseError("')' expected".to_string()));
+            }
+            self.advance_char();
+            self.skip_ws();
+            return Ok(FilterExpression::Not(Box::new(inner)));
+        }
+
+        let name = self.expect_word()?;
+        let expr = self.parse_term_body(&name, fold_case)?;
+        self.skip_ws();
+        if self.peek() != Some(')') {
+            return Err(RmpdError::ParseError("')' expected".to_string()));
+        }
+        self.advance_char();
+        self.skip_ws();
+        Ok(expr)
+    }
+
+    fn parse_term_body(&mut self, name: &str, fold_case: bool) -> Result<FilterExpression> {
+        match classify_filter_keyword(name) {
+            FilterKeyword::Base => Ok(FilterExpression::Base(self.expect_quoted()?)),
+            FilterKeyword::ModifiedSince => Ok(FilterExpression::ModifiedSince(parse_timestamp(
+                &self.expect_quoted()?,
+            )?)),
+            FilterKeyword::AddedSince => Ok(FilterExpression::AddedSince(parse_timestamp(
+                &self.expect_quoted()?,
+            )?)),
+            FilterKeyword::AudioFormat => {
+                let mask = if self.consume_literal("==") {
+                    false
+                } else if self.consume_literal("=~") {
+                    true
+                } else {
+                    return Err(RmpdError::ParseError("'==' or '=~' expected".to_string()));
+                };
+                self.skip_ws();
+                let value = self.expect_quoted()?;
+                let (sample_rate, bits, channels) = parse_audio_format(&value, mask)?;
+                Ok(FilterExpression::AudioFormat {
+                    sample_rate,
+                    bits,
+                    channels,
+                })
+            }
+            FilterKeyword::Priority => {
+                if !self.consume_literal(">=") {
+                    return Err(RmpdError::ParseError("'>=' expected".to_string()));
+                }
+                self.skip_ws();
+                let start = self.pos;
+                while matches!(self.peek(), Some(c) if c.is_ascii_digit()) {
+                    self.advance_char();
+                }
+                if self.pos == start {
+                    return Err(RmpdError::ParseError("Number expected".to_string()));
+                }
+                let value: u32 = self.input[start..self.pos]
+                    .parse()
+                    .map_err(|_| RmpdError::ParseError("Number expected".to_string()))?;
+                if value > 0xff {
+                    return Err(RmpdError::ParseError("Invalid priority value".to_string()));
+                }
+                self.skip_ws();
+                Ok(FilterExpression::Priority(value as u8))
+            }
+            FilterKeyword::File => self.parse_compare_tail("file", fold_case),
+            FilterKeyword::Any => self.parse_compare_tail("any", fold_case),
+            FilterKeyword::Tag(tag_lower) => {
+                if !is_known_tag(&tag_lower) {
+                    return Err(RmpdError::ParseError(format!(
+                        "Unknown filter type: {name}"
+                    )));
+                }
+                self.parse_compare_tail(&tag_lower, fold_case)
+            }
+        }
+    }
+
+    fn parse_compare_tail(&mut self, tag: &str, fold_case: bool) -> Result<FilterExpression> {
+        let (op, case_sensitive_override, negated) = self.parse_string_operator()?;
+        let value = self.expect_quoted()?;
+        Ok(FilterExpression::Compare {
+            tag: tag.to_string(),
+            op,
+            value,
+            case_sensitive: case_sensitive_override.unwrap_or(!fold_case),
+            negated,
+        })
     }
 }
 
@@ -362,9 +814,13 @@ impl<'a> Parser<'a> {
 mod tests {
     use super::*;
 
+    fn parse(input: &str, fold_case: bool) -> FilterExpression {
+        FilterExpression::parse(input, fold_case).unwrap()
+    }
+
     #[test]
     fn test_simple_comparison() {
-        let expr = FilterExpression::parse("((Artist == 'Radiohead'))").unwrap();
+        let expr = parse("(Artist == 'Radiohead')", false);
         let (sql, params) = expr.to_sql();
         assert!(sql.contains("song_tags"));
         assert_eq!(params, vec!["artist", "Radiohead"]);
@@ -372,31 +828,47 @@ mod tests {
 
     #[test]
     fn test_and_expression() {
-        let expr = FilterExpression::parse("((date >= '2000') AND (genre == 'Rock'))").unwrap();
+        let expr = parse("((date == '2000') AND (genre == 'Rock'))", false);
         let (sql, params) = expr.to_sql();
-        assert!(sql.contains("AND"), "SQL should contain AND: {}", sql);
+        assert!(sql.contains("AND"), "SQL should contain AND: {sql}");
         assert_eq!(params, vec!["date", "2000", "genre", "Rock"]);
     }
 
     #[test]
-    fn test_or_expression() {
-        let expr =
-            FilterExpression::parse("((artist == 'Radiohead') OR (artist == 'Muse'))").unwrap();
-        let (sql, params) = expr.to_sql();
-        assert!(sql.contains("OR"), "SQL should contain OR: {}", sql);
-        assert_eq!(params, vec!["artist", "Radiohead", "artist", "Muse"]);
+    fn test_three_way_and_chain() {
+        // MPD's AND-chain is variadic, not just binary.
+        let expr = parse(
+            "((artist == '1') AND (album == '2') AND (genre == '3'))",
+            false,
+        );
+        let (sql, _) = expr.to_sql();
+        // 2 structural ANDs from the chain itself, plus 2 per comparison
+        // (one from the tag_restriction's own `AND`, one joining it to the
+        // value comparison) — 3 comparisons here.
+        assert_eq!(sql.matches("AND").count(), 8);
+    }
+
+    #[test]
+    fn test_or_is_not_supported() {
+        // MPD's grammar has no OR at all.
+        assert!(FilterExpression::parse("((artist == 'A') OR (artist == 'B'))", false).is_err());
     }
 
     #[test]
     fn test_not_expression() {
-        let expr = FilterExpression::parse("(!(genre == 'Pop'))").unwrap();
+        let expr = parse("(!(genre == 'Pop'))", false);
         let (sql, _) = expr.to_sql();
-        assert!(sql.contains("NOT"));
+        assert!(sql.starts_with("NOT ("));
+    }
+
+    #[test]
+    fn test_not_requires_parens() {
+        assert!(FilterExpression::parse("(!genre == 'Pop')", false).is_err());
     }
 
     #[test]
     fn test_regex() {
-        let expr = FilterExpression::parse("((Artist =~ 'Radio.*'))").unwrap();
+        let expr = parse("(Artist =~ 'Radio.*')", false);
         let (sql, params) = expr.to_sql();
         assert!(sql.contains("REGEXP"), "SQL should contain REGEXP: {sql}");
         assert!(!sql.contains("LIKE"), "SQL must not contain LIKE: {sql}");
@@ -404,8 +876,15 @@ mod tests {
     }
 
     #[test]
+    fn test_not_regex() {
+        let expr = parse("(Artist !~ 'Radio.*')", false);
+        let (sql, _) = expr.to_sql();
+        assert!(sql.starts_with("NOT (") && sql.contains("REGEXP"));
+    }
+
+    #[test]
     fn test_double_quoted_values() {
-        let expr = FilterExpression::parse("(Artist == \"Amon Tobin\")").unwrap();
+        let expr = parse("(Artist == \"Amon Tobin\")", false);
         let (sql, params) = expr.to_sql();
         assert!(sql.contains("song_tags"));
         assert_eq!(params, vec!["artist", "Amon Tobin"]);
@@ -413,15 +892,14 @@ mod tests {
 
     #[test]
     fn test_double_quoted_with_escape() {
-        let expr = FilterExpression::parse(r#"(Artist == "Guns \"N\" Roses")"#).unwrap();
-        let (sql, params) = expr.to_sql();
-        assert!(sql.contains("song_tags"));
+        let expr = parse(r#"(Artist == "Guns \"N\" Roses")"#, false);
+        let (_, params) = expr.to_sql();
         assert_eq!(params, vec!["artist", r#"Guns "N" Roses"#]);
     }
 
     #[test]
     fn test_albumartist_fallback() {
-        let expr = FilterExpression::parse("(AlbumArtist == 'Led Zeppelin')").unwrap();
+        let expr = parse("(AlbumArtist == 'Led Zeppelin')", false);
         let (sql, params) = expr.to_sql();
         assert!(sql.contains("IN"));
         assert_eq!(params, vec!["albumartist", "artist", "Led Zeppelin"]);
@@ -429,39 +907,278 @@ mod tests {
 
     #[test]
     fn test_file_tag() {
-        let expr = FilterExpression::parse("(file == 'some/path.mp3')").unwrap();
+        let expr = parse("(file == 'some/path.mp3')", false);
         let (sql, params) = expr.to_sql();
         assert_eq!(sql, "path = ?");
         assert_eq!(params, vec!["some/path.mp3"]);
     }
 
     #[test]
+    fn test_any_tag_has_no_tag_restriction() {
+        let expr = parse("(any contains 'foo')", true);
+        let (sql, params) = expr.to_sql();
+        assert!(
+            !sql.contains("st.tag IN"),
+            "any must not restrict tag: {sql}"
+        );
+        assert_eq!(params, vec!["%foo%"]);
+    }
+
+    #[test]
     fn test_empty_equality_matches_missing_tag() {
-        // `Tag == ''` must match songs that have NO non-empty value for the tag
-        // (including songs with the tag entirely absent), so it is generated as a
-        // NOT EXISTS over non-empty rows — never as `value = ''` (which would only
-        // match present-but-empty rows and miss tagless songs).
-        let expr = FilterExpression::parse("((AlbumArtist == ''))").unwrap();
+        let expr = parse("(AlbumArtist == '')", false);
         let (sql, params) = expr.to_sql();
         assert!(
             sql.starts_with("NOT EXISTS"),
             "expected NOT EXISTS, got: {sql}"
         );
         assert!(sql.contains("st.value != ''"), "got: {sql}");
-        assert_eq!(
-            params,
-            vec!["albumartist", "artist"],
-            "tag names must be bound params, not inlined: {params:?}"
-        );
+        assert_eq!(params, vec!["albumartist", "artist"]);
     }
 
     #[test]
     fn test_empty_inequality_matches_present_value() {
-        // `Tag != ''` matches songs that DO have a non-empty value.
-        let expr = FilterExpression::parse("((Artist != ''))").unwrap();
+        let expr = parse("(Artist != '')", false);
         let (sql, params) = expr.to_sql();
         assert!(sql.starts_with("EXISTS"), "expected EXISTS, got: {sql}");
         assert!(sql.contains("st.value != ''"), "got: {sql}");
         assert_eq!(params, vec!["artist"]);
+    }
+
+    #[test]
+    fn test_find_default_is_case_sensitive_equal() {
+        let expr = parse("(Artist == 'X')", false);
+        let (sql, _) = expr.to_sql();
+        assert!(
+            !sql.contains("COLLATE NOCASE"),
+            "find should be case-sensitive: {sql}"
+        );
+    }
+
+    #[test]
+    fn test_search_default_is_case_insensitive_equal() {
+        let expr = parse("(Artist == 'X')", true);
+        let (sql, _) = expr.to_sql();
+        assert!(
+            sql.contains("COLLATE NOCASE"),
+            "search should be case-insensitive: {sql}"
+        );
+    }
+
+    #[test]
+    fn test_explicit_case_sensitivity_overrides_command_default() {
+        // eq_cs under `search` (fold_case=true) stays case-sensitive.
+        let expr = parse("(Artist eq_cs 'X')", true);
+        let (sql, _) = expr.to_sql();
+        assert!(
+            !sql.contains("COLLATE NOCASE"),
+            "eq_cs must override search's default: {sql}"
+        );
+
+        // eq_ci under `find` (fold_case=false) stays case-insensitive.
+        let expr = parse("(Artist eq_ci 'X')", false);
+        let (sql, _) = expr.to_sql();
+        assert!(
+            sql.contains("COLLATE NOCASE"),
+            "eq_ci must override find's default: {sql}"
+        );
+    }
+
+    #[test]
+    fn test_case_sensitive_contains_uses_instr_not_like() {
+        let expr = parse("(Artist contains_cs 'X')", true);
+        let (sql, params) = expr.to_sql();
+        assert!(sql.contains("INSTR"), "got: {sql}");
+        assert_eq!(params, vec!["artist", "X"]);
+    }
+
+    #[test]
+    fn test_negated_contains() {
+        // Bare `!contains` (no `_cs`/`_ci` suffix) follows the command's
+        // default case sensitivity; use search semantics (fold_case=true)
+        // to exercise the LIKE-based case-insensitive path.
+        let expr = parse("(Artist !contains 'X')", true);
+        let (sql, _) = expr.to_sql();
+        assert!(sql.starts_with("NOT (") && sql.contains("LIKE"));
+    }
+
+    #[test]
+    fn test_negated_starts_with_ci() {
+        let expr = parse("(Artist !starts_with_ci 'X')", false);
+        let (sql, _) = expr.to_sql();
+        assert!(sql.starts_with("NOT (") && sql.contains("LIKE"));
+    }
+
+    #[test]
+    fn test_base_filter() {
+        let expr = parse("(base 'Music/Rock')", false);
+        let (sql, params) = expr.to_sql();
+        assert_eq!(sql, "(path = ? OR path LIKE ? ESCAPE '\\')");
+        assert_eq!(params, vec!["Music/Rock", "Music/Rock/%"]);
+    }
+
+    #[test]
+    fn test_base_empty_matches_everything() {
+        let expr = parse("(base '')", false);
+        let (sql, params) = expr.to_sql();
+        assert_eq!(sql, "path != ''");
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn test_modified_since_iso8601() {
+        let expr = parse("(modified-since '2023-01-15T10:30:00Z')", false);
+        let (sql, params) = expr.to_sql();
+        assert_eq!(sql, "last_modified >= ?");
+        // 2023-01-15T10:30:00Z
+        assert_eq!(params, vec!["1673778600"]);
+    }
+
+    #[test]
+    fn test_modified_since_unix_timestamp() {
+        let expr = parse("(modified-since '1700000000')", false);
+        let (_, params) = expr.to_sql();
+        assert_eq!(params, vec!["1700000000"]);
+    }
+
+    #[test]
+    fn test_added_since() {
+        let expr = parse("(added-since '2023-01-15')", false);
+        let (sql, params) = expr.to_sql();
+        assert_eq!(sql, "added_at >= ?");
+        assert_eq!(params, vec!["1673740800"]);
+    }
+
+    #[test]
+    fn test_audio_format_exact() {
+        let expr = parse("(AudioFormat == '44100:16:2')", false);
+        let (sql, params) = expr.to_sql();
+        assert!(sql.contains("sample_rate = ?"));
+        assert!(sql.contains("bits_per_sample = ?"));
+        assert!(sql.contains("channels = ?"));
+        assert_eq!(params, vec!["44100", "16", "2"]);
+    }
+
+    #[test]
+    fn test_audio_format_mask() {
+        let expr = parse("(AudioFormat =~ '*:16:2')", false);
+        let (sql, params) = expr.to_sql();
+        assert!(!sql.contains("sample_rate = ?"));
+        assert!(sql.contains("bits_per_sample = ?"));
+        assert_eq!(params, vec!["16", "2"]);
+    }
+
+    #[test]
+    fn test_audio_format_wildcard_rejected_without_mask() {
+        assert!(FilterExpression::parse("(AudioFormat == '*:16:2')", false).is_err());
+    }
+
+    #[test]
+    fn test_priority_filter() {
+        let expr = parse("(prio >= 0)", false);
+        let (sql, params) = expr.to_sql();
+        assert_eq!(sql, "1");
+        assert!(params.is_empty());
+
+        let expr = parse("(prio >= 5)", false);
+        let (sql, _) = expr.to_sql();
+        assert_eq!(sql, "0");
+    }
+
+    #[test]
+    fn test_priority_out_of_range() {
+        assert!(FilterExpression::parse("(prio >= 256)", false).is_err());
+    }
+
+    #[test]
+    fn test_unknown_tag_error_message() {
+        let err = FilterExpression::parse("(notarealtag == 'x')", false).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Parse error: Unknown filter type: notarealtag"
+        );
+    }
+
+    #[test]
+    fn test_unknown_operator_error_message() {
+        let err = FilterExpression::parse("(Artist <> 'x')", false).unwrap_err();
+        assert!(
+            err.to_string().contains("Unknown filter operator"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_unparsed_garbage_after_expression() {
+        let err = FilterExpression::parse("(Artist == 'x') garbage", false).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Unparsed garbage after expression")
+        );
+    }
+
+    #[test]
+    fn test_legacy_pairs_find_is_equal_case_sensitive() {
+        let expr =
+            FilterExpression::from_pairs(&[("artist".to_string(), "Radiohead".to_string())], false)
+                .unwrap();
+        let (sql, params) = expr.to_sql();
+        assert!(!sql.contains("LIKE") && !sql.contains("COLLATE"));
+        assert_eq!(params, vec!["artist", "Radiohead"]);
+    }
+
+    #[test]
+    fn test_legacy_pairs_search_is_contains_case_insensitive() {
+        let expr =
+            FilterExpression::from_pairs(&[("artist".to_string(), "radio".to_string())], true)
+                .unwrap();
+        let (sql, params) = expr.to_sql();
+        assert!(sql.contains("LIKE"));
+        assert_eq!(params, vec!["artist", "%radio%"]);
+    }
+
+    #[test]
+    fn test_legacy_pairs_multi_and() {
+        let expr = FilterExpression::from_pairs(
+            &[
+                ("artist".to_string(), "A".to_string()),
+                ("album".to_string(), "B".to_string()),
+            ],
+            false,
+        )
+        .unwrap();
+        let (sql, params) = expr.to_sql();
+        assert!(sql.contains(" AND "));
+        assert_eq!(params, vec!["artist", "A", "album", "B"]);
+    }
+
+    #[test]
+    fn test_legacy_pairs_unknown_tag_rejected() {
+        // e.g. a `sort`/`window` keyword leaking into filter pairs for a
+        // command that doesn't strip them (count/searchcount).
+        let err = FilterExpression::from_pairs(&[("sort".to_string(), "Album".to_string())], false)
+            .unwrap_err();
+        assert_eq!(err.to_string(), "Parse error: Unknown filter type");
+    }
+
+    #[test]
+    fn test_legacy_pairs_base() {
+        let expr =
+            FilterExpression::from_pairs(&[("base".to_string(), "Music/Rock".to_string())], false)
+                .unwrap();
+        assert_eq!(expr, FilterExpression::Base("Music/Rock".to_string()));
+    }
+
+    #[test]
+    fn test_legacy_pairs_base_unsafe_uri_rejected() {
+        let err =
+            FilterExpression::from_pairs(&[("base".to_string(), "../etc".to_string())], false)
+                .unwrap_err();
+        assert_eq!(err.to_string(), "Parse error: Bad URI");
+    }
+
+    #[test]
+    fn test_legacy_pairs_empty_rejected() {
+        assert!(FilterExpression::from_pairs(&[], false).is_err());
     }
 }

--- a/rmpd-core/src/partition.rs
+++ b/rmpd-core/src/partition.rs
@@ -88,7 +88,14 @@ pub struct PartitionInfo {
 /// Manager for multiple partitions
 pub struct PartitionManager {
     partitions: RwLock<HashMap<String, Arc<PartitionState>>>,
+    /// Creation order of partition names, "default" always first. MPD lists
+    /// `listpartitions` in creation order, not alphabetically; a plain
+    /// `HashMap` iteration order would not match that.
+    order: RwLock<Vec<String>>,
 }
+
+/// MPD's arbitrary partition count limit (AllCommands.cxx: "too many partitions").
+const MAX_PARTITIONS: usize = 16;
 
 impl PartitionManager {
     /// Create a new partition manager with a default partition
@@ -101,6 +108,7 @@ impl PartitionManager {
         );
         Arc::new(Self {
             partitions: RwLock::new(partitions),
+            order: RwLock::new(vec!["default".to_string()]),
         })
     }
 
@@ -112,8 +120,13 @@ impl PartitionManager {
             return Err(format!("Partition already exists: {}", name));
         }
 
+        if partitions.len() >= MAX_PARTITIONS {
+            return Err("Too many partitions".to_string());
+        }
+
         let partition = Arc::new(PartitionState::new(name.clone()));
-        partitions.insert(name, partition.clone());
+        partitions.insert(name.clone(), partition.clone());
+        self.order.write().await.push(name);
 
         Ok(partition)
     }
@@ -127,11 +140,17 @@ impl PartitionManager {
 
         let mut partitions = self.partitions.write().await;
 
-        if !partitions.contains_key(name) {
-            return Err(format!("Partition not found: {}", name));
+        let partition = match partitions.get(name) {
+            Some(p) => p.clone(),
+            None => return Err(format!("Partition not found: {}", name)),
+        };
+
+        if !partition.get_outputs().await.is_empty() {
+            return Err(format!("Partition '{}' still has outputs", name));
         }
 
         partitions.remove(name);
+        self.order.write().await.retain(|n| n != name);
         Ok(())
     }
 
@@ -141,10 +160,9 @@ impl PartitionManager {
         partitions.get(name).cloned()
     }
 
-    /// List all partition names
+    /// List all partition names in creation order ("default" first)
     pub async fn list_partitions(&self) -> Vec<String> {
-        let partitions = self.partitions.read().await;
-        partitions.keys().cloned().collect()
+        self.order.read().await.clone()
     }
 
     /// Get partition count
@@ -217,6 +235,7 @@ impl Default for PartitionManager {
     fn default() -> Self {
         Self {
             partitions: RwLock::new(HashMap::new()),
+            order: RwLock::new(Vec::new()),
         }
     }
 }
@@ -285,6 +304,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_list_partitions_creation_order() {
+        let manager = PartitionManager::new();
+
+        manager.create_partition("zzz".to_string()).await.unwrap();
+        manager.create_partition("aaa".to_string()).await.unwrap();
+
+        // MPD lists partitions in creation order, not alphabetically;
+        // "default" is always first.
+        assert_eq!(
+            manager.list_partitions().await,
+            vec!["default".to_string(), "zzz".to_string(), "aaa".to_string()]
+        );
+    }
+
+    #[tokio::test]
     async fn test_output_assignment() {
         let partition = PartitionState::new("test".to_string());
 
@@ -323,5 +357,32 @@ mod tests {
 
         assert_eq!(part1.get_outputs().await.len(), 0);
         assert_eq!(part2.get_outputs().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_delete_partition_with_outputs_refused() {
+        let manager = PartitionManager::new();
+
+        let part = manager.create_partition("test".to_string()).await.unwrap();
+        part.assign_output(0).await;
+
+        let result = manager.delete_partition("test").await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("still has outputs"));
+        assert!(manager.get_partition("test").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_create_partition_limit() {
+        let manager = PartitionManager::new();
+
+        // "default" already counts as one; fill up to the 16-partition cap.
+        for i in 0..15 {
+            manager.create_partition(format!("part{i}")).await.unwrap();
+        }
+
+        let result = manager.create_partition("one_too_many".to_string()).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Too many partitions"));
     }
 }

--- a/rmpd-core/src/path.rs
+++ b/rmpd-core/src/path.rs
@@ -49,6 +49,57 @@ pub fn is_uri(s: &str) -> bool {
     }
 }
 
+/// Mirrors MPD's `uri_safe_local()`: a non-empty `/`-separated path with no
+/// `.` or `..` segments (used to validate client-supplied relative paths
+/// before joining them onto the music directory, e.g. the legacy `base`
+/// filter pair and `update`/`rescan`'s path argument).
+#[must_use]
+pub fn uri_safe_local(uri: &str) -> bool {
+    !uri.is_empty()
+        && uri
+            .split('/')
+            .all(|seg| !seg.is_empty() && seg != "." && seg != "..")
+}
+
+/// Orders two song paths the way MPD's database tree walk does
+/// (`Directory::Walk` in `db/plugins/simple/Directory.cxx`): within each
+/// directory, songs are visited before subdirectories, and both songs and
+/// subdirectories are name-sorted. This is deliberately NOT the same as
+/// sorting the full path strings — under a plain string sort, `"rock/..."`
+/// can sort before `"song1..."` (because `/` compares low), which puts a
+/// subdirectory's files ahead of root-level files. Comparing segment-wise
+/// and letting "no more segments left" (a file) win over "one more segment"
+/// (a subdirectory) at the point of divergence reproduces the tree order.
+///
+/// This is the *default* order (no `sort TAG` given) for `find`/`search`/
+/// `count`/`searchcount`/`findadd`/`searchadd`/`searchaddpl`/`list`.
+#[must_use]
+pub fn compare_db_path(a: &str, b: &str) -> std::cmp::Ordering {
+    let mut a_segs = a.split('/');
+    let mut b_segs = b.split('/');
+    loop {
+        match (a_segs.next(), b_segs.next()) {
+            (None, None) => return std::cmp::Ordering::Equal,
+            (None, Some(_)) => return std::cmp::Ordering::Less,
+            (Some(_), None) => return std::cmp::Ordering::Greater,
+            (Some(sa), Some(sb)) => {
+                let a_is_last = a_segs.clone().next().is_none();
+                let b_is_last = b_segs.clone().next().is_none();
+                if a_is_last && !b_is_last {
+                    return std::cmp::Ordering::Less;
+                }
+                if b_is_last && !a_is_last {
+                    return std::cmp::Ordering::Greater;
+                }
+                match sa.cmp(sb) {
+                    std::cmp::Ordering::Equal => continue,
+                    other => return other,
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,5 +128,58 @@ mod tests {
             "/abs/song.flac"
         );
         assert_eq!(resolve_path("a/b.flac", Some("/music")), "/music/a/b.flac");
+    }
+
+    #[test]
+    fn compare_db_path_root_files_before_subdirectory() {
+        // MPD's Directory::Walk visits a directory's own songs before its
+        // subdirectories, so root-level files sort before ANY path under a
+        // subdirectory — even "rock" < "song1" would say otherwise under a
+        // plain string sort.
+        let mut paths = vec![
+            "rock/track2.flac",
+            "rock/track1.flac",
+            "song3.flac",
+            "song1.flac",
+            "song2.flac",
+        ];
+        paths.sort_by(|a, b| compare_db_path(a, b));
+        assert_eq!(
+            paths,
+            vec![
+                "song1.flac",
+                "song2.flac",
+                "song3.flac",
+                "rock/track1.flac",
+                "rock/track2.flac",
+            ]
+        );
+    }
+
+    #[test]
+    fn compare_db_path_file_before_deeper_subdirectory_even_when_name_sorts_after() {
+        // "a/zzz.flac" (a file directly in "a") sorts before "a/deep/w.flac"
+        // (a file inside "a"'s subdirectory "deep") even though "deep" <
+        // "zzz" alphabetically — files always precede subdirectories at the
+        // point they diverge.
+        use std::cmp::Ordering;
+        assert_eq!(
+            compare_db_path("a/zzz.flac", "a/deep/w.flac"),
+            Ordering::Less
+        );
+        assert_eq!(compare_db_path("a/x.flac", "a/deep/w.flac"), Ordering::Less);
+        assert_eq!(compare_db_path("a/deep/w.flac", "b/y.flac"), Ordering::Less);
+    }
+
+    #[test]
+    fn compare_db_path_same_directory_sorts_by_name() {
+        assert_eq!(
+            compare_db_path("dir/b.flac", "dir/a.flac"),
+            std::cmp::Ordering::Greater
+        );
+        assert_eq!(
+            compare_db_path("dir/a.flac", "dir/a.flac"),
+            std::cmp::Ordering::Equal
+        );
     }
 }

--- a/rmpd-core/src/queue.rs
+++ b/rmpd-core/src/queue.rs
@@ -145,6 +145,11 @@ pub struct Queue {
     items: Vec<QueueItem>,
     next_id: u32,
     version: u32,
+    /// Name of the last stored playlist successfully loaded into this
+    /// queue (mirrors MPD's `Queue::last_loaded_playlist`, `Queue.hxx`).
+    /// Empty when none has been loaded since the last `clear`.
+    #[serde(default)]
+    last_loaded_playlist: String,
 }
 
 impl Queue {
@@ -152,9 +157,22 @@ impl Queue {
         Self::default()
     }
 
-    pub fn add(&mut self, song: Song) -> u32 {
+    /// Allocate the next queue-item id. Mirrors MPD's `IdTable`, whose
+    /// counter starts at 1: id 0 is never a valid song id, and clients
+    /// (libmpdclient, mpc) read a 0 `songid` as "no song". The zero guard
+    /// also normalizes a queue restored from a state file written before
+    /// this rule.
+    fn allocate_id(&mut self) -> u32 {
+        if self.next_id == 0 {
+            self.next_id = 1;
+        }
         let id = self.next_id;
         self.next_id += 1;
+        id
+    }
+
+    pub fn add(&mut self, song: Song) -> u32 {
+        let id = self.allocate_id();
 
         let position = self.items.len() as u32;
         self.items.push(QueueItem {
@@ -194,7 +212,23 @@ impl Queue {
 
     pub fn clear(&mut self) {
         self.items.clear();
+        self.last_loaded_playlist.clear();
         self.version += 1;
+    }
+
+    /// Name of the last stored playlist loaded into this queue via `load`,
+    /// or `""` if none has been loaded since the last `clear`. Mirrors
+    /// MPD's `playlist::GetLastLoadedPlaylist()`.
+    pub fn last_loaded_playlist(&self) -> &str {
+        &self.last_loaded_playlist
+    }
+
+    /// Record `name` as the last stored playlist loaded into this queue.
+    /// Mirrors MPD's `playlist::SetLastLoadedPlaylist()`, called
+    /// unconditionally once a `load` has successfully read the playlist
+    /// file, regardless of how many songs ended up queued.
+    pub fn set_last_loaded_playlist(&mut self, name: impl Into<String>) {
+        self.last_loaded_playlist = name.into();
     }
 
     pub fn get(&self, position: u32) -> Option<&QueueItem> {
@@ -296,8 +330,7 @@ impl Queue {
     }
 
     pub fn add_at(&mut self, song: Song, position: Option<u32>) -> u32 {
-        let id = self.next_id;
-        self.next_id += 1;
+        let id = self.allocate_id();
 
         let pos = position.unwrap_or(self.items.len() as u32);
         let item = QueueItem {

--- a/rmpd-core/tests/filter_tests.rs
+++ b/rmpd-core/tests/filter_tests.rs
@@ -2,7 +2,7 @@ use rmpd_core::filter::{CompareOp, FilterExpression};
 
 #[test]
 fn test_simple_equality_filter() {
-    let expr = FilterExpression::parse("(artist == 'Radiohead')").unwrap();
+    let expr = FilterExpression::parse("(artist == 'Radiohead')", false).unwrap();
     let (sql, params) = expr.to_sql();
 
     assert!(sql.contains("song_tags"));
@@ -11,8 +11,8 @@ fn test_simple_equality_filter() {
 
 #[test]
 fn test_case_insensitive_tag_name() {
-    let expr1 = FilterExpression::parse("(Artist == 'Radiohead')").unwrap();
-    let expr2 = FilterExpression::parse("(artist == 'Radiohead')").unwrap();
+    let expr1 = FilterExpression::parse("(Artist == 'Radiohead')", false).unwrap();
+    let expr2 = FilterExpression::parse("(artist == 'Radiohead')", false).unwrap();
 
     let (sql1, params1) = expr1.to_sql();
     let (sql2, params2) = expr2.to_sql();
@@ -24,8 +24,28 @@ fn test_case_insensitive_tag_name() {
 }
 
 #[test]
+fn test_find_vs_search_case_sensitivity() {
+    // find (fold_case=false) is case-sensitive: plain `=`, no COLLATE.
+    let find_expr = FilterExpression::parse("(artist == 'Radiohead')", false).unwrap();
+    let (find_sql, _) = find_expr.to_sql();
+    assert!(
+        !find_sql.contains("COLLATE"),
+        "find should be case-sensitive: {find_sql}"
+    );
+
+    // search (fold_case=true) is case-insensitive: `= ? COLLATE NOCASE`.
+    let search_expr = FilterExpression::parse("(artist == 'Radiohead')", true).unwrap();
+    let (search_sql, _) = search_expr.to_sql();
+    assert!(
+        search_sql.contains("COLLATE NOCASE"),
+        "search should be case-insensitive: {search_sql}"
+    );
+}
+
+#[test]
 fn test_and_combination() {
-    let expr = FilterExpression::parse("((artist == 'Radiohead') AND (genre == 'Rock'))").unwrap();
+    let expr =
+        FilterExpression::parse("((artist == 'Radiohead') AND (genre == 'Rock'))", false).unwrap();
     let (sql, params) = expr.to_sql();
 
     assert!(sql.contains("AND"));
@@ -37,20 +57,17 @@ fn test_and_combination() {
 }
 
 #[test]
-fn test_or_combination() {
-    let expr = FilterExpression::parse("((artist == 'Radiohead') OR (artist == 'Muse'))").unwrap();
-    let (sql, params) = expr.to_sql();
-
-    assert!(sql.contains("OR"));
-    assert_eq!(params.len(), 4);
-    assert!(params.contains(&"artist".to_string()));
-    assert!(params.contains(&"Radiohead".to_string()));
-    assert!(params.contains(&"Muse".to_string()));
+fn test_or_is_rejected() {
+    // MPD's grammar (Filter.cxx::ParseExpression) has no `OR` — only `AND`
+    // chains of parenthesized sub-expressions.
+    let err = FilterExpression::parse("((artist == 'Radiohead') OR (artist == 'Muse'))", false)
+        .unwrap_err();
+    assert_eq!(err.to_string(), "Parse error: 'AND' expected");
 }
 
 #[test]
 fn test_negation() {
-    let expr = FilterExpression::parse("(!(genre == 'Pop'))").unwrap();
+    let expr = FilterExpression::parse("(!(genre == 'Pop'))", false).unwrap();
     let (sql, _) = expr.to_sql();
 
     assert!(sql.contains("NOT"));
@@ -58,16 +75,18 @@ fn test_negation() {
 
 #[test]
 fn test_not_equal_operator() {
-    let expr = FilterExpression::parse("(artist != 'Unknown')").unwrap();
+    let expr = FilterExpression::parse("(artist != 'Unknown')", false).unwrap();
     let (sql, params) = expr.to_sql();
 
-    assert!(sql.contains("!="));
+    // `!=` is `Equal` + `negated`: the whole EXISTS is NOT-wrapped rather
+    // than emitting a literal `!=` SQL operator.
+    assert!(sql.starts_with("NOT ("), "got: {sql}");
     assert_eq!(params, vec!["artist", "Unknown"]);
 }
 
 #[test]
 fn test_regex_operator() {
-    let expr = FilterExpression::parse("(artist =~ 'Radio.*')").unwrap();
+    let expr = FilterExpression::parse("(artist =~ 'Radio.*')", false).unwrap();
     let (sql, params) = expr.to_sql();
 
     assert!(sql.contains("REGEXP"));
@@ -76,52 +95,59 @@ fn test_regex_operator() {
 
 #[test]
 fn test_not_regex_operator() {
-    let expr = FilterExpression::parse("(artist !~ 'Unknown.*')").unwrap();
+    let expr = FilterExpression::parse("(artist !~ 'Unknown.*')", false).unwrap();
     let (sql, params) = expr.to_sql();
 
-    assert!(sql.contains("NOT REGEXP"));
+    assert!(sql.starts_with("NOT ("), "got: {sql}");
+    assert!(sql.contains("REGEXP"), "got: {sql}");
     assert_eq!(params, vec!["artist", "Unknown.*"]);
 }
 
-#[test]
-fn test_less_than_operator() {
-    let expr = FilterExpression::parse("(date < '2000')").unwrap();
-    let (sql, params) = expr.to_sql();
+// MPD's `operators` table (Filter.cxx:209) is 12 string operators plus
+// `==`/`!=`/`=~`/`!~`/`contains`/`starts_with` — no relational operators on
+// arbitrary tags exist at all (the only numeric comparison in the whole
+// grammar is the hardcoded `prio >= N`). `<`/`>`/`<=`/`>=` must be rejected
+// with MPD's exact "Unknown filter operator: <remainder>" text, not parsed.
 
-    assert!(sql.contains("<"));
-    assert_eq!(params, vec!["date", "2000"]);
+#[test]
+fn test_less_than_operator_is_rejected() {
+    let err = FilterExpression::parse("(date < '2000')", false).unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Parse error: Unknown filter operator: < '2000')"
+    );
 }
 
 #[test]
-fn test_greater_than_operator() {
-    let expr = FilterExpression::parse("(date > '2000')").unwrap();
-    let (sql, params) = expr.to_sql();
-
-    assert!(sql.contains(">"));
-    assert_eq!(params, vec!["date", "2000"]);
+fn test_greater_than_operator_is_rejected() {
+    let err = FilterExpression::parse("(date > '2000')", false).unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Parse error: Unknown filter operator: > '2000')"
+    );
 }
 
 #[test]
-fn test_less_equal_operator() {
-    let expr = FilterExpression::parse("(date <= '2000')").unwrap();
-    let (sql, params) = expr.to_sql();
-
-    assert!(sql.contains("<="));
-    assert_eq!(params, vec!["date", "2000"]);
+fn test_less_equal_operator_is_rejected() {
+    let err = FilterExpression::parse("(date <= '2000')", false).unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Parse error: Unknown filter operator: <= '2000')"
+    );
 }
 
 #[test]
-fn test_greater_equal_operator() {
-    let expr = FilterExpression::parse("(date >= '2000')").unwrap();
-    let (sql, params) = expr.to_sql();
-
-    assert!(sql.contains(">="));
-    assert_eq!(params, vec!["date", "2000"]);
+fn test_greater_equal_operator_is_rejected() {
+    let err = FilterExpression::parse("(date >= '2000')", false).unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Parse error: Unknown filter operator: >= '2000')"
+    );
 }
 
 #[test]
 fn test_file_tag_special_handling() {
-    let expr = FilterExpression::parse("(file == 'some/path.mp3')").unwrap();
+    let expr = FilterExpression::parse("(file == 'some/path.mp3')", false).unwrap();
     let (sql, params) = expr.to_sql();
 
     // file tag should map to path column directly
@@ -131,7 +157,7 @@ fn test_file_tag_special_handling() {
 
 #[test]
 fn test_albumartist_fallback_chain() {
-    let expr = FilterExpression::parse("(AlbumArtist == 'Led Zeppelin')").unwrap();
+    let expr = FilterExpression::parse("(AlbumArtist == 'Led Zeppelin')", false).unwrap();
     let (sql, params) = expr.to_sql();
 
     // Should generate IN clause for fallback tags
@@ -144,7 +170,7 @@ fn test_albumartist_fallback_chain() {
 
 #[test]
 fn test_double_quoted_values() {
-    let expr = FilterExpression::parse("(artist == \"Amon Tobin\")").unwrap();
+    let expr = FilterExpression::parse("(artist == \"Amon Tobin\")", false).unwrap();
     let (sql, params) = expr.to_sql();
 
     assert!(sql.contains("song_tags"));
@@ -153,7 +179,7 @@ fn test_double_quoted_values() {
 
 #[test]
 fn test_escaped_quotes_in_values() {
-    let expr = FilterExpression::parse(r#"(artist == "Guns \"N\" Roses")"#).unwrap();
+    let expr = FilterExpression::parse(r#"(artist == "Guns \"N\" Roses")"#, false).unwrap();
     let (sql, params) = expr.to_sql();
 
     assert!(sql.contains("song_tags"));
@@ -162,20 +188,30 @@ fn test_escaped_quotes_in_values() {
 
 #[test]
 fn test_complex_nested_expression() {
+    // MPD's grammar has no OR; deep nesting is still exercised via AND,
+    // nested rather than flat (each AND member is itself a parenthesized
+    // AND-group here, not a bare comparison).
     let expr = FilterExpression::parse(
-        "((artist == 'Radiohead') AND ((genre == 'Rock') OR (genre == 'Alternative')))",
+        "((artist == 'Radiohead') AND ((genre == 'Rock') AND (date == '1990')))",
+        false,
     )
     .unwrap();
     let (sql, params) = expr.to_sql();
 
-    assert!(sql.contains("AND"));
-    assert!(sql.contains("OR"));
+    // 2 structural ANDs from the nesting, plus 2 per comparison (one from
+    // the tag_restriction's own `AND`, one joining it to the value
+    // comparison) — 3 comparisons here.
+    assert_eq!(sql.matches("AND").count(), 8);
     assert_eq!(params.len(), 6);
 }
 
 #[test]
 fn test_contains_operator() {
-    let expr = FilterExpression::parse("(title contains 'love')").unwrap();
+    // fold_case=true (search semantics): bare `contains` without an
+    // explicit `_cs`/`_ci` suffix uses the command's default case
+    // sensitivity, which is what selects the LIKE-based (case-insensitive)
+    // SQL form asserted below.
+    let expr = FilterExpression::parse("(title contains 'love')", true).unwrap();
     let (sql, params) = expr.to_sql();
 
     assert!(sql.contains("LIKE"));
@@ -184,7 +220,7 @@ fn test_contains_operator() {
 
 #[test]
 fn test_starts_with_operator() {
-    let expr = FilterExpression::parse("(title starts_with 'The')").unwrap();
+    let expr = FilterExpression::parse("(title starts_with 'The')", true).unwrap();
     let (sql, params) = expr.to_sql();
 
     assert!(sql.contains("LIKE"));
@@ -197,31 +233,23 @@ fn test_filter_expression_equality() {
         tag: "artist".to_string(),
         op: CompareOp::Equal,
         value: "Radiohead".to_string(),
+        case_sensitive: true,
+        negated: false,
     };
     let expr2 = FilterExpression::Compare {
         tag: "artist".to_string(),
         op: CompareOp::Equal,
         value: "Radiohead".to_string(),
+        case_sensitive: true,
+        negated: false,
     };
 
     assert_eq!(expr1, expr2);
 }
 
 #[test]
-fn test_multiple_and_operators() {
-    let expr = FilterExpression::parse(
-        "((artist == 'Radiohead') AND (genre == 'Rock') AND (date >= '1990'))",
-    )
-    .unwrap();
-    let (sql, params) = expr.to_sql();
-
-    assert!(sql.contains("AND"));
-    assert_eq!(params.len(), 6);
-}
-
-#[test]
 fn test_contains_escapes_percent() {
-    let expr = FilterExpression::parse("(artist contains '50%')").unwrap();
+    let expr = FilterExpression::parse("(artist contains '50%')", true).unwrap();
     let (sql, params) = expr.to_sql();
 
     assert!(sql.contains("LIKE"));
@@ -231,7 +259,7 @@ fn test_contains_escapes_percent() {
 
 #[test]
 fn test_starts_with_escapes_underscore() {
-    let expr = FilterExpression::parse("(title starts_with 'foo_bar')").unwrap();
+    let expr = FilterExpression::parse("(title starts_with 'foo_bar')", true).unwrap();
     let (sql, params) = expr.to_sql();
 
     assert!(sql.contains("LIKE"));
@@ -241,7 +269,7 @@ fn test_starts_with_escapes_underscore() {
 
 #[test]
 fn test_contains_escapes_backslash() {
-    let expr = FilterExpression::parse(r"(title contains 'a\\b')").unwrap();
+    let expr = FilterExpression::parse(r"(title contains 'a\\b')", true).unwrap();
     let (sql, params) = expr.to_sql();
 
     assert!(sql.contains("ESCAPE '\\'"), "got: {sql}");
@@ -250,9 +278,96 @@ fn test_contains_escapes_backslash() {
 
 #[test]
 fn test_non_like_operators_have_no_escape_clause() {
-    let expr = FilterExpression::parse("(artist == '50%')").unwrap();
+    let expr = FilterExpression::parse("(artist == '50%')", false).unwrap();
     let (sql, params) = expr.to_sql();
 
     assert!(!sql.contains("ESCAPE"), "got: {sql}");
     assert_eq!(params, vec!["artist", "50%"]);
+}
+
+#[test]
+fn test_explicit_cs_ci_operator_suffixes() {
+    // `eq_cs`/`eq_ci` etc. override the command's default case sensitivity
+    // regardless of `fold_case`.
+    let cs_under_search = FilterExpression::parse("(Artist eq_cs 'X')", true).unwrap();
+    let (sql, _) = cs_under_search.to_sql();
+    assert!(
+        !sql.contains("COLLATE NOCASE"),
+        "eq_cs must stay case-sensitive: {sql}"
+    );
+
+    let ci_under_find = FilterExpression::parse("(Artist eq_ci 'X')", false).unwrap();
+    let (sql, _) = ci_under_find.to_sql();
+    assert!(
+        sql.contains("COLLATE NOCASE"),
+        "eq_ci must stay case-insensitive: {sql}"
+    );
+
+    let cs_contains = FilterExpression::parse("(Artist contains_cs 'X')", true).unwrap();
+    let (sql, params) = cs_contains.to_sql();
+    assert!(sql.contains("INSTR"), "contains_cs should use INSTR: {sql}");
+    assert_eq!(params, vec!["artist", "X"]);
+}
+
+#[test]
+fn test_any_tag_sentinel() {
+    // The special `any` tag checks all tag types: no `st.tag IN (...)`
+    // restriction at all.
+    let expr = FilterExpression::parse("(any == 'X')", false).unwrap();
+    let (sql, params) = expr.to_sql();
+    assert!(
+        !sql.contains("st.tag IN"),
+        "any must not restrict tag: {sql}"
+    );
+    assert_eq!(params, vec!["X"]);
+}
+
+#[test]
+fn test_base_filter() {
+    let expr = FilterExpression::parse("(base 'Music/Rock')", false).unwrap();
+    let (sql, params) = expr.to_sql();
+    assert_eq!(sql, "(path = ? OR path LIKE ? ESCAPE '\\')");
+    assert_eq!(params, vec!["Music/Rock", "Music/Rock/%"]);
+}
+
+#[test]
+fn test_modified_since_filter() {
+    let expr = FilterExpression::parse("(modified-since '2023-01-15T10:30:00Z')", false).unwrap();
+    let (sql, params) = expr.to_sql();
+    assert_eq!(sql, "last_modified >= ?");
+    assert_eq!(params, vec!["1673778600"]);
+}
+
+#[test]
+fn test_added_since_filter() {
+    let expr = FilterExpression::parse("(added-since '1700000000')", false).unwrap();
+    let (sql, params) = expr.to_sql();
+    assert_eq!(sql, "added_at >= ?");
+    assert_eq!(params, vec!["1700000000"]);
+}
+
+#[test]
+fn test_audio_format_filter() {
+    let exact = FilterExpression::parse("(AudioFormat == '44100:16:2')", false).unwrap();
+    let (sql, params) = exact.to_sql();
+    assert!(sql.contains("sample_rate = ?"));
+    assert!(sql.contains("bits_per_sample = ?"));
+    assert!(sql.contains("channels = ?"));
+    assert_eq!(params, vec!["44100", "16", "2"]);
+
+    let mask = FilterExpression::parse("(AudioFormat =~ '*:16:2')", false).unwrap();
+    let (sql, params) = mask.to_sql();
+    assert!(!sql.contains("sample_rate = ?"));
+    assert_eq!(params, vec!["16", "2"]);
+}
+
+#[test]
+fn test_priority_filter() {
+    let zero = FilterExpression::parse("(prio >= 0)", false).unwrap();
+    let (sql, _) = zero.to_sql();
+    assert_eq!(sql, "1");
+
+    let nonzero = FilterExpression::parse("(prio >= 5)", false).unwrap();
+    let (sql, _) = nonzero.to_sql();
+    assert_eq!(sql, "0");
 }

--- a/rmpd-core/tests/queue_tests.rs
+++ b/rmpd-core/tests/queue_tests.rs
@@ -9,7 +9,8 @@ fn test_add_single_song() {
     let id = queue.add(song);
 
     assert_eq!(queue.len(), 1);
-    assert_eq!(id, 0);
+    // MPD's IdTable counter starts at 1; id 0 is never a valid song id.
+    assert_eq!(id, 1);
     assert!(!queue.is_empty());
 }
 
@@ -22,9 +23,9 @@ fn test_add_multiple_songs() {
     let id3 = queue.add(create_test_song(3, "song3"));
 
     assert_eq!(queue.len(), 3);
-    assert_eq!(id1, 0);
-    assert_eq!(id2, 1);
-    assert_eq!(id3, 2);
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
+    assert_eq!(id3, 3);
 }
 
 #[test]

--- a/rmpd-library/src/artwork.rs
+++ b/rmpd-library/src/artwork.rs
@@ -8,6 +8,56 @@ use crate::database::Database;
 
 const MAX_ARTWORK_SIZE: usize = 5 * 1024 * 1024; // 5MB
 
+/// MPD's default binary chunk size (`Client::binary_limit`'s default).
+const CHUNK_SIZE: usize = 8192;
+
+/// Standalone cover-art filenames searched in a song's directory, in MPD's
+/// priority order (`FileCommands.cxx::find_stream_art`). Used by `albumart`
+/// only — never by `readpicture`, which reads embedded tag pictures instead.
+const COVER_FILE_NAMES: [&str; 4] = ["cover.png", "cover.jpg", "cover.jxl", "cover.webp"];
+
+/// Result of a chunked art lookup, mirroring the three outcomes MPD
+/// distinguishes: found (with a chunk at the requested offset), no art
+/// exists at all, or the requested offset is past the end of the art data.
+#[derive(Debug)]
+pub enum ArtLookup<T> {
+    Found(T),
+    NotFound,
+    OffsetTooLarge,
+}
+
+/// A chunk of a standalone cover-art file (`cover.png`/`.jpg`/`.jxl`/`.webp`).
+#[derive(Debug)]
+pub struct ExternalArtwork {
+    pub filename: &'static str,
+    pub total_size: usize,
+    pub data: Vec<u8>,
+}
+
+/// Locate a standalone cover-art file in `dir` and return the chunk at
+/// `offset`. This is MPD's `albumart` lookup: it only considers separate
+/// image files, never embedded tag pictures (see `AlbumArtExtractor::get_artwork`
+/// for that).
+#[must_use]
+pub fn find_external_cover(dir: &Path, offset: usize) -> ArtLookup<ExternalArtwork> {
+    for filename in COVER_FILE_NAMES {
+        let Ok(data) = std::fs::read(dir.join(filename)) else {
+            continue;
+        };
+        let total_size = data.len();
+        if offset > total_size {
+            return ArtLookup::OffsetTooLarge;
+        }
+        let end = (offset + CHUNK_SIZE).min(total_size);
+        return ArtLookup::Found(ExternalArtwork {
+            filename,
+            total_size,
+            data: data[offset..end].to_vec(),
+        });
+    }
+    ArtLookup::NotFound
+}
+
 fn infer_mime(data: &[u8]) -> &'static str {
     if data.starts_with(b"\xFF\xD8\xFF") {
         "image/jpeg"
@@ -133,10 +183,10 @@ impl AlbumArtExtractor {
         cache_key: &str,
         file_path: &str,
         offset: usize,
-    ) -> Result<Option<ArtworkData>> {
+    ) -> Result<ArtLookup<ArtworkData>> {
         let (data, stored_mime) = match self.extract_and_cache(cache_key, file_path)? {
             Some(result) => result,
-            None => return Ok(None),
+            None => return Ok(ArtLookup::NotFound),
         };
 
         // Use the stored MIME type; fall back to magic-byte inference only when empty.
@@ -146,20 +196,13 @@ impl AlbumArtExtractor {
             stored_mime
         };
 
-        // Handle offset for chunked transfer
-        // MPD protocol uses 8KB (8192 byte) chunks
-        const CHUNK_SIZE: usize = 8192;
+        if offset > data.len() {
+            return Ok(ArtLookup::OffsetTooLarge);
+        }
+        let end = (offset + CHUNK_SIZE).min(data.len());
+        let chunk = data[offset..end].to_vec();
 
-        let chunk = if offset >= data.len() {
-            // Return empty chunk when offset is past the end
-            // This is needed for proper MPD protocol compliance
-            Vec::new()
-        } else {
-            let end = (offset + CHUNK_SIZE).min(data.len());
-            data[offset..end].to_vec()
-        };
-
-        Ok(Some(ArtworkData {
+        Ok(ArtLookup::Found(ArtworkData {
             mime_type,
             total_size: data.len(),
             data: chunk,

--- a/rmpd-library/src/database.rs
+++ b/rmpd-library/src/database.rs
@@ -1060,14 +1060,16 @@ impl Database {
         Ok(songs)
     }
 
-    /// Find songs using filter expression
+    /// Find songs using filter expression. Default order (no `sort TAG`
+    /// override applied by the caller) matches MPD's database tree walk —
+    /// see `rmpd_core::path::compare_db_path` — not a plain path string sort.
     pub fn find_songs_filter(
         &self,
         filter_expr: &rmpd_core::filter::FilterExpression,
     ) -> Result<Vec<Song>> {
         let (where_clause, filter_params) = filter_expr.to_sql();
 
-        let sql = format!("SELECT {SONG_COLUMNS} FROM songs WHERE {where_clause} ORDER BY path");
+        let sql = format!("SELECT {SONG_COLUMNS} FROM songs WHERE {where_clause}");
 
         let mut stmt = self.conn.prepare(&sql)?;
 
@@ -1083,16 +1085,20 @@ impl Database {
             .query_map(params_refs.as_slice(), song_from_row)?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         self.load_tags_for_songs(&mut songs)?;
+        songs.sort_by(|a, b| rmpd_core::path::compare_db_path(a.path.as_str(), b.path.as_str()));
         Ok(songs)
     }
 
+    /// Default order matches MPD's database tree walk (see
+    /// `find_songs_filter`'s doc comment), not a plain path string sort.
     pub fn list_all_songs(&self) -> Result<Vec<Song>> {
-        let sql = format!("SELECT {SONG_COLUMNS} FROM songs ORDER BY path");
+        let sql = format!("SELECT {SONG_COLUMNS} FROM songs");
         let mut stmt = self.conn.prepare(&sql)?;
         let mut songs: Vec<Song> = stmt
             .query_map([], song_from_row)?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         self.load_tags_for_songs(&mut songs)?;
+        songs.sort_by(|a, b| rmpd_core::path::compare_db_path(a.path.as_str(), b.path.as_str()));
         Ok(songs)
     }
 
@@ -1339,15 +1345,17 @@ impl Database {
         Ok(DirectoryListing { directories, songs })
     }
 
-    /// List all songs under a directory recursively
+    /// List all songs under a directory recursively, in MPD's database
+    /// tree-walk order (see `rmpd_core::path::compare_db_path`) — used by
+    /// `add DIRECTORY` / `add /`.
     pub fn list_directory_recursive(&self, path: &str) -> Result<Vec<Song>> {
-        let sql =
-            format!("SELECT {SONG_COLUMNS} FROM songs WHERE path LIKE ?1 || '%' ORDER BY path");
+        let sql = format!("SELECT {SONG_COLUMNS} FROM songs WHERE path LIKE ?1 || '%'");
         let mut stmt = self.conn.prepare(&sql)?;
         let mut songs: Vec<Song> = stmt
             .query_map(params![path], song_from_row)?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         self.load_tags_for_songs(&mut songs)?;
+        songs.sort_by(|a, b| rmpd_core::path::compare_db_path(a.path.as_str(), b.path.as_str()));
         Ok(songs)
     }
 
@@ -1742,6 +1750,20 @@ impl Database {
         }
 
         Ok(results)
+    }
+
+    /// All distinct sticker names across every URI, matching MPD's global
+    /// `stickernames` command (`SELECT DISTINCT name FROM sticker ORDER BY name`).
+    pub fn list_all_sticker_names(&self) -> Result<Vec<String>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT DISTINCT name FROM stickers ORDER BY name")?;
+        let rows = stmt.query_map([], |row| row.get(0))?;
+        let mut names = Vec::new();
+        for row in rows {
+            names.push(row?);
+        }
+        Ok(names)
     }
 }
 

--- a/rmpd-library/src/lib.rs
+++ b/rmpd-library/src/lib.rs
@@ -9,7 +9,9 @@ pub mod metadata;
 pub mod scanner;
 pub mod watcher;
 
-pub use artwork::{AlbumArtExtractor, ArtworkData};
+pub use artwork::{
+    AlbumArtExtractor, ArtLookup, ArtworkData, ExternalArtwork, find_external_cover,
+};
 pub use cue::{CueTrack, parse_cue};
 pub use database::{Database, DbPool, DirectoryListing, PlaylistInfo, WalkEntry};
 pub use fingerprint::Fingerprinter;

--- a/rmpd-library/src/scanner.rs
+++ b/rmpd-library/src/scanner.rs
@@ -32,6 +32,7 @@ pub struct Scanner {
     event_bus: EventBus,
     music_directory: Option<Utf8PathBuf>,
     follow_symlinks: bool,
+    force_rescan: bool,
 }
 
 impl Scanner {
@@ -40,6 +41,7 @@ impl Scanner {
             event_bus,
             music_directory: None,
             follow_symlinks,
+            force_rescan: false,
         }
     }
 
@@ -52,6 +54,20 @@ impl Scanner {
             event_bus: self.event_bus.clone(),
             music_directory: Some(dir),
             follow_symlinks: self.follow_symlinks,
+            force_rescan: self.force_rescan,
+        }
+    }
+
+    /// When `true`, re-reads tags for every file even if its on-disk mtime
+    /// hasn't advanced past the database's recorded `last_modified` —
+    /// matches MPD's `rescan` command (`update` only re-reads modified
+    /// files, `rescan` also rescans unmodified ones).
+    pub fn with_force_rescan(&self, force: bool) -> Self {
+        Self {
+            event_bus: self.event_bus.clone(),
+            music_directory: self.music_directory.clone(),
+            follow_symlinks: self.follow_symlinks,
+            force_rescan: force,
         }
     }
 
@@ -332,8 +348,9 @@ impl Scanner {
                         .unwrap_or(std::time::SystemTime::UNIX_EPOCH),
                 );
 
-                // Skip if file hasn't been modified
-                if let Some(ref existing) = existing_song
+                // Skip if file hasn't been modified (unless a forced rescan)
+                if !self.force_rescan
+                    && let Some(existing) = &existing_song
                     && existing.last_modified >= mtime
                 {
                     continue;

--- a/rmpd-player/src/null_output.rs
+++ b/rmpd-player/src/null_output.rs
@@ -1,19 +1,77 @@
-//! Null audio output — silently discards all samples.
+//! Null audio output — discards all samples.
 //!
 //! Used as the output backend for outputs that are disabled or when no
 //! audio device is available.
+//!
+//! Like MPD's `null_output_plugin`, this paces writes in real time by
+//! default (`sync = true`): MPD's plugin drives a `Timer` from the audio
+//! format and reports the remaining delay to the player thread, so a null
+//! output plays a track over its real duration instead of instantly. Without
+//! pacing, a client sees the queue race to the end the moment playback
+//! starts. Set `sync = false` on the output to discard samples as fast as
+//! the decoder produces them.
 
 use crate::audio_output::{AudioOutput, PauseState};
 use rmpd_core::error::Result;
+use rmpd_core::song::AudioFormat;
+use std::time::{Duration, Instant};
+
+/// Real-time pacer, mirroring MPD's `Timer` (`src/output/Timer.cxx`): it
+/// tracks how many frames have been handed over and sleeps out the
+/// difference between that playback position and the wall clock.
+struct Pacer {
+    frames_per_second: f64,
+    channels: usize,
+    started: Option<Instant>,
+    frames: u64,
+}
+
+impl Pacer {
+    fn new(format: AudioFormat) -> Self {
+        Self {
+            frames_per_second: f64::from(format.sample_rate.max(1)),
+            channels: usize::from(format.channels).max(1),
+            started: None,
+            frames: 0,
+        }
+    }
+
+    fn add(&mut self, samples: usize) {
+        let start = *self.started.get_or_insert_with(Instant::now);
+        self.frames += (samples / self.channels) as u64;
+        let target = Duration::from_secs_f64(self.frames as f64 / self.frames_per_second);
+        if let Some(remaining) = target.checked_sub(start.elapsed()) {
+            std::thread::sleep(remaining);
+        }
+    }
+
+    fn reset(&mut self) {
+        self.started = None;
+        self.frames = 0;
+    }
+}
 
 pub struct NullOutput {
     pause_state: PauseState,
+    pacer: Option<Pacer>,
 }
 
 impl NullOutput {
+    /// Unpaced null output: samples are dropped as fast as they arrive
+    /// (MPD's `sync = false`).
     pub fn new() -> Self {
         Self {
             pause_state: PauseState::new(),
+            pacer: None,
+        }
+    }
+
+    /// Null output paced to `format`'s sample rate, matching MPD's default
+    /// `sync = true`.
+    pub fn synced(format: AudioFormat) -> Self {
+        Self {
+            pause_state: PauseState::new(),
+            pacer: Some(Pacer::new(format)),
         }
     }
 }
@@ -29,14 +87,20 @@ impl AudioOutput for NullOutput {
         Ok(())
     }
 
-    fn write(&mut self, _samples: &[f32]) -> Result<()> {
+    fn write(&mut self, samples: &[f32]) -> Result<()> {
         if self.is_paused() {
             return Ok(());
+        }
+        if let Some(pacer) = self.pacer.as_mut() {
+            pacer.add(samples.len());
         }
         Ok(())
     }
 
     fn stop(&mut self) -> Result<()> {
+        if let Some(pacer) = self.pacer.as_mut() {
+            pacer.reset();
+        }
         Ok(())
     }
 

--- a/rmpd-player/src/output_registry.rs
+++ b/rmpd-player/src/output_registry.rs
@@ -28,11 +28,21 @@ fn cpal_factory(
 }
 
 fn null_factory(
-    _format: AudioFormat,
+    format: AudioFormat,
     _quality: ResamplerQuality,
-    _cfg: &OutputConfig,
+    cfg: &OutputConfig,
 ) -> Result<Box<dyn AudioOutput>> {
-    Ok(Box::new(NullOutput::new()))
+    // MPD's null plugin: `sync` defaults to true, pacing playback in real
+    // time via a Timer.
+    let sync = cfg
+        .setting_str("sync")
+        .map(|v| !matches!(v.as_str(), "0" | "no" | "false"))
+        .unwrap_or(true);
+    Ok(Box::new(if sync {
+        NullOutput::synced(format)
+    } else {
+        NullOutput::new()
+    }))
 }
 
 fn fifo_factory(

--- a/rmpd-protocol/Cargo.toml
+++ b/rmpd-protocol/Cargo.toml
@@ -27,6 +27,7 @@ thiserror.workspace = true
 bytes.workspace = true
 tracing.workspace = true
 rand = "0.10"
+regex = "1"
 mdns-sd.workspace = true
 mpris-server.workspace = true
 

--- a/rmpd-protocol/src/commands/connection.rs
+++ b/rmpd-protocol/src/commands/connection.rs
@@ -4,13 +4,24 @@
 //! and connection management.
 
 use super::{AppState, ResponseBuilder};
-use crate::commands::utils::ACK_ERROR_PASSWORD;
+use crate::commands::utils::{ACK_ERROR_PASSWORD, ACK_ERROR_PERMISSION};
 use crate::connection::ConnectionState;
 
 /// Return server configuration
 ///
-/// Returns server configuration information from AppState.
-pub async fn handle_config_command(state: &AppState) -> String {
+/// Returns server configuration information from AppState. MPD restricts
+/// this command to clients connected over the local Unix socket
+/// (`Client::IsLocal`); remote clients get an ACK.
+pub async fn handle_config_command(state: &AppState, conn_state: &ConnectionState) -> String {
+    if !conn_state.is_local {
+        return ResponseBuilder::error(
+            ACK_ERROR_PERMISSION,
+            0,
+            "config",
+            "Command only permitted to local clients",
+        );
+    }
+
     let mut resp = ResponseBuilder::new();
 
     if let Some(music_dir) = &state.music_dir {
@@ -21,8 +32,8 @@ pub async fn handle_config_command(state: &AppState) -> String {
         resp.field("playlist_directory", playlist_dir);
     }
 
-    // MPD reports pcre support; rmpd uses basic regex matching
-    resp.field("pcre", "0");
+    // rmpd has no PCRE support compiled in (matches MPD builds without
+    // HAVE_PCRE): omit the field entirely rather than reporting "pcre: 0".
     resp.ok()
 }
 

--- a/rmpd-protocol/src/commands/database.rs
+++ b/rmpd-protocol/src/commands/database.rs
@@ -27,17 +27,29 @@ fn strip_music_dir_prefix<'a>(path: &'a str, music_dir: Option<&str>) -> &'a str
     path
 }
 
-use super::utils::{
-    ACK_ERROR_ARG, ACK_ERROR_NO_EXIST, ACK_ERROR_SYS, apply_range, build_filter,
-    format_iso8601_timestamp, open_db,
-};
-
-/// Helper function to get tag value with MPD-style fallback.
-/// Delegates to Song::tag_with_fallback() for the normalized tag storage.
-fn get_tag_value<'a>(song: &'a rmpd_core::song::Song, tag: &str) -> std::borrow::Cow<'a, str> {
-    use std::borrow::Cow;
-    Cow::Borrowed(song.tag_with_fallback(tag).unwrap_or_default())
+/// Maps a database directory-lookup failure to the right ACK code, mirroring
+/// MPD's `CommandError.cxx` exception mapping: `DatabaseErrorCode::NOT_FOUND`
+/// (a directory that isn't in the database tree) becomes `ACK_ERROR_NO_EXIST`
+/// (50), while any other failure (a real SQL/IO error) keeps `ACK_ERROR_SYS`
+/// (52) — MPD reserves 52 for genuine `std::system_error` failures, not
+/// "not found". `rmpd_library::Database::list_directory`/`walk_recursive`
+/// only ever produce the literal `"No such directory"` message for the
+/// former; any other message is the latter.
+fn directory_lookup_ack(command: &str, err: &rmpd_core::error::RmpdError) -> String {
+    let msg = err.to_string();
+    let msg = msg.strip_prefix("Library error: ").unwrap_or(&msg);
+    if msg == "No such directory" {
+        ResponseBuilder::error(ACK_ERROR_NO_EXIST, 0, command, msg)
+    } else {
+        ResponseBuilder::error(ACK_ERROR_SYS, 0, command, msg)
+    }
 }
+
+use super::utils::{
+    ACK_ERROR_ARG, ACK_ERROR_NO_EXIST, ACK_ERROR_SYS, add_songs_at_position, apply_range,
+    filter_parse_ack, format_iso8601_timestamp, open_db, parse_filter_args, parse_sort_tag,
+    resolve_add_position, sort_songs,
+};
 
 async fn handle_find_search_core(
     state: &AppState,
@@ -61,18 +73,19 @@ async fn handle_find_search_core(
             Err(e) => return e,
         };
 
-        if let Some(sort_tag) = sort.as_deref() {
-            songs.sort_by(|a, b| {
-                let a_val = get_tag_value(a, sort_tag);
-                let b_val = get_tag_value(b, sort_tag);
-                a_val.cmp(&b_val)
-            });
+        if let Some(sort_arg) = sort.as_deref() {
+            match parse_sort_tag(sort_arg) {
+                Some((key, descending)) => sort_songs(&mut songs, &key, descending),
+                None => {
+                    return ResponseBuilder::error(ACK_ERROR_ARG, 0, cmd, "Unknown sort tag");
+                }
+            }
         }
 
         let filtered = apply_range(&songs, window);
         let mut resp = ResponseBuilder::new();
         for song in filtered {
-            resp.song(song, None, None);
+            resp.song(song, None, None, None);
         }
         resp.ok()
     })
@@ -101,208 +114,159 @@ pub async fn handle_search_command(
     handle_find_search_core(state, filters, sort, window, false).await
 }
 
+/// Nested tag-value tree for `list`'s (repeatable) grouping, mirroring
+/// MPD's `RecursiveMap<std::string>` (`std::map<std::string,
+/// RecursiveMap<std::string>>`): each level groups by one tag type in
+/// `names` order (innermost = the requested tag), sorted byte-wise like
+/// `std::map` — MPD applies no locale collation here.
+#[derive(Default)]
+#[allow(clippy::disallowed_types)] // `list ... group` output must be key-ordered
+struct TagTree(std::collections::BTreeMap<String, TagTree>);
+
+impl TagTree {
+    /// `values[0]` is the set of values for this level's tag (usually one,
+    /// but a multi-valued tag fans out into multiple branches, each
+    /// continuing with the same remaining `values[1..]`).
+    fn insert_path(&mut self, values: &[Vec<&str>]) {
+        let Some((first, rest)) = values.split_first() else {
+            return;
+        };
+        let keys: &[&str] = if first.is_empty() { &[""] } else { first };
+        for &key in keys {
+            self.0.entry(key.to_string()).or_default().insert_path(rest);
+        }
+    }
+}
+
+/// Prints `name: key` for every entry at this level, recursing into deeper
+/// levels. `window` restricts only the outermost level (matches MPD, which
+/// passes `RangeArg::All()` to every recursive call after the first).
+fn print_tag_tree(
+    resp: &mut ResponseBuilder,
+    names: &[&str],
+    tree: &TagTree,
+    window: Option<(u32, u32)>,
+) {
+    let Some((&name, rest_names)) = names.split_first() else {
+        return;
+    };
+    let (start, end) = window.unwrap_or((0, u32::MAX));
+    for (i, (key, child)) in tree.0.iter().enumerate() {
+        let pos = i as u32;
+        if pos < start {
+            continue;
+        }
+        if pos >= end {
+            break;
+        }
+        resp.field(name, key);
+        if !rest_names.is_empty() {
+            print_tag_tree(resp, rest_names, child, None);
+        }
+    }
+}
+
 pub async fn handle_list_command(
     state: &AppState,
     tag: &str,
-    filter_tag: Option<&str>,
-    filter_value: Option<&str>,
-    group: Option<&str>,
+    filters: &[(String, String)],
+    groups: &[String],
+    window: Option<(u32, u32)>,
 ) -> String {
     let state = state.clone();
     let tag = tag.to_string();
-    let filter_tag = filter_tag.map(|s| s.to_string());
-    let filter_value = filter_value.map(|s| s.to_string());
-    let group = group.map(|s| s.to_string());
+    let filters = filters.to_vec();
+    let groups = groups.to_vec();
     match tokio::task::spawn_blocking(move || {
-        let tag = tag.as_str();
-        let filter_tag = filter_tag.as_deref();
-        let filter_value = filter_value.as_deref();
-        let group = group.as_deref();
         let db = match open_db(&state, "list") {
             Ok(d) => d,
             Err(e) => return e,
         };
 
-        // For grouped queries we need the full song list to extract both the group tag
-        // and the requested tag. For non-grouped queries we can use the optimised path.
-        if let Some(group_tag) = group {
-            // Grouped: get all matching songs, then group by group_tag
-            let songs = if let Some(ft) = filter_tag {
-                if ft.starts_with('(') {
-                    match rmpd_core::filter::FilterExpression::parse(ft) {
-                        Ok(filter) => match db.find_songs_filter(&filter) {
-                            Ok(s) => s,
-                            Err(e) => {
-                                return ResponseBuilder::error(
-                                    ACK_ERROR_SYS,
-                                    0,
-                                    "list",
-                                    &format!("query error: {e}"),
-                                );
-                            }
-                        },
-                        Err(e) => {
-                            return ResponseBuilder::error(
-                                ACK_ERROR_ARG,
-                                0,
-                                "list",
-                                &format!("filter parse error: {e}"),
-                            );
-                        }
-                    }
-                } else if let Some(fv) = filter_value {
-                    match db.find_songs(ft, fv) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            return ResponseBuilder::error(
-                                ACK_ERROR_SYS,
-                                0,
-                                "list",
-                                &format!("query error: {e}"),
-                            );
-                        }
-                    }
-                } else {
-                    return ResponseBuilder::error(
-                        ACK_ERROR_ARG,
-                        0,
-                        "list",
-                        "missing filter value",
-                    );
-                }
+        let query_songs = |db: &rmpd_library::Database| {
+            if filters.is_empty() {
+                db.get_all_songs().map_err(|e| {
+                    ResponseBuilder::error(ACK_ERROR_SYS, 0, "list", &format!("query error: {e}"))
+                })
             } else {
-                match db.get_all_songs() {
-                    Ok(s) => s,
-                    Err(e) => {
-                        return ResponseBuilder::error(
-                            ACK_ERROR_SYS,
-                            0,
-                            "list",
-                            &format!("query error: {e}"),
-                        );
-                    }
-                }
-            };
-
-            // Build map: group_value -> BTreeSet<tag_value> (sorted set)
-            // Group values are sorted by MPD's std::map order (lexicographic)
-            #[allow(clippy::disallowed_types)]
-            let mut groups: std::collections::BTreeMap<
-                String,
-                std::collections::BTreeSet<String>,
-            > = std::collections::BTreeMap::new();
-
-            let group_tag_lower = group_tag.to_lowercase();
-            let tag_lower = tag.to_lowercase();
-            for song in &songs {
-                let group_vals = song.tag_values_with_fallback(&group_tag_lower);
-                let tag_vals = song.tag_values_with_fallback(&tag_lower);
-
-                let group_vals: Vec<&str> = if group_vals.is_empty() {
-                    vec![""]
-                } else {
-                    group_vals
-                };
-
-                for gv in &group_vals {
-                    let tag_set = groups.entry(gv.to_string()).or_default();
-                    if tag_vals.is_empty() {
-                        tag_set.insert(String::new());
-                    } else {
-                        for tv in &tag_vals {
-                            tag_set.insert(tv.to_string());
-                        }
-                    }
-                }
+                // `list`'s filter is always parsed case-sensitively,
+                // regardless of tag/value casing (MPD hardcodes
+                // `fold_case=false` for both call sites in handle_list).
+                let expr =
+                    parse_filter_args(&filters, false).map_err(|e| filter_parse_ack("list", &e))?;
+                db.find_songs_filter(&expr).map_err(|e| {
+                    ResponseBuilder::error(ACK_ERROR_SYS, 0, "list", &format!("query error: {e}"))
+                })
             }
+        };
 
-            let group_key = rmpd_core::song::canonical_tag_name(&group_tag_lower);
-            let tag_key = rmpd_core::song::canonical_tag_name(&tag_lower);
-
+        // Deprecated `list file`/`list filename`: lists matching file URIs.
+        // Never grouped/sorted in MPD (handle_list_file has no such concept).
+        if tag.eq_ignore_ascii_case("file") || tag.eq_ignore_ascii_case("filename") {
+            let songs = match query_songs(&db) {
+                Ok(s) => s,
+                Err(e) => return e,
+            };
+            let filtered = apply_range(&songs, window);
             let mut resp = ResponseBuilder::new();
-            for (group_val, tag_vals) in &groups {
-                resp.field(group_key, group_val);
-                for tv in tag_vals {
-                    resp.field(tag_key, tv);
-                }
+            for song in filtered {
+                resp.field("file", &song.path);
             }
             return resp.ok();
         }
 
-        // Non-grouped path (original logic)
-        let values = if let Some(ft) = filter_tag {
-            if ft.starts_with('(') {
-                // Filter expression
-                match rmpd_core::filter::FilterExpression::parse(ft) {
-                    Ok(filter) => match db.find_songs_filter(&filter) {
-                        Ok(songs) => {
-                            // Extract unique values of the requested tag
-                            let mut seen = std::collections::BTreeSet::new();
-                            for song in &songs {
-                                let vals = song.tag_values_with_fallback(tag);
-                                for val in vals {
-                                    if !val.is_empty() {
-                                        seen.insert(val.to_string());
-                                    }
-                                }
-                            }
-                            seen.into_iter().collect()
-                        }
-                        Err(e) => {
-                            return ResponseBuilder::error(
-                                ACK_ERROR_SYS,
-                                0,
-                                "list",
-                                &format!("query error: {e}"),
-                            );
-                        }
-                    },
-                    Err(e) => {
-                        return ResponseBuilder::error(
-                            ACK_ERROR_ARG,
-                            0,
-                            "list",
-                            &format!("filter parse error: {e}"),
-                        );
-                    }
-                }
-            } else if let Some(fv) = filter_value {
-                // Traditional tag/value filter
-                match db.list_filtered(tag, ft, fv) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        return ResponseBuilder::error(
-                            ACK_ERROR_SYS,
-                            0,
-                            "list",
-                            &format!("query error: {e}"),
-                        );
-                    }
-                }
-            } else {
-                return ResponseBuilder::error(ACK_ERROR_ARG, 0, "list", "missing filter value");
+        let tag_lower = tag.to_lowercase();
+        if rmpd_core::song::canonical_tag_name(&tag_lower) == "Unknown" {
+            return ResponseBuilder::error(
+                ACK_ERROR_ARG,
+                0,
+                "list",
+                &format!("Unknown tag type: {tag}"),
+            );
+        }
+
+        let mut group_lowers: Vec<String> = Vec::with_capacity(groups.len());
+        for g in &groups {
+            let gl = g.to_lowercase();
+            if rmpd_core::song::canonical_tag_name(&gl) == "Unknown" {
+                return ResponseBuilder::error(
+                    ACK_ERROR_ARG,
+                    0,
+                    "list",
+                    &format!("Unknown tag type: {g}"),
+                );
             }
-        } else {
-            // No filter, list all values using generic tag query
-            let result = db.list_tag_values(tag);
-            match result {
-                Ok(v) => v,
-                Err(_) => {
-                    return ResponseBuilder::error(
-                        ACK_ERROR_ARG,
-                        0,
-                        "list",
-                        &format!("unsupported tag: {tag}"),
-                    );
-                }
+            if gl == tag_lower || group_lowers.contains(&gl) {
+                return ResponseBuilder::error(ACK_ERROR_ARG, 0, "list", "Conflicting group");
             }
+            group_lowers.push(gl);
+        }
+
+        let songs = match query_songs(&db) {
+            Ok(s) => s,
+            Err(e) => return e,
         };
 
-        let mut resp = ResponseBuilder::new();
-        let tag_key = rmpd_core::song::canonical_tag_name(&tag.to_lowercase());
-        for value in values {
-            resp.field(tag_key, value);
+        // tag_types order: groups first, then the requested tag (the
+        // requested tag is always the innermost/leaf level).
+        let mut names = group_lowers;
+        names.push(tag_lower);
+
+        let mut tree = TagTree::default();
+        for song in &songs {
+            let value_sets: Vec<Vec<&str>> = names
+                .iter()
+                .map(|n| song.tag_values_with_fallback(n))
+                .collect();
+            tree.insert_path(&value_sets);
         }
+
+        let display_names: Vec<&str> = names
+            .iter()
+            .map(|n| rmpd_core::song::canonical_tag_name(n))
+            .collect();
+        let mut resp = ResponseBuilder::new();
+        print_tag_tree(&mut resp, &display_names, &tree, window);
         resp.ok()
     })
     .await
@@ -312,100 +276,84 @@ pub async fn handle_list_command(
     }
 }
 
-pub async fn handle_count_command(
+async fn handle_count_core(
     state: &AppState,
     filters: &[(String, String)],
     group: Option<&str>,
+    fold_case: bool,
 ) -> String {
+    let cmd = if fold_case { "searchcount" } else { "count" };
     let state = state.clone();
     let filters = filters.to_vec();
     let group = group.map(|s| s.to_string());
     match tokio::task::spawn_blocking(move || {
-        let group = group.as_deref();
-        let db = match open_db(&state, "count") {
+        // MPD validates the group tag before touching the filter/database.
+        let group_lower = match group.as_deref() {
+            Some(g) => {
+                let gl = g.to_lowercase();
+                if rmpd_core::song::canonical_tag_name(&gl) == "Unknown" {
+                    return ResponseBuilder::error(
+                        ACK_ERROR_ARG,
+                        0,
+                        cmd,
+                        &format!("Unknown tag type: {g}"),
+                    );
+                }
+                Some(gl)
+            }
+            None => None,
+        };
+
+        let db = match open_db(&state, cmd) {
             Ok(d) => d,
             Err(e) => return e,
         };
 
-        // Bare "count" with no args or bare tag without value (e.g. "count Genre") should error.
-        // But "count group <tag>" (empty filters with group) is valid: count all songs grouped by tag.
-        if filters.is_empty() && group.is_none() {
+        // Bare "count"/"searchcount" with no filter and no group is an
+        // error; "count group TAG" (empty filter, grouped) counts everything.
+        if filters.is_empty() && group_lower.is_none() {
             return ResponseBuilder::error(
                 ACK_ERROR_ARG,
                 0,
-                "count",
-                "too few arguments for \"count\"",
+                cmd,
+                &format!("too few arguments for \"{cmd}\""),
             );
         }
-        // Note: empty string value is valid in MPD (e.g. "count title \"\"" finds songs with blank title).
+        // Note: an empty string value is valid (e.g. `count title ""` finds
+        // songs with a blank title).
 
-        // Get songs based on filters (empty filters = all songs)
         let songs = if filters.is_empty() {
-            // No filter - count all songs (used with "count group <tag>")
             match db.get_all_songs() {
                 Ok(s) => s,
                 Err(e) => {
                     return ResponseBuilder::error(
                         ACK_ERROR_SYS,
                         0,
-                        "count",
-                        &format!("query error: {e}"),
-                    );
-                }
-            }
-        } else if filters[0].0.starts_with('(') {
-            // Parse as filter expression
-            match rmpd_core::filter::FilterExpression::parse(&filters[0].0) {
-                Ok(filter) => match db.find_songs_filter(&filter) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        return ResponseBuilder::error(
-                            ACK_ERROR_SYS,
-                            0,
-                            "count",
-                            &format!("query error: {e}"),
-                        );
-                    }
-                },
-                Err(e) => {
-                    return ResponseBuilder::error(
-                        ACK_ERROR_ARG,
-                        0,
-                        "count",
-                        &format!("filter parse error: {e}"),
-                    );
-                }
-            }
-        } else if filters.len() == 1 {
-            match db.find_songs(&filters[0].0, &filters[0].1) {
-                Ok(s) => s,
-                Err(e) => {
-                    return ResponseBuilder::error(
-                        ACK_ERROR_SYS,
-                        0,
-                        "count",
+                        cmd,
                         &format!("query error: {e}"),
                     );
                 }
             }
         } else {
-            let expr = build_filter(&filters, rmpd_core::filter::CompareOp::Equal);
-            match db.find_songs_filter(&expr) {
-                Ok(s) => s,
-                Err(e) => {
-                    return ResponseBuilder::error(
-                        ACK_ERROR_SYS,
-                        0,
-                        "count",
-                        &format!("query error: {e}"),
-                    );
-                }
+            match parse_filter_args(&filters, fold_case) {
+                Ok(expr) => match db.find_songs_filter(&expr) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        return ResponseBuilder::error(
+                            ACK_ERROR_SYS,
+                            0,
+                            cmd,
+                            &format!("query error: {e}"),
+                        );
+                    }
+                },
+                Err(e) => return filter_parse_ack(cmd, &e),
             }
         };
 
         let mut resp = ResponseBuilder::new();
 
-        if let Some(group_tag) = group {
+        if let Some(group_tag) = group_lower.as_deref() {
             // Group by specified tag — sorted output to match MPD
             use std::collections::HashMap;
             let mut groups: HashMap<String, (usize, f64)> = HashMap::new();
@@ -423,7 +371,7 @@ pub async fn handle_count_command(
             // Sort by tag value (MPD uses std::map which sorts lexicographically)
             let mut sorted: Vec<_> = groups.into_iter().collect();
             sorted.sort_by(|a, b| a.0.cmp(&b.0));
-            let tag_key = rmpd_core::song::canonical_tag_name(&group_tag.to_lowercase());
+            let tag_key = rmpd_core::song::canonical_tag_name(group_tag);
             for (value, (count, playtime)) in &sorted {
                 resp.field(tag_key, value);
                 resp.field("songs", count);
@@ -447,54 +395,96 @@ pub async fn handle_count_command(
     .await
     {
         Ok(s) => s,
-        Err(_) => ResponseBuilder::error(ACK_ERROR_SYS, 0, "count", "internal error"),
+        Err(_) => ResponseBuilder::error(ACK_ERROR_SYS, 0, cmd, "internal error"),
     }
 }
 
-pub async fn handle_update_command(state: &AppState, _path: Option<&str>) -> String {
+pub async fn handle_count_command(
+    state: &AppState,
+    filters: &[(String, String)],
+    group: Option<&str>,
+) -> String {
+    handle_count_core(state, filters, group, false).await
+}
+
+pub async fn handle_update_command(state: &AppState, path: Option<&str>, discard: bool) -> String {
+    let cmd = if discard { "rescan" } else { "update" };
     if state.db_path.is_none() {
-        return ResponseBuilder::error(ACK_ERROR_SYS, 0, "update", "database not configured");
+        return ResponseBuilder::error(ACK_ERROR_SYS, 0, cmd, "database not configured");
     }
-    if state.music_dir.is_none() {
-        return ResponseBuilder::error(
-            ACK_ERROR_SYS,
-            0,
-            "update",
-            "music directory not configured",
-        );
+    let Some(music_dir) = state.music_dir.as_deref() else {
+        return ResponseBuilder::error(ACK_ERROR_SYS, 0, cmd, "music directory not configured");
+    };
+
+    // Backward-compat aliases for "the whole music directory" (MPD 0.15).
+    let path = match path {
+        Some(p) if !p.is_empty() && p != "/" => p,
+        _ => "",
+    };
+    if !path.is_empty() {
+        if !rmpd_core::path::uri_safe_local(path) {
+            return ResponseBuilder::error(ACK_ERROR_ARG, 0, cmd, "Malformed path");
+        }
+        if !std::path::Path::new(music_dir).join(path).exists() {
+            return ResponseBuilder::error(ACK_ERROR_NO_EXIST, 0, cmd, "No such directory");
+        }
+        // NOTE: the scan below always covers the whole music directory.
+        // Scoping it to `path` would require decoupling `Scanner`'s
+        // `music_directory` (used for relative-path computation) from its
+        // scan root, which `scan_directory` currently conflates — deferred,
+        // not a surgical fix. `path` is still validated and still gets
+        // rescanned, just as part of the full tree rather than exclusively.
     }
 
-    // Spawn the background scan (shared with auto-update on startup).
-    state.spawn_library_update();
     // Also sync enabled music sources.
     state.spawn_source_sync();
 
-    // Return update job ID
-    let mut resp = ResponseBuilder::new();
-    resp.field("updating_db", 1);
-    resp.ok()
+    match state.spawn_library_update(discard).await {
+        Some(job_id) => {
+            let mut resp = ResponseBuilder::new();
+            resp.field("updating_db", job_id);
+            resp.ok()
+        }
+        None => ResponseBuilder::error(ACK_ERROR_SYS, 0, cmd, "database not configured"),
+    }
+}
+
+/// Derive a plausible cover filename from a MIME type, for the synthetic
+/// `file` field on source-backed (remote) albumart responses where there is
+/// no real on-disk directory to report a filename from.
+fn synth_cover_filename(uri: &str, mime_type: &str) -> String {
+    let ext = match mime_type {
+        "image/png" => "png",
+        "image/webp" => "webp",
+        "image/gif" => "gif",
+        _ => "jpg",
+    };
+    match uri.rsplit_once('/') {
+        Some((dir, _)) => format!("{dir}/cover.{ext}"),
+        None => format!("cover.{ext}"),
+    }
 }
 
 pub async fn handle_albumart_command(state: &AppState, uri: &str, offset: usize) -> Response {
     debug!("albumart command: uri=[{}], offset={}", uri, offset);
 
-    let state_open = state.clone();
-    let db = match tokio::task::spawn_blocking(move || open_db(&state_open, "albumart")).await {
-        Ok(Ok(d)) => d,
-        Ok(Err(e)) => return Response::Text(e),
-        Err(_) => {
-            return Response::Text(ResponseBuilder::error(
-                ACK_ERROR_SYS,
-                0,
-                "albumart",
-                "internal error",
-            ));
-        }
-    };
-
     // Source-backed mount-style paths (e.g. `alarm-music/…`): artwork is fetched
     // from the source server (once) and cached locally — never read from a file.
     if state.sources.owns_path(uri) {
+        let state_open = state.clone();
+        let db = match tokio::task::spawn_blocking(move || open_db(&state_open, "albumart")).await {
+            Ok(Ok(d)) => d,
+            Ok(Err(e)) => return Response::Text(e),
+            Err(_) => {
+                return Response::Text(ResponseBuilder::error(
+                    ACK_ERROR_SYS,
+                    0,
+                    "albumart",
+                    "internal error",
+                ));
+            }
+        };
+
         let uri_owned = uri.to_string();
         let (extractor, is_cached) = match tokio::task::spawn_blocking(move || {
             let extractor = rmpd_library::AlbumArtExtractor::new(db);
@@ -514,32 +504,27 @@ pub async fn handle_albumart_command(state: &AppState, uri: &str, offset: usize)
             }
         };
 
-        if !is_cached && let Ok(Some(bytes)) = state.sources.cover_art(uri).await {
+        let extractor = if !is_cached && let Ok(Some(bytes)) = state.sources.cover_art(uri).await {
             let uri_owned = uri.to_string();
-            return match tokio::task::spawn_blocking(move || {
+            match tokio::task::spawn_blocking(move || {
                 let _ = extractor.cache_external(&uri_owned, &bytes);
-                extractor.get_artwork(&uri_owned, "", offset)
+                extractor
             })
             .await
             {
-                Ok(Ok(Some(artwork))) => {
-                    let mut resp = ResponseBuilder::new();
-                    resp.field("size", artwork.total_size);
-                    resp.field("type", &artwork.mime_type);
-                    resp.binary_field("binary", &artwork.data);
-                    Response::Binary(resp.to_binary_response())
+                Ok(e) => e,
+                Err(_) => {
+                    return Response::Text(ResponseBuilder::error(
+                        ACK_ERROR_SYS,
+                        0,
+                        "albumart",
+                        "internal error",
+                    ));
                 }
-                Ok(_) => {
-                    Response::Text(ResponseBuilder::error(50, 0, "albumart", "No file exists"))
-                }
-                Err(_) => Response::Text(ResponseBuilder::error(
-                    ACK_ERROR_SYS,
-                    0,
-                    "albumart",
-                    "internal error",
-                )),
-            };
-        }
+            }
+        } else {
+            extractor
+        };
 
         let uri_owned = uri.to_string();
         return match tokio::task::spawn_blocking(move || {
@@ -547,14 +532,29 @@ pub async fn handle_albumart_command(state: &AppState, uri: &str, offset: usize)
         })
         .await
         {
-            Ok(Ok(Some(artwork))) => {
+            Ok(Ok(rmpd_library::ArtLookup::Found(artwork))) => {
+                let file_field = synth_cover_filename(uri, &artwork.mime_type);
                 let mut resp = ResponseBuilder::new();
+                resp.field("file", &file_field);
                 resp.field("size", artwork.total_size);
-                resp.field("type", &artwork.mime_type);
                 resp.binary_field("binary", &artwork.data);
                 Response::Binary(resp.to_binary_response())
             }
-            Ok(_) => Response::Text(ResponseBuilder::error(50, 0, "albumart", "No file exists")),
+            Ok(Ok(rmpd_library::ArtLookup::NotFound)) => Response::Text(ResponseBuilder::error(
+                ACK_ERROR_NO_EXIST,
+                0,
+                "albumart",
+                "No file exists",
+            )),
+            Ok(Ok(rmpd_library::ArtLookup::OffsetTooLarge)) => Response::Text(
+                ResponseBuilder::error(ACK_ERROR_ARG, 0, "albumart", "Offset too large"),
+            ),
+            Ok(Err(_)) => Response::Text(ResponseBuilder::error(
+                ACK_ERROR_NO_EXIST,
+                0,
+                "albumart",
+                "No file exists",
+            )),
             Err(_) => Response::Text(ResponseBuilder::error(
                 ACK_ERROR_SYS,
                 0,
@@ -564,20 +564,17 @@ pub async fn handle_albumart_command(state: &AppState, uri: &str, offset: usize)
         };
     }
 
-    // Resolve relative path to absolute path
+    // Local files: `albumart` only looks at a standalone cover image
+    // (cover.png/.jpg/.jxl/.webp) in the song's directory — it never reads
+    // embedded tag pictures. That's `readpicture`'s job.
     let absolute_path = if uri.starts_with('/') {
-        // Already absolute
         uri.to_string()
     } else {
-        // Relative to music directory
         match &state.music_dir {
-            Some(music_dir) => {
-                let path = format!("{music_dir}/{uri}");
-                path
-            }
+            Some(music_dir) => format!("{music_dir}/{uri}"),
             None => {
                 return Response::Text(ResponseBuilder::error(
-                    50,
+                    ACK_ERROR_NO_EXIST,
                     0,
                     "albumart",
                     "music directory not configured",
@@ -585,27 +582,44 @@ pub async fn handle_albumart_command(state: &AppState, uri: &str, offset: usize)
             }
         }
     };
+    let dir = match std::path::Path::new(&absolute_path).parent() {
+        Some(d) => d.to_path_buf(),
+        None => {
+            return Response::Text(ResponseBuilder::error(
+                ACK_ERROR_NO_EXIST,
+                0,
+                "albumart",
+                "No file exists",
+            ));
+        }
+    };
+    let uri_dir = uri.rsplit_once('/').map(|(d, _)| d.to_string());
 
-    let uri_owned = uri.to_string();
-    match tokio::task::spawn_blocking(move || {
-        let extractor = rmpd_library::AlbumArtExtractor::new(db);
-        extractor.get_artwork(&uri_owned, &absolute_path, offset)
-    })
-    .await
+    match tokio::task::spawn_blocking(move || rmpd_library::find_external_cover(&dir, offset)).await
     {
-        Ok(Ok(Some(artwork))) => {
-            // Binary response with proper format
+        Ok(rmpd_library::ArtLookup::Found(art)) => {
+            let file_field = match &uri_dir {
+                Some(d) => format!("{d}/{}", art.filename),
+                None => art.filename.to_string(),
+            };
             let mut resp = ResponseBuilder::new();
-            resp.field("size", artwork.total_size);
-            resp.field("type", &artwork.mime_type);
-            resp.binary_field("binary", &artwork.data);
+            resp.field("file", &file_field);
+            resp.field("size", art.total_size);
+            resp.binary_field("binary", &art.data);
             Response::Binary(resp.to_binary_response())
         }
-        Ok(Ok(None)) => {
-            // File exists but no album art found
-            Response::Text(ResponseBuilder::error(50, 0, "albumart", "No file exists"))
-        }
-        Ok(Err(_)) => Response::Text(ResponseBuilder::error(50, 0, "albumart", "No file exists")),
+        Ok(rmpd_library::ArtLookup::NotFound) => Response::Text(ResponseBuilder::error(
+            ACK_ERROR_NO_EXIST,
+            0,
+            "albumart",
+            "No file exists",
+        )),
+        Ok(rmpd_library::ArtLookup::OffsetTooLarge) => Response::Text(ResponseBuilder::error(
+            ACK_ERROR_ARG,
+            0,
+            "albumart",
+            "Offset too large",
+        )),
         Err(_) => Response::Text(ResponseBuilder::error(
             ACK_ERROR_SYS,
             0,
@@ -682,14 +696,20 @@ pub async fn handle_readpicture_command(state: &AppState, uri: &str, offset: usi
         })
         .await
         {
-            Ok(Ok(Some(artwork))) => {
+            Ok(Ok(rmpd_library::ArtLookup::Found(artwork))) => {
                 let mut resp = ResponseBuilder::new();
                 resp.field("size", artwork.total_size);
                 resp.field("type", &artwork.mime_type);
                 resp.binary_field("binary", &artwork.data);
                 Response::Binary(resp.to_binary_response())
             }
-            Ok(_) => Response::Text(ResponseBuilder::new().ok()),
+            Ok(Ok(rmpd_library::ArtLookup::NotFound)) => {
+                Response::Text(ResponseBuilder::new().ok())
+            }
+            Ok(Err(_)) => Response::Text(ResponseBuilder::new().ok()),
+            Ok(Ok(rmpd_library::ArtLookup::OffsetTooLarge)) => Response::Text(
+                ResponseBuilder::error(ACK_ERROR_ARG, 0, "readpicture", "Bad file offset"),
+            ),
             Err(_) => Response::Text(ResponseBuilder::error(
                 ACK_ERROR_SYS,
                 0,
@@ -706,7 +726,7 @@ pub async fn handle_readpicture_command(state: &AppState, uri: &str, offset: usi
             Some(music_dir) => format!("{music_dir}/{uri}"),
             None => {
                 return Response::Text(ResponseBuilder::error(
-                    50,
+                    ACK_ERROR_NO_EXIST,
                     0,
                     "readpicture",
                     "music directory not configured",
@@ -723,17 +743,23 @@ pub async fn handle_readpicture_command(state: &AppState, uri: &str, offset: usi
     })
     .await
     {
-        Ok(Ok(Some(artwork))) => {
+        Ok(Ok(rmpd_library::ArtLookup::Found(artwork))) => {
             let mut resp = ResponseBuilder::new();
             resp.field("size", artwork.total_size);
             resp.field("type", &artwork.mime_type);
             resp.binary_field("binary", &artwork.data);
             Response::Binary(resp.to_binary_response())
         }
-        Ok(Ok(None)) => {
+        Ok(Ok(rmpd_library::ArtLookup::NotFound)) => {
             // File exists but no embedded picture — return empty OK
             Response::Text(ResponseBuilder::new().ok())
         }
+        Ok(Ok(rmpd_library::ArtLookup::OffsetTooLarge)) => Response::Text(ResponseBuilder::error(
+            ACK_ERROR_ARG,
+            0,
+            "readpicture",
+            "Bad file offset",
+        )),
         Ok(Err(_)) => {
             // Check if the file actually exists
             // If it does, treat the error as "no embedded picture" -> OK
@@ -741,7 +767,12 @@ pub async fn handle_readpicture_command(state: &AppState, uri: &str, offset: usi
             if std::path::Path::new(&absolute_path_for_check).exists() {
                 Response::Text(ResponseBuilder::new().ok())
             } else {
-                Response::Text(ResponseBuilder::error(50, 0, "readpicture", "No such song"))
+                Response::Text(ResponseBuilder::error(
+                    ACK_ERROR_NO_EXIST,
+                    0,
+                    "readpicture",
+                    "No such song",
+                ))
             }
         }
         Err(_) => Response::Text(ResponseBuilder::error(
@@ -772,9 +803,14 @@ pub async fn handle_currentsong_command(state: &AppState) -> String {
             } else {
                 song.tags.push((std::borrow::Cow::Borrowed("title"), title));
             }
-            resp.song(&song, Some(current.position), Some(current.id));
+            resp.song(&song, Some(current.position), Some(current.id), item.range);
         } else {
-            resp.song(&item.song, Some(current.position), Some(current.id));
+            resp.song(
+                &item.song,
+                Some(current.position),
+                Some(current.id),
+                item.range,
+            );
         }
         return resp.ok();
     }
@@ -806,7 +842,7 @@ pub async fn handle_lsinfo_command(state: &AppState, path: Option<&str>) -> Stri
                     let display_path = strip_music_dir_prefix(song.path.as_str(), music_dir);
                     let mut display_song = song.clone();
                     display_song.path = display_path.into();
-                    resp.song(&display_song, None, None);
+                    resp.song(&display_song, None, None, None);
                     return resp.ok();
                 }
                 Ok(None) => {}
@@ -825,7 +861,7 @@ pub async fn handle_lsinfo_command(state: &AppState, path: Option<&str>) -> Stri
                     let display_path = strip_music_dir_prefix(song.path.as_str(), music_dir);
                     let mut display_song = song.clone();
                     display_song.path = display_path.into();
-                    resp.song(&display_song, None, None);
+                    resp.song(&display_song, None, None, None);
                 }
                 for (dir, mtime) in &listing.directories {
                     let display_dir = strip_music_dir_prefix(dir, music_dir);
@@ -868,12 +904,7 @@ pub async fn handle_lsinfo_command(state: &AppState, path: Option<&str>) -> Stri
 
                 resp.ok()
             }
-            Err(e) => {
-                // Strip the "Library error: " prefix that RmpdError::Library adds
-                let msg = e.to_string();
-                let msg = msg.strip_prefix("Library error: ").unwrap_or(&msg);
-                ResponseBuilder::error(ACK_ERROR_SYS, 0, "lsinfo", msg)
-            }
+            Err(e) => directory_lookup_ack("lsinfo", &e),
         }
     })
     .await
@@ -925,11 +956,7 @@ pub async fn handle_listall_command(state: &AppState, path: Option<&str>) -> Str
 
         match result {
             Ok(()) => resp.ok(),
-            Err(e) => {
-                let msg = e.to_string();
-                let msg = msg.strip_prefix("Library error: ").unwrap_or(&msg);
-                ResponseBuilder::error(ACK_ERROR_SYS, 0, "listall", msg)
-            }
+            Err(e) => directory_lookup_ack("listall", &e),
         }
     })
     .await
@@ -957,7 +984,7 @@ pub async fn handle_listallinfo_command(state: &AppState, path: Option<&str>) ->
             match db.get_song_by_path(path_str) {
                 Ok(Some(song)) => {
                     // MPD returns just the file's full info for a file path
-                    resp.song(&song, None, None);
+                    resp.song(&song, None, None, None);
                     return resp.ok();
                 }
                 Ok(None) => {}
@@ -975,7 +1002,7 @@ pub async fn handle_listallinfo_command(state: &AppState, path: Option<&str>) ->
         let result = db.walk_recursive(path_str, &mut |entry| {
             match entry {
                 rmpd_library::WalkEntry::Song(song) => {
-                    resp.song(song, None, None);
+                    resp.song(song, None, None, None);
                 }
                 rmpd_library::WalkEntry::Directory(dir, mtime) => {
                     resp.field("directory", dir);
@@ -989,11 +1016,7 @@ pub async fn handle_listallinfo_command(state: &AppState, path: Option<&str>) ->
 
         match result {
             Ok(()) => resp.ok(),
-            Err(e) => {
-                let msg = e.to_string();
-                let msg = msg.strip_prefix("Library error: ").unwrap_or(&msg);
-                ResponseBuilder::error(ACK_ERROR_SYS, 0, "listallinfo", msg)
-            }
+            Err(e) => directory_lookup_ack("listallinfo", &e),
         }
     })
     .await
@@ -1003,76 +1026,77 @@ pub async fn handle_listallinfo_command(state: &AppState, path: Option<&str>) ->
     }
 }
 
-pub async fn handle_searchadd_command(state: &AppState, tag: &str, value: &str) -> String {
+async fn handle_match_add_core(
+    state: &AppState,
+    filters: &[(String, String)],
+    sort: Option<&str>,
+    window: Option<(u32, u32)>,
+    position: Option<crate::parser::InsertPosition>,
+    case_sensitive: bool,
+) -> String {
+    let cmd = if case_sensitive {
+        "findadd"
+    } else {
+        "searchadd"
+    };
     let state_db = state.clone();
-    let tag_owned = tag.to_string();
-    let value_owned = value.to_string();
+    let filters = filters.to_vec();
+    let sort = sort.map(|s| s.to_string());
     let songs = match tokio::task::spawn_blocking(move || {
-        let db = open_db(&state_db, "searchadd")?;
-
-        // Search for songs
-        if tag_owned.eq_ignore_ascii_case("any") {
-            db.search_songs(&value_owned).map_err(|e| {
-                ResponseBuilder::error(ACK_ERROR_SYS, 0, "searchadd", &format!("search error: {e}"))
-            })
-        } else {
-            db.search_songs_by_tag(&tag_owned, &value_owned)
-                .map_err(|e| {
-                    ResponseBuilder::error(
-                        ACK_ERROR_SYS,
+        let db = open_db(&state_db, cmd)?;
+        let mut songs = helpers::resolve_filters(&db, &filters, cmd, case_sensitive)?;
+        if let Some(sort_arg) = sort.as_deref() {
+            match parse_sort_tag(sort_arg) {
+                Some((key, descending)) => sort_songs(&mut songs, &key, descending),
+                None => {
+                    return Err(ResponseBuilder::error(
+                        ACK_ERROR_ARG,
                         0,
-                        "searchadd",
-                        &format!("query error: {e}"),
-                    )
-                })
+                        cmd,
+                        "Unknown sort tag",
+                    ));
+                }
+            }
         }
+        Ok(songs)
     })
     .await
     {
         Ok(Ok(s)) => s,
         Ok(Err(e)) => return e,
-        Err(_) => return ResponseBuilder::error(ACK_ERROR_SYS, 0, "searchadd", "internal error"),
+        Err(_) => return ResponseBuilder::error(ACK_ERROR_SYS, 0, cmd, "internal error"),
     };
 
-    for song in songs {
-        state.queue.write().await.add(song);
-    }
+    let position = match resolve_add_position(state, position, cmd).await {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
 
-    helpers::update_playlist_version(state).await;
-    ResponseBuilder::new().ok()
+    let windowed = apply_range(&songs, window).to_vec();
+    match add_songs_at_position(state, windowed, position, cmd).await {
+        Ok(()) => ResponseBuilder::new().ok(),
+        Err(e) => e,
+    }
 }
 
-pub async fn handle_findadd_command(state: &AppState, tag: &str, value: &str) -> String {
-    let state_db = state.clone();
-    let tag_owned = tag.to_string();
-    let value_owned = value.to_string();
-    let songs = match tokio::task::spawn_blocking(move || {
-        let db = open_db(&state_db, "findadd")?;
+pub async fn handle_searchadd_command(
+    state: &AppState,
+    filters: &[(String, String)],
+    sort: Option<&str>,
+    window: Option<(u32, u32)>,
+    position: Option<crate::parser::InsertPosition>,
+) -> String {
+    handle_match_add_core(state, filters, sort, window, position, false).await
+}
 
-        // findadd uses exact match (unlike searchadd which uses partial/FTS for "any")
-        if tag_owned.eq_ignore_ascii_case("any") {
-            db.find_songs_any(&value_owned).map_err(|e| {
-                ResponseBuilder::error(ACK_ERROR_SYS, 0, "findadd", &format!("search error: {e}"))
-            })
-        } else {
-            db.find_songs(&tag_owned, &value_owned).map_err(|e| {
-                ResponseBuilder::error(ACK_ERROR_SYS, 0, "findadd", &format!("query error: {e}"))
-            })
-        }
-    })
-    .await
-    {
-        Ok(Ok(s)) => s,
-        Ok(Err(e)) => return e,
-        Err(_) => return ResponseBuilder::error(ACK_ERROR_SYS, 0, "findadd", "internal error"),
-    };
-
-    for song in songs {
-        state.queue.write().await.add(song);
-    }
-
-    helpers::update_playlist_version(state).await;
-    ResponseBuilder::new().ok()
+pub async fn handle_findadd_command(
+    state: &AppState,
+    filters: &[(String, String)],
+    sort: Option<&str>,
+    window: Option<(u32, u32)>,
+    position: Option<crate::parser::InsertPosition>,
+) -> String {
+    handle_match_add_core(state, filters, sort, window, position, true).await
 }
 
 pub async fn handle_listfiles_command(state: &AppState, uri: Option<&str>) -> String {
@@ -1204,7 +1228,7 @@ pub async fn handle_listfiles_command(state: &AppState, uri: Option<&str>) -> St
                 }
                 resp.ok()
             }
-            Err(e) => ResponseBuilder::error(ACK_ERROR_SYS, 0, "listfiles", &format!("Error: {e}")),
+            Err(e) => directory_lookup_ack("listfiles", &e),
         }
     })
     .await
@@ -1214,82 +1238,14 @@ pub async fn handle_listfiles_command(state: &AppState, uri: Option<&str>) -> St
     }
 }
 
-/// Count search results with optional grouping
-///
-/// This is a convenience wrapper for count_command
+/// Count search results with optional grouping (case-insensitive, like
+/// `search`). Parameters have the same meaning as `count`.
 pub async fn handle_searchcount_command(
     state: &AppState,
-    tag: &str,
-    value: &str,
+    filters: &[(String, String)],
     group: Option<&str>,
 ) -> String {
-    let state = state.clone();
-    let tag = tag.to_string();
-    let value = value.to_string();
-    let group = group.map(|s| s.to_string());
-    match tokio::task::spawn_blocking(move || {
-        let group = group.as_deref();
-        let db = match open_db(&state, "searchcount") {
-            Ok(d) => d,
-            Err(e) => return e,
-        };
-
-        // searchcount does case-insensitive substring matching (like `search`, not `count`)
-        let songs = match db.search_songs_by_tag(&tag, &value) {
-            Ok(s) => s,
-            Err(e) => {
-                return ResponseBuilder::error(
-                    ACK_ERROR_SYS,
-                    0,
-                    "searchcount",
-                    &format!("query error: {e}"),
-                );
-            }
-        };
-
-        let mut resp = ResponseBuilder::new();
-
-        if let Some(group_tag) = group {
-            use std::collections::HashMap;
-            let mut groups: HashMap<String, (usize, f64)> = HashMap::new();
-            for song in &songs {
-                let vals = song.tag_values_with_fallback(group_tag);
-                let vals: Vec<&str> = if vals.is_empty() { vec![""] } else { vals };
-                for group_value in vals {
-                    let entry = groups.entry(group_value.to_string()).or_insert((0, 0.0));
-                    entry.0 += 1;
-                    if let Some(duration) = song.duration {
-                        entry.1 += duration.as_secs_f64();
-                    }
-                }
-            }
-            let mut sorted: Vec<_> = groups.into_iter().collect();
-            sorted.sort_by(|a, b| a.0.cmp(&b.0));
-            let tag_key = rmpd_core::song::canonical_tag_name(&group_tag.to_lowercase());
-            for (val, (count, playtime)) in &sorted {
-                resp.field(tag_key, val);
-                resp.field("songs", count);
-                resp.field("playtime", playtime.floor() as u64);
-            }
-        } else {
-            // Sum fractional seconds, then truncate (MPD uses duration_cast<seconds> = truncation)
-            let total_duration: u64 = songs
-                .iter()
-                .filter_map(|s| s.duration)
-                .map(|d| d.as_secs_f64())
-                .sum::<f64>()
-                .floor() as u64;
-            resp.field("songs", songs.len());
-            resp.field("playtime", total_duration);
-        }
-
-        resp.ok()
-    })
-    .await
-    {
-        Ok(s) => s,
-        Err(_) => ResponseBuilder::error(ACK_ERROR_SYS, 0, "searchcount", "internal error"),
-    }
+    handle_count_core(state, filters, group, true).await
 }
 
 /// Read file metadata comments

--- a/rmpd-protocol/src/commands/fingerprint.rs
+++ b/rmpd-protocol/src/commands/fingerprint.rs
@@ -18,7 +18,7 @@ pub async fn handle_getfingerprint_command(state: &AppState, uri: &str) -> Strin
         Ok(p) => p,
         Err(e) => {
             return ResponseBuilder::error(
-                50,
+                ACK_ERROR_NO_EXIST,
                 0,
                 "getfingerprint",
                 &format!("Failed to resolve URI: {e}"),

--- a/rmpd-protocol/src/commands/messaging.rs
+++ b/rmpd-protocol/src/commands/messaging.rs
@@ -7,6 +7,17 @@ use super::{AppState, ResponseBuilder};
 use crate::commands::utils::{ACK_ERROR_ARG, ACK_ERROR_EXIST, ACK_ERROR_NO_EXIST};
 use crate::connection::ConnectionState;
 
+/// MPD caps subscriptions per client (`Client::MAX_SUBSCRIPTIONS`).
+const MAX_SUBSCRIPTIONS: usize = 16;
+
+/// Notify idle clients that a channel subscription changed, mirroring MPD's
+/// `EmitIdle(IDLE_SUBSCRIPTION)`.
+fn notify_subscription_changed(state: &AppState) {
+    state
+        .event_bus
+        .emit(rmpd_core::event::Event::SubscriptionChanged);
+}
+
 /// Subscribe to a message channel
 ///
 /// Clients can subscribe to named channels to receive messages.
@@ -35,8 +46,17 @@ pub async fn handle_subscribe_command(
             "already subscribed to this channel",
         );
     }
+    if conn_state.subscribed_channels().len() >= MAX_SUBSCRIPTIONS {
+        return ResponseBuilder::error(
+            ACK_ERROR_EXIST,
+            0,
+            "subscribe",
+            "subscription list is full",
+        );
+    }
     conn_state.subscribe(channel.to_string());
     state.message_broker.register_subscriber(channel).await;
+    notify_subscription_changed(state);
     ResponseBuilder::new().ok()
 }
 
@@ -61,6 +81,7 @@ pub async fn handle_unsubscribe_command(
     }
     conn_state.unsubscribe(channel);
     state.message_broker.unregister_subscriber(channel).await;
+    notify_subscription_changed(state);
     ResponseBuilder::new().ok()
 }
 
@@ -103,11 +124,23 @@ pub async fn handle_readmessages_command(state: &AppState, conn_state: &Connecti
 /// Broadcasts a message to a channel. All subscribed clients will receive it
 /// when they call readmessages.
 pub async fn handle_sendmessage_command(state: &AppState, channel: &str, message: &str) -> String {
+    // MPD validates the channel name on send too (`handle_send_message`), not
+    // just on subscribe.
+    if channel.is_empty()
+        || !channel
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.' || c == ':')
+    {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "sendmessage", "invalid channel name");
+    }
     let ok = state
         .message_broker
         .send_message(channel.to_string(), message.to_string())
         .await;
     if ok {
+        state
+            .event_bus
+            .emit(rmpd_core::event::Event::MessageReceived);
         ResponseBuilder::new().ok()
     } else {
         ResponseBuilder::error(

--- a/rmpd-protocol/src/commands/outputs.rs
+++ b/rmpd-protocol/src/commands/outputs.rs
@@ -3,7 +3,7 @@
 use crate::response::ResponseBuilder;
 use crate::state::AppState;
 
-use super::utils::ACK_ERROR_NO_EXIST;
+use super::utils::{ACK_ERROR_ARG, ACK_ERROR_NO_EXIST};
 
 /// Reconcile the engine's active output set after an enabled-flag change.
 /// Feeds the engine ALL enabled outputs; if none are enabled, stops playback.
@@ -23,11 +23,14 @@ async fn reconcile_active_output(state: &AppState) {
     }
 }
 
-pub async fn handle_outputs_command(state: &AppState) -> String {
+pub async fn handle_outputs_command(state: &AppState, current_partition: &str) -> String {
     let outputs = state.outputs.read().await;
     let mut resp = ResponseBuilder::new();
 
-    for (i, output) in outputs.iter().enumerate() {
+    for output in outputs
+        .iter()
+        .filter(|o| o.partition.as_deref() == Some(current_partition))
+    {
         resp.field("outputid", output.id);
         resp.field("outputname", &output.name);
         resp.field("plugin", &output.plugin);
@@ -35,19 +38,22 @@ pub async fn handle_outputs_command(state: &AppState) -> String {
         for (key, value) in &output.attributes {
             resp.field("attribute", format!("{key}={value}"));
         }
-        // Add blank line between outputs, but not after the last one
-        if i < outputs.len() - 1 {
-            resp.blank_line();
-        }
     }
 
     resp.ok()
 }
 
-pub async fn handle_enableoutput_command(state: &AppState, id: u32) -> String {
+pub async fn handle_enableoutput_command(
+    state: &AppState,
+    current_partition: &str,
+    id: u32,
+) -> String {
     let found = {
         let mut outputs = state.outputs.write().await;
-        if let Some(output) = outputs.iter_mut().find(|o| o.id == id) {
+        if let Some(output) = outputs
+            .iter_mut()
+            .find(|o| o.id == id && o.partition.as_deref() == Some(current_partition))
+        {
             output.enabled = true;
             true
         } else {
@@ -71,10 +77,17 @@ pub async fn handle_enableoutput_command(state: &AppState, id: u32) -> String {
     }
 }
 
-pub async fn handle_disableoutput_command(state: &AppState, id: u32) -> String {
+pub async fn handle_disableoutput_command(
+    state: &AppState,
+    current_partition: &str,
+    id: u32,
+) -> String {
     let found = {
         let mut outputs = state.outputs.write().await;
-        if let Some(output) = outputs.iter_mut().find(|o| o.id == id) {
+        if let Some(output) = outputs
+            .iter_mut()
+            .find(|o| o.id == id && o.partition.as_deref() == Some(current_partition))
+        {
             output.enabled = false;
             true
         } else {
@@ -98,10 +111,17 @@ pub async fn handle_disableoutput_command(state: &AppState, id: u32) -> String {
     }
 }
 
-pub async fn handle_toggleoutput_command(state: &AppState, id: u32) -> String {
+pub async fn handle_toggleoutput_command(
+    state: &AppState,
+    current_partition: &str,
+    id: u32,
+) -> String {
     let found = {
         let mut outputs = state.outputs.write().await;
-        if let Some(output) = outputs.iter_mut().find(|o| o.id == id) {
+        if let Some(output) = outputs
+            .iter_mut()
+            .find(|o| o.id == id && o.partition.as_deref() == Some(current_partition))
+        {
             output.enabled = !output.enabled;
             true
         } else {
@@ -125,14 +145,27 @@ pub async fn handle_toggleoutput_command(state: &AppState, id: u32) -> String {
     }
 }
 
+/// MPD's IsValidAttributeName: non-empty, alphanumeric plus '_'.
+fn is_valid_attribute_name(name: &str) -> bool {
+    !name.is_empty() && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
 pub async fn handle_outputset_command(
     state: &AppState,
+    current_partition: &str,
     id: u32,
     name: &str,
     value: &str,
 ) -> String {
+    if !is_valid_attribute_name(name) {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "outputset", "Illegal attribute name");
+    }
+
     let mut outputs = state.outputs.write().await;
-    if let Some(output) = outputs.iter_mut().find(|o| o.id == id) {
+    if let Some(output) = outputs
+        .iter_mut()
+        .find(|o| o.id == id && o.partition.as_deref() == Some(current_partition))
+    {
         output
             .attributes
             .insert(name.to_string(), value.to_string());

--- a/rmpd-protocol/src/commands/partition.rs
+++ b/rmpd-protocol/src/commands/partition.rs
@@ -51,7 +51,12 @@ pub async fn handle_partition_command(
         conn_state.current_partition = name.to_string();
         ResponseBuilder::new().ok()
     } else {
-        ResponseBuilder::error(ACK_ERROR_NO_EXIST, 0, "partition", "No such partition")
+        ResponseBuilder::error(
+            ACK_ERROR_NO_EXIST,
+            0,
+            "partition",
+            "partition does not exist",
+        )
     }
 }
 
@@ -67,34 +72,14 @@ pub async fn handle_partition_command(
 /// OK
 /// ```
 pub async fn handle_listpartitions_command(state: &AppState) -> String {
-    let manager = match &state.partition_manager {
-        Some(m) => m,
-        None => {
-            // If no partition manager, return just default
-            let mut resp = ResponseBuilder::new();
-            resp.field("partition", "default");
-            return resp.ok();
-        }
-    };
-
-    let mut partitions = manager.list_partitions().await;
-
-    // Always include "default" partition (MPD guarantees it exists)
-    if !partitions.contains(&"default".to_string()) {
-        partitions.insert(0, "default".to_string());
-    }
-    // Sort so "default" comes first, others alphabetically
-    partitions.sort_by(|a, b| {
-        if a == "default" {
-            std::cmp::Ordering::Less
-        } else if b == "default" {
-            std::cmp::Ordering::Greater
-        } else {
-            a.cmp(b)
-        }
-    });
     let mut resp = ResponseBuilder::new();
-    for name in partitions {
+
+    let names = match &state.partition_manager {
+        Some(m) => m.list_partitions().await,
+        // If no partition manager, MPD still always has "default".
+        None => vec!["default".to_string()],
+    };
+    for name in names {
         resp.field("partition", &name);
     }
     resp.ok()
@@ -107,17 +92,19 @@ pub async fn handle_listpartitions_command(state: &AppState) -> String {
 ///
 /// Returns:
 /// - OK if partition created successfully
-/// - ACK `[50@0]` {newpartition} Partition already exists
-/// - ACK `[50@0]` {newpartition} Invalid partition name
-pub async fn handle_newpartition_command(state: &AppState, name: &str) -> String {
-    // Validate partition name
-    // Validate partition name: only alphanumeric, '-', '_' allowed (MPD IsValidPartitionName)
-    let is_valid = !name.is_empty()
+/// - ACK `[56@0]` {newpartition} name already exists
+/// - ACK `[2@0]` {newpartition} bad name
+fn is_valid_partition_name(name: &str) -> bool {
+    // MPD's IsValidPartitionName: non-empty, alphanumeric plus '-'/'_'.
+    !name.is_empty()
         && name
             .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
-    if !is_valid {
-        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "newpartition", "Invalid partition name");
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+pub async fn handle_newpartition_command(state: &AppState, name: &str) -> String {
+    if !is_valid_partition_name(name) {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "newpartition", "bad name");
     }
 
     let manager = match &state.partition_manager {
@@ -135,6 +122,9 @@ pub async fn handle_newpartition_command(state: &AppState, name: &str) -> String
     match manager.create_partition(name.to_string()).await {
         Ok(_) => {
             info!("created new partition: {}", name);
+            state
+                .event_bus
+                .emit(rmpd_core::event::Event::PartitionsChanged);
             ResponseBuilder::new().ok()
         }
         Err(e) if e.contains("already exists") => {
@@ -149,13 +139,18 @@ pub async fn handle_newpartition_command(state: &AppState, name: &str) -> String
 /// Delete an existing partition
 ///
 /// Deletes a partition and all its associated state. Cannot delete the
-/// default partition. Clients in the deleted partition are moved to default.
+/// default partition, one that still has clients, or one that still has
+/// outputs assigned.
 ///
 /// Returns:
 /// - OK if partition deleted successfully
-/// - ACK `[50@0]` {delpartition} Cannot delete default partition
-/// - ACK `[50@0]` {delpartition} No such partition
+/// - ACK `[5@0]` {delpartition} cannot delete the default partition
+/// - ACK `[50@0]` {delpartition} no such partition
 pub async fn handle_delpartition_command(state: &AppState, name: &str) -> String {
+    if !is_valid_partition_name(name) {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "delpartition", "bad name");
+    }
+
     let manager = match &state.partition_manager {
         Some(m) => m,
         None => {
@@ -171,16 +166,19 @@ pub async fn handle_delpartition_command(state: &AppState, name: &str) -> String
     match manager.delete_partition(name).await {
         Ok(_) => {
             info!("deleted partition: {}", name);
+            state
+                .event_bus
+                .emit(rmpd_core::event::Event::PartitionsChanged);
             ResponseBuilder::new().ok()
         }
         Err(e) if e.contains("Cannot delete default") => ResponseBuilder::error(
             ACK_ERROR_UNKNOWN,
             0,
             "delpartition",
-            "Cannot delete default partition",
+            "cannot delete the default partition",
         ),
         Err(e) if e.contains("not found") || e.contains("Not found") => {
-            ResponseBuilder::error(ACK_ERROR_NO_EXIST, 0, "delpartition", "No such partition")
+            ResponseBuilder::error(ACK_ERROR_NO_EXIST, 0, "delpartition", "no such partition")
         }
         Err(e) if e.contains("still has clients") => ResponseBuilder::error(
             ACK_ERROR_UNKNOWN,
@@ -291,6 +289,10 @@ pub async fn handle_moveoutput_command(
                     output.partition = Some(to.clone());
                 }
             }
+
+            state
+                .event_bus
+                .emit(rmpd_core::event::Event::OutputsChanged);
 
             info!("moved output '{}' to partition '{}'", output_name, to);
             ResponseBuilder::new().ok()

--- a/rmpd-protocol/src/commands/playlists.rs
+++ b/rmpd-protocol/src/commands/playlists.rs
@@ -4,9 +4,10 @@ use crate::response::ResponseBuilder;
 use crate::state::AppState;
 
 use super::utils::{
-    ACK_ERROR_ARG, ACK_ERROR_EXIST, ACK_ERROR_NO_EXIST, ACK_ERROR_SYS, format_iso8601_timestamp,
-    open_db,
+    ACK_ERROR_ARG, ACK_ERROR_EXIST, ACK_ERROR_NO_EXIST, ACK_ERROR_PLAYER_SYNC, ACK_ERROR_SYS,
+    apply_range, format_iso8601_timestamp, open_db, parse_sort_tag, sort_songs,
 };
+use crate::parser::InsertPosition;
 use std::path::Path;
 
 fn strip_file_uri_prefix(value: &str) -> String {
@@ -30,15 +31,13 @@ fn notify_stored_playlist(state: &AppState) {
 }
 
 /// Reject playlist names that could escape `playlist_directory` or otherwise
-/// misbehave, mirroring MPD's `playlist_check_name()` (playlist_file.c).
+/// misbehave. Mirrors MPD's `spl_valid_name()` (PlaylistFile.cxx) exactly:
+/// on a non-Windows build the only forbidden character is '/' (the
+/// directory separator), plus the name must be non-empty. Names like "."
+/// or ".." are valid single path components once the ".m3u" suffix is
+/// appended, so MPD does not special-case them.
 pub(crate) fn validate_playlist_name(name: &str) -> Result<(), String> {
-    if name.is_empty()
-        || name.contains('/')
-        || name.contains('\\')
-        || name == "."
-        || name == ".."
-        || name.chars().any(|c| c.is_control())
-    {
+    if name.is_empty() || name.contains('/') {
         return Err("Bad playlist name".to_string());
     }
     Ok(())
@@ -283,10 +282,13 @@ pub async fn handle_listplaylists_command(state: &AppState) -> String {
         for entry in dir.flatten() {
             let path = entry.path();
             let ext = path.extension().and_then(|e| e.to_str());
-            if matches!(
-                ext,
-                Some("m3u") | Some("pls") | Some("xspf") | Some("cue") | Some("asx")
-            ) && let Some(stem) = path.file_stem().and_then(|s| s.to_str())
+            // MPD's `listplaylists` enumerates only the stored-playlist
+            // directory's `.m3u` files (`ListPlaylistFiles()` in
+            // PlaylistFile.cxx filters on `PLAYLIST_FILE_SUFFIX`); playlist
+            // plugin files (.pls/.xspf/.cue/.asx) are readable via
+            // `listplaylist`/`load` but are not "stored playlists".
+            if ext == Some("m3u")
+                && let Some(stem) = path.file_stem().and_then(|s| s.to_str())
             {
                 let mtime = entry
                     .metadata()
@@ -316,16 +318,29 @@ pub async fn handle_listplaylists_command(state: &AppState) -> String {
     }
 }
 
-pub async fn handle_save_command(
-    state: &AppState,
-    name: &str,
-    mode: Option<crate::parser::SaveMode>,
-) -> String {
+pub async fn handle_save_command(state: &AppState, name: &str, mode: Option<String>) -> String {
     use crate::parser::SaveMode;
 
     if let Err(e) = validate_playlist_name(name) {
         return ResponseBuilder::error(ACK_ERROR_ARG, 0, "save", &e);
     }
+
+    // Mode names are matched case-sensitively, as MPD does with
+    // `StringIsEqual` in `handle_save` (PlaylistCommands.cxx).
+    let mode = match mode.as_deref() {
+        None => SaveMode::Create,
+        Some("create") => SaveMode::Create,
+        Some("append") => SaveMode::Append,
+        Some("replace") => SaveMode::Replace,
+        Some(_) => {
+            return ResponseBuilder::error(
+                ACK_ERROR_ARG,
+                0,
+                "save",
+                "Unrecognized save mode, expected one of 'create', 'append', 'replace'",
+            );
+        }
+    };
 
     let playlist_dir = match &state.playlist_dir {
         Some(d) => d.clone(),
@@ -339,9 +354,11 @@ pub async fn handle_save_command(
         }
     };
     let pl_path = Path::new(&playlist_dir).join(format!("{name}.m3u"));
-    let mode = mode.unwrap_or(SaveMode::Replace);
 
-    // Enforce mode preconditions (matching MPD's PlaylistSave.cxx spl_save_queue)
+    // Enforce mode preconditions (matching MPD's PlaylistSave.cxx
+    // spl_save_queue: CREATE fails if the playlist exists; APPEND and
+    // REPLACE both fail unless it already exists — "replace" is not a
+    // create-or-overwrite despite the name).
     match mode {
         SaveMode::Create => {
             if pl_path.exists() {
@@ -353,13 +370,10 @@ pub async fn handle_save_command(
                 );
             }
         }
-        SaveMode::Append => {
+        SaveMode::Append | SaveMode::Replace => {
             if !pl_path.exists() {
                 return ResponseBuilder::error(ACK_ERROR_NO_EXIST, 0, "save", "No such playlist");
             }
-        }
-        SaveMode::Replace => {
-            // Replace works whether playlist exists or not (create-or-overwrite)
         }
     }
 
@@ -414,11 +428,48 @@ pub async fn handle_save_command(
     }
 }
 
+/// Resolve `load`'s POSITION argument to an absolute queue index, mirroring
+/// MPD's `ParseInsertPosition()` (PositionArg.cxx): `+N`/`-N` are relative to
+/// the currently playing song, bounds-checked against the queue's length and
+/// current position *before* the load inserts anything.
+fn resolve_insert_position(
+    pos: InsertPosition,
+    queue_len: u32,
+    current_song_position: Option<u32>,
+) -> Result<u32, String> {
+    match pos {
+        InsertPosition::Absolute(n) => {
+            if n > queue_len {
+                Err("Bad song index".to_string())
+            } else {
+                Ok(n)
+            }
+        }
+        InsertPosition::After(n) => {
+            let current = current_song_position.ok_or_else(|| "No current song".to_string())?;
+            let max = queue_len - current - 1;
+            if n > max {
+                Err("Bad song index".to_string())
+            } else {
+                Ok(current + 1 + n)
+            }
+        }
+        InsertPosition::Before(n) => {
+            let current = current_song_position.ok_or_else(|| "No current song".to_string())?;
+            if n > current {
+                Err("Bad song index".to_string())
+            } else {
+                Ok(current - n)
+            }
+        }
+    }
+}
+
 pub async fn handle_load_command(
     state: &AppState,
     name: &str,
     range: Option<(u32, u32)>,
-    position: Option<u32>,
+    position: Option<InsertPosition>,
 ) -> String {
     if let Err(e) = validate_playlist_name(name) {
         return ResponseBuilder::error(ACK_ERROR_ARG, 0, "load", &e);
@@ -436,6 +487,28 @@ pub async fn handle_load_command(
         }
     };
 
+    // Resolve a relative (+N/-N) or absolute POSITION against the queue's
+    // pre-load length and current song, mirroring MPD's ParseInsertPosition
+    // call (which runs before the songs are loaded into the queue).
+    let resolved_position = match position {
+        None => None,
+        Some(pos) => {
+            let queue_len = state.queue.read().await.len() as u32;
+            let current = state.status.read().await.current_song.map(|q| q.position);
+            match resolve_insert_position(pos, queue_len, current) {
+                Ok(p) => Some(p),
+                Err(e) => {
+                    let code = if e == "No current song" {
+                        ACK_ERROR_PLAYER_SYNC
+                    } else {
+                        ACK_ERROR_ARG
+                    };
+                    return ResponseBuilder::error(code, 0, "load", &e);
+                }
+            }
+        }
+    };
+
     // A `.cue` sheet (when no higher-priority playlist of the same name exists)
     // expands into virtual tracks with playback ranges instead of plain paths.
     let cue_only = {
@@ -447,30 +520,25 @@ pub async fn handle_load_command(
             && !p("asx").exists()
     };
     if cue_only {
-        return load_cue_virtual_tracks(state, &playlist_dir, name, range, position).await;
+        return load_cue_virtual_tracks(state, &playlist_dir, name, range, resolved_position).await;
     }
 
     let state_clone = state.clone();
     let playlist_dir_clone = playlist_dir.clone();
     let name_owned = name.to_string();
     let songs = match tokio::task::spawn_blocking(move || {
-        let mut paths = read_playlist(&playlist_dir_clone, &name_owned)
-            .map_err(|e| ResponseBuilder::error(ACK_ERROR_SYS, 0, "load", &e))?;
+        let mut paths = read_playlist(&playlist_dir_clone, &name_owned).map_err(|_| {
+            ResponseBuilder::error(ACK_ERROR_NO_EXIST, 0, "load", "No such playlist")
+        })?;
 
-        // Apply range filter if specified
+        // Apply the optional range, clamping like MPD's playlist enumerator:
+        // a start beyond the playlist's length simply yields nothing, not an
+        // error (`playlist_load_into_queue` never validates the range).
         if let Some((start, end)) = range {
-            let start = start as usize;
-            let end = (end as usize).min(paths.len());
-            if start <= paths.len() {
-                paths = paths[start..end].to_vec();
-            } else {
-                return Err(ResponseBuilder::error(
-                    ACK_ERROR_ARG,
-                    0,
-                    "load",
-                    "Invalid range",
-                ));
-            }
+            let total = paths.len();
+            let start = (start as usize).min(total);
+            let end = (end as usize).min(total).max(start);
+            paths = paths[start..end].to_vec();
         }
 
         // Look up songs from DB; fall back to stub Song if not found
@@ -490,7 +558,7 @@ pub async fn handle_load_command(
 
     {
         let mut queue = state.queue.write().await;
-        if let Some(pos) = position {
+        if let Some(pos) = resolved_position {
             for (i, song) in songs.into_iter().enumerate() {
                 queue.add_at(song, Some(pos + i as u32));
             }
@@ -499,6 +567,11 @@ pub async fn handle_load_command(
                 queue.add(song);
             }
         }
+        // Mirrors MPD's unconditional `SetLastLoadedPlaylist(uri)` at the
+        // end of `playlist_load_into_queue`: recorded once the playlist
+        // file was successfully read, regardless of how many songs (if
+        // any) actually matched the range/database.
+        queue.set_last_loaded_playlist(name);
     }
 
     crate::helpers::update_playlist_version(state).await;
@@ -507,7 +580,8 @@ pub async fn handle_load_command(
 
 /// Load a `.cue` sheet as virtual tracks: each track is added to the queue with
 /// its own playback range (start/end in seconds) so playback is restricted to
-/// that segment of the underlying audio file.
+/// that segment of the underlying audio file. `position` is already an
+/// absolute queue index, resolved by `resolve_insert_position`.
 async fn load_cue_virtual_tracks(
     state: &AppState,
     playlist_dir: &str,
@@ -517,15 +591,15 @@ async fn load_cue_virtual_tracks(
 ) -> String {
     let mut tracks = match read_cue_tracks(playlist_dir, name) {
         Ok(t) => t,
-        Err(e) => return ResponseBuilder::error(ACK_ERROR_SYS, 0, "load", &e),
+        Err(_) => {
+            return ResponseBuilder::error(ACK_ERROR_NO_EXIST, 0, "load", "No such playlist");
+        }
     };
 
     if let Some((start, end)) = range {
-        let start = start as usize;
-        let end = (end as usize).min(tracks.len());
-        if start > tracks.len() || start > end {
-            return ResponseBuilder::error(ACK_ERROR_ARG, 0, "load", "Invalid range");
-        }
+        let total = tracks.len();
+        let start = (start as usize).min(total);
+        let end = (end as usize).min(total).max(start);
         tracks = tracks[start..end].to_vec();
     }
 
@@ -536,6 +610,7 @@ async fn load_cue_virtual_tracks(
             let id = queue.add_at(song, pos);
             queue.set_range_by_id(id, Some(song_range));
         }
+        queue.set_last_loaded_playlist(name);
     }
 
     crate::helpers::update_playlist_version(state).await;
@@ -545,17 +620,51 @@ async fn load_cue_virtual_tracks(
 pub async fn handle_searchaddpl_command(
     state: &AppState,
     name: &str,
-    tag: &str,
-    value: &str,
+    filters: &[(String, String)],
+    sort: Option<&str>,
+    window: Option<(u32, u32)>,
+    position: Option<u32>,
 ) -> String {
     if let Err(e) = validate_playlist_name(name) {
         return ResponseBuilder::error(ACK_ERROR_ARG, 0, "searchaddpl", &e);
     }
 
+    let state_db = state.clone();
+    let filters = filters.to_vec();
+    let sort = sort.map(|s| s.to_string());
+    let songs = match tokio::task::spawn_blocking(move || {
+        let db = open_db(&state_db, "searchaddpl")?;
+        // `searchaddpl`'s parameters have the same meaning as `search`
+        // (case-insensitive).
+        let mut songs = crate::helpers::resolve_filters(&db, &filters, "searchaddpl", false)?;
+        if let Some(sort_arg) = sort.as_deref() {
+            match parse_sort_tag(sort_arg) {
+                Some((key, descending)) => sort_songs(&mut songs, &key, descending),
+                None => {
+                    return Err(ResponseBuilder::error(
+                        ACK_ERROR_ARG,
+                        0,
+                        "searchaddpl",
+                        "Unknown sort tag",
+                    ));
+                }
+            }
+        }
+        Ok(songs)
+    })
+    .await
+    {
+        Ok(Ok(s)) => s,
+        Ok(Err(e)) => return e,
+        Err(_) => return ResponseBuilder::error(ACK_ERROR_SYS, 0, "searchaddpl", "internal error"),
+    };
+    let new_paths: Vec<String> = apply_range(&songs, window)
+        .iter()
+        .map(|s| s.path.to_string())
+        .collect();
+
     let state = state.clone();
     let name = name.to_string();
-    let tag = tag.to_string();
-    let value = value.to_string();
     match tokio::task::spawn_blocking(move || {
         let playlist_dir = match &state.playlist_dir {
             Some(d) => d.clone(),
@@ -568,46 +677,27 @@ pub async fn handle_searchaddpl_command(
                 );
             }
         };
-        let db = match open_db(&state, "searchaddpl") {
-            Ok(d) => d,
-            Err(e) => return e,
-        };
-
-        let songs = if tag.eq_ignore_ascii_case("any") {
-            match db.search_songs(&value) {
-                Ok(s) => s,
-                Err(e) => {
-                    return ResponseBuilder::error(
-                        ACK_ERROR_SYS,
-                        0,
-                        "searchaddpl",
-                        &format!("search error: {e}"),
-                    );
-                }
-            }
-        } else {
-            match db.find_songs(&tag, &value) {
-                Ok(s) => s,
-                Err(e) => {
-                    return ResponseBuilder::error(
-                        ACK_ERROR_SYS,
-                        0,
-                        "searchaddpl",
-                        &format!("query error: {e}"),
-                    );
-                }
-            }
-        };
-
         let pl_path = Path::new(&playlist_dir).join(format!("{name}.m3u"));
         let mut paths = if pl_path.exists() {
             read_m3u_playlist(&playlist_dir, &name).unwrap_or_default()
         } else {
             vec![]
         };
-        for song in &songs {
-            paths.push(song.path.to_string());
+
+        if let Some(pos) = position
+            && pos as usize > paths.len()
+        {
+            return ResponseBuilder::error(ACK_ERROR_ARG, 0, "searchaddpl", "Bad position");
         }
+
+        if let Some(pos) = position {
+            for (i, p) in new_paths.into_iter().enumerate() {
+                paths.insert(pos as usize + i, p);
+            }
+        } else {
+            paths.extend(new_paths);
+        }
+
         let content = paths
             .iter()
             .map(|p| p.as_str())
@@ -658,9 +748,16 @@ pub async fn handle_listplaylist_command(
     let name = name.to_string();
 
     match tokio::task::spawn_blocking(move || {
-        let paths = match read_m3u_playlist(&playlist_dir, &name) {
+        let paths = match read_playlist(&playlist_dir, &name) {
             Ok(p) => p,
-            Err(e) => return ResponseBuilder::error(ACK_ERROR_SYS, 0, "listplaylist", &e),
+            Err(_) => {
+                return ResponseBuilder::error(
+                    ACK_ERROR_NO_EXIST,
+                    0,
+                    "listplaylist",
+                    "No such playlist",
+                );
+            }
         };
 
         let total = paths.len();
@@ -707,9 +804,16 @@ pub async fn handle_listplaylistinfo_command(
             }
         };
 
-        let paths = match read_m3u_playlist(&playlist_dir, &name) {
+        let paths = match read_playlist(&playlist_dir, &name) {
             Ok(p) => p,
-            Err(e) => return ResponseBuilder::error(ACK_ERROR_SYS, 0, "listplaylistinfo", &e),
+            Err(_) => {
+                return ResponseBuilder::error(
+                    ACK_ERROR_NO_EXIST,
+                    0,
+                    "listplaylistinfo",
+                    "No such playlist",
+                );
+            }
         };
         let db = match open_db(&state, "listplaylistinfo") {
             Ok(d) => d,
@@ -728,7 +832,7 @@ pub async fn handle_listplaylistinfo_command(
         for path in slice {
             match db.find_songs("file", path) {
                 Ok(songs) if !songs.is_empty() => {
-                    resp.song(&songs[0], None, None);
+                    resp.song(&songs[0], None, None, None);
                 }
                 _ => {
                     // Song not in DB — emit just the file path like MPD does for unknown tracks
@@ -770,6 +874,23 @@ pub async fn handle_playlistadd_command(
                 );
             }
         };
+
+        let pl_path = Path::new(&playlist_dir).join(format!("{name}.m3u"));
+        let mut paths = if pl_path.exists() {
+            read_m3u_playlist(&playlist_dir, &name).unwrap_or_default()
+        } else {
+            vec![]
+        };
+
+        // Bound-check POSITION against the playlist's current size ahead of
+        // any lookup, matching MPD's `handle_playlistadd_position` (checked
+        // once, before either the scheme-URI or database-search path runs).
+        if let Some(pos) = position
+            && pos as usize > paths.len()
+        {
+            return ResponseBuilder::error(ACK_ERROR_ARG, 0, "playlistadd", "Bad position");
+        }
+
         let db = match open_db(&state, "playlistadd") {
             Ok(d) => d,
             Err(e) => return e,
@@ -796,18 +917,10 @@ pub async fn handle_playlistadd_command(
             }
         };
 
-        let pl_path = Path::new(&playlist_dir).join(format!("{name}.m3u"));
-        let mut paths = if pl_path.exists() {
-            read_m3u_playlist(&playlist_dir, &name).unwrap_or_default()
-        } else {
-            vec![]
-        };
-
-        // Collect new paths to append (sorted, matching MPD behavior)
-        let start_pos = position.map(|p| p as usize);
+        // Collect new paths to insert/append (matching MPD behavior)
         let new_paths: Vec<String> = songs.iter().map(|s| s.path.to_string()).collect();
-        if let Some(pos) = start_pos {
-            let pos = pos.min(paths.len());
+        if let Some(pos) = position {
+            let pos = pos as usize;
             for (i, p) in new_paths.into_iter().enumerate() {
                 paths.insert(pos + i, p);
             }
@@ -887,7 +1000,11 @@ pub async fn handle_playlistclear_command(state: &AppState, name: &str) -> Strin
     }
 }
 
-pub async fn handle_playlistdelete_command(state: &AppState, name: &str, position: u32) -> String {
+pub async fn handle_playlistdelete_command(
+    state: &AppState,
+    name: &str,
+    range: (u32, u32),
+) -> String {
     if let Err(e) = validate_playlist_name(name) {
         return ResponseBuilder::error(ACK_ERROR_ARG, 0, "playlistdelete", &e);
     }
@@ -908,13 +1025,25 @@ pub async fn handle_playlistdelete_command(state: &AppState, name: &str, positio
     match tokio::task::spawn_blocking(move || {
         let mut paths = match read_m3u_playlist(&playlist_dir, &name) {
             Ok(p) => p,
-            Err(e) => return ResponseBuilder::error(ACK_ERROR_SYS, 0, "playlistdelete", &e),
+            Err(_) => {
+                return ResponseBuilder::error(
+                    ACK_ERROR_NO_EXIST,
+                    0,
+                    "playlistdelete",
+                    "No such playlist",
+                );
+            }
         };
-        let pos = position as usize;
-        if pos >= paths.len() {
+        // Mirrors `RangeArg::CheckClip`: only the start bound is validated;
+        // the end is silently clipped to the playlist's length (so e.g. a
+        // single index one past the end is accepted as a no-op removal).
+        let (start, end) = range;
+        let start = start as usize;
+        if start > paths.len() {
             return ResponseBuilder::error(ACK_ERROR_ARG, 0, "playlistdelete", "Bad song index");
         }
-        paths.remove(pos);
+        let end = (end as usize).min(paths.len());
+        paths.drain(start..end);
         let content = paths
             .iter()
             .map(|p| p.as_str())
@@ -946,9 +1075,28 @@ pub async fn handle_playlistdelete_command(state: &AppState, name: &str, positio
 pub async fn handle_playlistmove_command(
     state: &AppState,
     name: &str,
-    from: u32,
+    from: (u32, u32),
     to: u32,
 ) -> String {
+    // MPD doesn't support an open-ended FROM range for playlistmove, and an
+    // empty range or a move to its own start position succeeds as a no-op
+    // without even checking the playlist name/existence (MPD's comment:
+    // "this doesn't check whether the playlist exists, but what the
+    // hell.."). Both checks run before `PlaylistFileEditor` (which is what
+    // validates the name) is ever constructed, so they must precede our own
+    // name validation too.
+    if from.1 == u32::MAX {
+        return ResponseBuilder::error(
+            ACK_ERROR_ARG,
+            0,
+            "playlistmove",
+            "Open-ended range not supported",
+        );
+    }
+    if from.0 >= from.1 || from.0 == to {
+        return ResponseBuilder::new().ok();
+    }
+
     if let Err(e) = validate_playlist_name(name) {
         return ResponseBuilder::error(ACK_ERROR_ARG, 0, "playlistmove", &e);
     }
@@ -969,16 +1117,28 @@ pub async fn handle_playlistmove_command(
     match tokio::task::spawn_blocking(move || {
         let mut paths = match read_m3u_playlist(&playlist_dir, &name) {
             Ok(p) => p,
-            Err(e) => return ResponseBuilder::error(ACK_ERROR_SYS, 0, "playlistmove", &e),
+            Err(_) => {
+                return ResponseBuilder::error(
+                    ACK_ERROR_NO_EXIST,
+                    0,
+                    "playlistmove",
+                    "No such playlist",
+                );
+            }
         };
-        let from = from as usize;
+        // Mirrors `PlaylistFileEditor::MoveIndex`: `src.end` must fit inside
+        // the playlist, and `dest` is bounded by the size *after* removing
+        // the moved range (not the original length).
+        let (start, end) = from;
+        let (start, end) = (start as usize, end as usize);
         let to = to as usize;
-        if from >= paths.len() || to > paths.len() {
-            return ResponseBuilder::error(ACK_ERROR_ARG, 0, "playlistmove", "Bad song index");
+        let total = paths.len();
+        let count = end - start;
+        if end > total || to > total - count {
+            return ResponseBuilder::error(ACK_ERROR_ARG, 0, "playlistmove", "Bad range");
         }
-        let song = paths.remove(from);
-        let insert_pos = if to > from { to - 1 } else { to };
-        paths.insert(insert_pos.min(paths.len()), song);
+        let moved: Vec<String> = paths.drain(start..end).collect();
+        paths.splice(to..to, moved);
         let content = paths
             .iter()
             .map(|p| p.as_str())
@@ -1095,17 +1255,19 @@ pub async fn handle_rename_command(state: &AppState, from: &str, to: &str) -> St
 pub async fn handle_searchplaylist_command(
     state: &AppState,
     name: &str,
-    tag: &str,
-    value: &str,
+    filters: &[(String, String)],
+    window: Option<(u32, u32)>,
 ) -> String {
     if let Err(e) = validate_playlist_name(name) {
         return ResponseBuilder::error(ACK_ERROR_ARG, 0, "searchplaylist", &e);
     }
+    if filters.is_empty() {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "searchplaylist", "missing arguments");
+    }
 
     let state = state.clone();
     let name = name.to_string();
-    let tag = tag.to_string();
-    let value = value.to_string();
+    let filters = filters.to_vec();
     match tokio::task::spawn_blocking(move || {
         let playlist_dir = match &state.playlist_dir {
             Some(d) => d.clone(),
@@ -1118,7 +1280,7 @@ pub async fn handle_searchplaylist_command(
                 );
             }
         };
-        let paths = match read_m3u_playlist(&playlist_dir, &name) {
+        let paths = match read_playlist(&playlist_dir, &name) {
             Ok(p) => p,
             Err(_) => {
                 return ResponseBuilder::error(
@@ -1134,15 +1296,38 @@ pub async fn handle_searchplaylist_command(
             Err(e) => return e,
         };
 
+        // Same filter grammar and case-insensitivity as `search` (MPD's
+        // `filter.Parse(args, /*fold_case=*/true)`), matched against the DB
+        // then intersected with this playlist's own songs so the printed
+        // "Pos:" reflects the playlist's order, not a DB query order.
+        let matched = match crate::helpers::resolve_filters(&db, &filters, "searchplaylist", false)
+        {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let matched_by_path: std::collections::HashMap<&str, &rmpd_core::song::Song> =
+            matched.iter().map(|s| (s.path.as_str(), s)).collect();
+
+        // Mirrors `playlist_provider_search_print`: `position` walks every
+        // playlist entry regardless of match; `window` skips/limits matches.
+        let (win_start, win_end) = window.unwrap_or((0, u32::MAX));
+        let mut skip = win_start as u64;
+        let mut remaining = (win_end as u64).saturating_sub(win_start as u64);
+
         let mut resp = ResponseBuilder::new();
-        let value_lower = value.to_lowercase();
-        let tag_lower = tag.to_lowercase();
-        for path in &paths {
-            if let Ok(Some(song)) = db.get_song_by_path(path)
-                && song.tag_contains(&tag_lower, &value_lower)
-            {
-                resp.song(&song, None, None);
+        for (pos, path) in paths.iter().enumerate() {
+            if remaining == 0 {
+                break;
             }
+            let Some(song) = matched_by_path.get(path.as_str()).copied() else {
+                continue;
+            };
+            if skip > 0 {
+                skip -= 1;
+                continue;
+            }
+            resp.song(song, Some(pos as u32), None, None);
+            remaining -= 1;
         }
         resp.ok()
     })
@@ -1172,7 +1357,7 @@ pub async fn handle_playlistlength_command(state: &AppState, name: &str) -> Stri
                 );
             }
         };
-        let paths = match read_m3u_playlist(&playlist_dir, &name) {
+        let paths = match read_playlist(&playlist_dir, &name) {
             Ok(p) => p,
             Err(_) => {
                 return ResponseBuilder::error(

--- a/rmpd-protocol/src/commands/queue.rs
+++ b/rmpd-protocol/src/commands/queue.rs
@@ -8,12 +8,182 @@ use crate::response::ResponseBuilder;
 use crate::state::AppState;
 
 use super::utils::{
-    ACK_ERROR_ARG, ACK_ERROR_NO_EXIST, ACK_ERROR_SYS, add_at_checked, add_queue_item_metadata,
-    apply_range, open_db, prepare_song_for_playback, update_next_song,
+    ACK_ERROR_ARG, ACK_ERROR_NO_EXIST, ACK_ERROR_PERMISSION, ACK_ERROR_PLAYER_SYNC, ACK_ERROR_SYS,
+    add_at_checked, add_queue_item_metadata, apply_range, open_db, prepare_song_for_playback,
+    update_next_song,
 };
 
-pub async fn handle_add_command(state: &AppState, uri: &str, position: Option<u32>) -> String {
+fn number_too_large(command: &str, n: u32) -> String {
+    ResponseBuilder::error(ACK_ERROR_ARG, 0, command, &format!("Number too large: {n}"))
+}
+
+/// Look up the position of the currently-playing/paused song, mirroring
+/// MPD's `RequireCurrentPosition` (PositionArg.cxx). Errors when nothing is
+/// current (e.g. an empty queue, or playback never started).
+async fn require_current_position(state: &AppState, command: &str) -> Result<u32, String> {
+    match state.status.read().await.current_song {
+        Some(pos) => Ok(pos.position),
+        None => Err(ResponseBuilder::error(
+            ACK_ERROR_PLAYER_SYNC,
+            0,
+            command,
+            "No current song",
+        )),
+    }
+}
+
+/// Resolve an `add`/`addid` POSITION argument (`+N`/`-N`/absolute) into an
+/// absolute queue index, mirroring MPD's `ParseInsertPosition`
+/// (PositionArg.cxx).
+async fn resolve_insert_position(
+    state: &AppState,
+    spec: crate::parser::InsertPosition,
+    command: &str,
+) -> Result<u32, String> {
+    use crate::parser::InsertPosition;
+
+    let queue_len = state.queue.read().await.len() as u32;
+    match spec {
+        InsertPosition::Absolute(n) => {
+            if n > queue_len {
+                return Err(number_too_large(command, n));
+            }
+            Ok(n)
+        }
+        InsertPosition::After(n) => {
+            let current = require_current_position(state, command).await?;
+            let max = queue_len - current - 1;
+            if n > max {
+                return Err(number_too_large(command, n));
+            }
+            Ok(current + 1 + n)
+        }
+        InsertPosition::Before(n) => {
+            let current = require_current_position(state, command).await?;
+            if n > current {
+                return Err(number_too_large(command, n));
+            }
+            Ok(current - n)
+        }
+    }
+}
+
+/// Resolve a `move`/`moveid` TO argument (`+N`/`-N`/absolute) into an
+/// absolute queue index, mirroring MPD's `ParseMoveDestination`
+/// (PositionArg.cxx). `range` is the half-open `[start, end)` source range
+/// being moved; it must already be non-empty and within `[0, queue_len]`.
+async fn resolve_move_destination(
+    state: &AppState,
+    to: crate::parser::InsertPosition,
+    range: (u32, u32),
+    queue_len: u32,
+    command: &str,
+) -> Result<u32, String> {
+    use crate::parser::InsertPosition;
+
+    let (start, end) = range;
+    let count = i64::from(end - start);
+
+    let n = match to {
+        InsertPosition::Absolute(n) => {
+            let max = i64::from(queue_len) - count;
+            if i64::from(n) > max {
+                return Err(number_too_large(command, n));
+            }
+            return Ok(n);
+        }
+        InsertPosition::After(n) | InsertPosition::Before(n) => n,
+    };
+
+    let mut current = i64::from(require_current_position(state, command).await?);
+    if current >= i64::from(start) && current < i64::from(end) {
+        return Err(ResponseBuilder::error(
+            ACK_ERROR_ARG,
+            0,
+            command,
+            "Cannot move current song relative to itself",
+        ));
+    }
+    if current >= i64::from(end) {
+        current -= count;
+    }
+    let max = i64::from(queue_len) - current - count;
+    if i64::from(n) > max {
+        return Err(number_too_large(command, n));
+    }
+    let resolved = if matches!(to, InsertPosition::After(_)) {
+        current + 1 + i64::from(n)
+    } else {
+        current - i64::from(n)
+    };
+    if resolved < 0 {
+        return Err(ResponseBuilder::error(
+            ACK_ERROR_ARG,
+            0,
+            command,
+            "Bad song index",
+        ));
+    }
+    Ok(resolved as u32)
+}
+/// Move the half-open range `[start, end)` to destination `to` (already
+/// resolved, absolute, and bounds-checked against `queue_len - (end -
+/// start)`) by repeatedly moving individual items — mirrors MPD's
+/// `Queue::MoveRange`. `to` is the range's final absolute start position
+/// in the *resulting* queue (i.e. the moved block ends up occupying
+/// `[to, to + range_size)`), not an index into the post-removal array.
+/// Returns `false` if a move failed (shouldn't happen for validated inputs).
+fn move_range_in_queue(queue: &mut rmpd_core::queue::Queue, start: u32, end: u32, to: u32) -> bool {
+    let range_size = end - start;
+    if to <= start {
+        // Each move removes the item now sitting at `start + i` (the next
+        // not-yet-moved member of the range — items already moved out no
+        // longer occupy `start`) and reinserts it at `to + i`.
+        for i in 0..range_size {
+            if !queue.move_item(start + i, to + i) {
+                return false;
+            }
+        }
+    } else {
+        // Moving forward: repeatedly pop the item still at `start` (every
+        // prior pop shifts the next range member down into `start`) and
+        // reinsert it at the block's final last slot, `to + range_size -
+        // 1`; later reinsertions push earlier ones back to keep the whole
+        // block landing at `[to, to + range_size)` in order.
+        let target = to + range_size - 1;
+        for _ in 0..range_size {
+            if !queue.move_item(start, target) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Result of resolving `add`'s URI: a single song, or every song under a
+/// directory (including the database root), added recursively in path
+/// order — mirrors MPD's `LocateUri` + `AddFromDatabase`.
+enum AddOutcome {
+    Song(rmpd_core::song::Song),
+    Directory(Vec<rmpd_core::song::Song>),
+}
+
+pub async fn handle_add_command(
+    state: &AppState,
+    uri: &str,
+    position: Option<crate::parser::InsertPosition>,
+) -> String {
     debug!("add command received with URI: [{}]", uri);
+    let position = match position {
+        Some(spec) => match resolve_insert_position(state, spec, "add").await {
+            Ok(pos) => Some(pos),
+            Err(resp) => return resp,
+        },
+        None => None,
+    };
+    // "add /" is malformed but kept for backwards compatibility: it adds
+    // the whole database, same as "add ''" (QueueCommands.cxx::handle_add).
+    let uri = if uri == "/" { "" } else { uri };
     // A `<scheme>://` URI is a network stream (radio): validate the scheme and
     // add a synthetic stream song. Mount-style source paths and local paths have
     // no `://`, so they skip this block and fall through to the DB lookup below.
@@ -34,51 +204,84 @@ pub async fn handle_add_command(state: &AppState, uri: &str, position: Option<u3
             };
         }
     }
-    // Get song from database (file:// or relative path) — run the blocking
-    // DB open + query on a blocking-pool thread so it never stalls the async
-    // runtime. The closure returns either the resolved `Song` or the fully
-    // formatted error response, matching the original inline error handling.
+    // Resolve the URI on a blocking-pool thread (SQLite is sync): a single
+    // song by exact path, or — if that fails — a directory (including the
+    // root) added recursively. The closure returns either the outcome or
+    // the fully formatted error response.
     let state_clone = state.clone();
     let uri_owned = uri.to_string();
-    let song_result: Result<rmpd_core::song::Song, String> =
-        match tokio::task::spawn_blocking(move || {
-            let db = open_db(&state_clone, "add")?;
-            match db.get_song_by_path(&uri_owned) {
-                Ok(Some(s)) => Ok(s),
-                Ok(None) => Err(ResponseBuilder::error(
+    let outcome_result: Result<AddOutcome, String> = match tokio::task::spawn_blocking(move || {
+        let db = open_db(&state_clone, "add")?;
+        match db.get_song_by_path(&uri_owned) {
+            Ok(Some(s)) => Ok(AddOutcome::Song(s)),
+            Ok(None) => match db.list_directory(&uri_owned) {
+                Ok(_) => match db.list_directory_recursive(&uri_owned) {
+                    Ok(songs) => Ok(AddOutcome::Directory(songs)),
+                    Err(e) => Err(ResponseBuilder::error(
+                        ACK_ERROR_SYS,
+                        0,
+                        "add",
+                        &format!("query error: {e}"),
+                    )),
+                },
+                Err(_) => Err(ResponseBuilder::error(
                     ACK_ERROR_NO_EXIST,
                     0,
                     "add",
                     "No such directory",
                 )),
-                Err(e) => Err(ResponseBuilder::error(
-                    ACK_ERROR_SYS,
-                    0,
-                    "add",
-                    &format!("query error: {e}"),
-                )),
-            }
-        })
-        .await
-        {
-            Ok(res) => res,
-            Err(_) => {
-                return ResponseBuilder::error(ACK_ERROR_SYS, 0, "add", "internal error");
-            }
-        };
+            },
+            Err(e) => Err(ResponseBuilder::error(
+                ACK_ERROR_SYS,
+                0,
+                "add",
+                &format!("query error: {e}"),
+            )),
+        }
+    })
+    .await
+    {
+        Ok(res) => res,
+        Err(_) => {
+            return ResponseBuilder::error(ACK_ERROR_SYS, 0, "add", "internal error");
+        }
+    };
 
-    let song = match song_result {
-        Ok(s) => s,
+    let outcome = match outcome_result {
+        Ok(o) => o,
         Err(resp) => return resp,
     };
 
     // `add` returns no Id (unlike `addid`) — MPD replies with bare OK.
-    match add_at_checked(state, song, position, "add").await {
-        Ok(_) => {
+    match outcome {
+        AddOutcome::Song(song) => match add_at_checked(state, song, position, "add").await {
+            Ok(_) => {
+                helpers::update_playlist_version(state).await;
+                ResponseBuilder::new().ok()
+            }
+            Err(resp) => resp,
+        },
+        AddOutcome::Directory(songs) => {
+            let mut queue = state.queue.write().await;
+            let old_size = queue.len() as u32;
+            for song in songs {
+                queue.add(song);
+            }
+            let new_size = queue.len() as u32;
+            // Mirror MPD: move the appended block to POSITION only when it
+            // was requested and lands before where it was appended; a
+            // failed move is ignored (best-effort, matches handle_add's
+            // `catch (...) { /* ignore */ }`).
+            if let Some(pos) = position
+                && pos < old_size
+                && new_size > old_size
+            {
+                move_range_in_queue(&mut queue, old_size, new_size, pos);
+            }
+            drop(queue);
             helpers::update_playlist_version(state).await;
             ResponseBuilder::new().ok()
         }
-        Err(resp) => resp,
     }
 }
 
@@ -100,51 +303,47 @@ pub async fn handle_delete_command(
 ) -> String {
     use crate::parser::DeleteTarget;
 
-    match target {
-        DeleteTarget::Position(position) => {
-            let mut queue = state.queue.write().await;
-            let len = queue.len() as u32;
-            // Single position delete: position must be < len
-            if position >= len {
-                return ResponseBuilder::error(ACK_ERROR_ARG, 0, "delete", "Bad song index");
-            }
-            if queue.delete(position).is_some() {
-                drop(queue);
-                helpers::update_playlist_version(state).await;
-                ResponseBuilder::new().ok()
-            } else {
-                ResponseBuilder::error(ACK_ERROR_ARG, 0, "delete", "Bad song index")
-            }
-        }
-        DeleteTarget::Range(start, end) => {
-            let mut queue = state.queue.write().await;
-            let len = queue.len() as u32;
-            // MPD CheckClip: start > count -> error
-            if start > len {
-                return ResponseBuilder::error(ACK_ERROR_ARG, 0, "delete", "Bad song index");
-            }
-            // Clip end to len
-            let end = end.min(len);
-            if start >= end {
-                // Empty range: no-op
-                return ResponseBuilder::new().ok();
-            }
-            // Delete from highest to lowest to avoid position shifts
-            for pos in (start..end).rev() {
-                queue.delete(pos);
-            }
-            drop(queue);
-            helpers::update_playlist_version(state).await;
-            ResponseBuilder::new().ok()
-        }
+    // Normalize to a half-open [start, end) range — a bare position is
+    // [pos, pos+1) — mirroring MPD's RangeArg::CheckClip semantics: only
+    // `start > len` is an error; `start == len` (and any end beyond it)
+    // clips down to an empty, silently-OK range.
+    let (start, end) = match target {
+        DeleteTarget::Position(pos) => (pos, pos.saturating_add(1)),
+        DeleteTarget::Range(start, end) => (start, end),
+    };
+
+    let mut queue = state.queue.write().await;
+    let len = queue.len() as u32;
+    if start > len {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "delete", "Bad song index");
     }
+    let end = end.min(len);
+    if start >= end {
+        // Empty range: no-op
+        return ResponseBuilder::new().ok();
+    }
+    // Delete from highest to lowest to avoid position shifts
+    for pos in (start..end).rev() {
+        queue.delete(pos);
+    }
+    drop(queue);
+    helpers::update_playlist_version(state).await;
+    ResponseBuilder::new().ok()
 }
 
-pub async fn handle_addid_command(state: &AppState, uri: &str, position: Option<u32>) -> String {
-    debug!(
-        "addid command received with URI: [{}], position: {:?}",
-        uri, position
-    );
+pub async fn handle_addid_command(
+    state: &AppState,
+    uri: &str,
+    position: Option<crate::parser::InsertPosition>,
+) -> String {
+    debug!("addid command received with URI: [{}]", uri);
+    let position = match position {
+        Some(spec) => match resolve_insert_position(state, spec, "addid").await {
+            Ok(pos) => Some(pos),
+            Err(resp) => return resp,
+        },
+        None => None,
+    };
     // A `<scheme>://` URI is a network stream (radio): validate the scheme and
     // add a synthetic stream song. Mount-style source paths and local paths have
     // no `://`, so they skip this block and fall through to the DB lookup below.
@@ -225,7 +424,25 @@ pub async fn handle_deleteid_command(state: &AppState, id: u32) -> String {
     }
 }
 
-pub async fn handle_moveid_command(state: &AppState, id: u32, to: u32) -> String {
+pub async fn handle_moveid_command(
+    state: &AppState,
+    id: u32,
+    to: crate::parser::InsertPosition,
+) -> String {
+    let queue_len = state.queue.read().await.len() as u32;
+    let position = match state.queue.read().await.get_by_id(id) {
+        Some(item) => item.position,
+        None => return ResponseBuilder::error(ACK_ERROR_NO_EXIST, 0, "moveid", "No such song"),
+    };
+
+    let to =
+        match resolve_move_destination(state, to, (position, position + 1), queue_len, "moveid")
+            .await
+        {
+            Ok(pos) => pos,
+            Err(resp) => return resp,
+        };
+
     if state.queue.write().await.move_by_id(id, to) {
         helpers::update_playlist_version(state).await;
         ResponseBuilder::new().ok()
@@ -237,78 +454,46 @@ pub async fn handle_moveid_command(state: &AppState, id: u32, to: u32) -> String
 pub async fn handle_move_command(
     state: &AppState,
     from: crate::parser::MoveFrom,
-    to: u32,
+    to: crate::parser::InsertPosition,
 ) -> String {
     use crate::parser::MoveFrom;
 
-    match from {
-        MoveFrom::Position(from_pos) => {
-            let queue_len = state.queue.read().await.len() as u32;
-            if from_pos >= queue_len {
-                return ResponseBuilder::error(ACK_ERROR_ARG, 0, "move", "Bad song index");
-            }
-            if to >= queue_len {
-                return ResponseBuilder::error(
-                    ACK_ERROR_ARG,
-                    0,
-                    "move",
-                    &format!("Number too large: {to}"),
-                );
-            }
-            if state.queue.write().await.move_item(from_pos, to) {
-                helpers::update_playlist_version(state).await;
-                ResponseBuilder::new().ok()
-            } else {
-                ResponseBuilder::error(ACK_ERROR_ARG, 0, "move", "Bad song index")
-            }
-        }
+    // Normalize to a half-open [start, end) range — a bare position is
+    // [pos, pos+1) — mirroring MPD's RangeArg. `move` never accepts an
+    // open-ended FROM range (QueueCommands.cxx::handle_move).
+    let (start, end) = match from {
+        MoveFrom::Position(pos) => (pos, pos.saturating_add(1)),
         MoveFrom::Range(start, end) => {
-            // Move range of songs [start, end) to position
-            // MPD semantics: move each song individually to maintain order
-            let mut queue = state.queue.write().await;
-
-            if start >= end || start >= queue.len() as u32 {
-                return ResponseBuilder::error(ACK_ERROR_ARG, 0, "move", "Bad song index");
-            }
-
-            // MPD allows `to` up to `len` — items are removed then reinserted.
-            let max_to = queue.len() as u32;
-            if to > max_to {
+            if end == u32::MAX {
                 return ResponseBuilder::error(
                     ACK_ERROR_ARG,
                     0,
                     "move",
-                    &format!("Number too large: {to}"),
+                    "Open-ended range not supported",
                 );
             }
-
-            let range_size = end.saturating_sub(start);
-
-            // Move songs one by one
-            // If moving to a position before the range, move from start to end
-            // If moving to a position after the range, move from end-1 to start
-            if to <= start {
-                // Moving up in the queue
-                for i in 0..range_size.min(queue.len() as u32 - start) {
-                    if !queue.move_item(start, to + i) {
-                        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "move", "Bad song index");
-                    }
-                }
-            } else {
-                // Moving down in the queue
-                let actual_end = end.min(queue.len() as u32);
-                for _ in 0..(actual_end - start) {
-                    if !queue.move_item(start, to.saturating_sub(1)) {
-                        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "move", "Bad song index");
-                    }
-                }
-            }
-
-            drop(queue);
-            helpers::update_playlist_version(state).await;
-            ResponseBuilder::new().ok()
+            (start, end)
         }
+    };
+
+    let queue_len = state.queue.read().await.len() as u32;
+    if start >= end || end > queue_len {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "move", "Bad song index");
     }
+
+    let to = match resolve_move_destination(state, to, (start, end), queue_len, "move").await {
+        Ok(pos) => pos,
+        Err(resp) => return resp,
+    };
+
+    let mut queue = state.queue.write().await;
+    if !move_range_in_queue(&mut queue, start, end, to) {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "move", "Bad song index");
+    }
+
+    drop(queue);
+    helpers::update_playlist_version(state).await;
+    ResponseBuilder::new().ok()
 }
 
 pub async fn handle_swap_command(state: &AppState, pos1: u32, pos2: u32) -> String {
@@ -330,11 +515,29 @@ pub async fn handle_swapid_command(state: &AppState, id1: u32, id2: u32) -> Stri
 }
 
 pub async fn handle_shuffle_command(state: &AppState, range: Option<(u32, u32)>) -> String {
-    if let Some((start, end)) = range {
-        state.queue.write().await.shuffle_range(start, end);
-    } else {
-        state.queue.write().await.shuffle();
+    let mut queue = state.queue.write().await;
+    let len = queue.len() as u32;
+
+    match range {
+        Some((start, end)) => {
+            if start > len {
+                return ResponseBuilder::error(ACK_ERROR_ARG, 0, "shuffle", "Bad song index");
+            }
+            let end = end.min(len);
+            if end.saturating_sub(start) >= 2 {
+                queue.shuffle_range(start, end);
+            } else {
+                return ResponseBuilder::new().ok();
+            }
+        }
+        None => {
+            if len < 2 {
+                return ResponseBuilder::new().ok();
+            }
+            queue.shuffle();
+        }
     }
+    drop(queue);
     helpers::update_playlist_version(state).await;
     ResponseBuilder::new().ok()
 }
@@ -346,7 +549,7 @@ pub async fn handle_playlistid_command(state: &AppState, id: Option<u32>) -> Str
     if let Some(song_id) = id {
         // Get specific song by ID
         if let Some(item) = queue.get_by_id(song_id) {
-            resp.song(&item.song, Some(item.position), Some(item.id));
+            resp.song(&item.song, Some(item.position), Some(item.id), item.range);
             add_queue_item_metadata(&mut resp, item);
         } else {
             return ResponseBuilder::error(ACK_ERROR_NO_EXIST, 0, "playlistid", "No such song");
@@ -354,7 +557,7 @@ pub async fn handle_playlistid_command(state: &AppState, id: Option<u32>) -> Str
     } else {
         // Get all songs with IDs
         for item in queue.items() {
-            resp.song(&item.song, Some(item.position), Some(item.id));
+            resp.song(&item.song, Some(item.position), Some(item.id), item.range);
             add_queue_item_metadata(&mut resp, item);
         }
     }
@@ -365,14 +568,20 @@ pub async fn handle_playlistid_command(state: &AppState, id: Option<u32>) -> Str
 pub async fn handle_playlistinfo_command(state: &AppState, range: Option<(u32, u32)>) -> String {
     let queue = state.queue.read().await;
     let items = queue.items();
+
+    // MPD's CheckClip: only `start > length` is an error; `start == length`
+    // (and any end beyond it) clips down to an empty, silently-OK range.
+    if let Some((start, _)) = range
+        && start > items.len() as u32
+    {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "playlistinfo", "Bad song index");
+    }
+
     let mut resp = ResponseBuilder::new();
-
-    // MPD returns empty for out-of-bounds positions (apply_range handles slicing).
-
     let filtered = apply_range(items, range);
 
     for item in filtered {
-        resp.song(&item.song, Some(item.position), Some(item.id));
+        resp.song(&item.song, Some(item.position), Some(item.id), item.range);
         add_queue_item_metadata(&mut resp, item);
     }
 
@@ -459,54 +668,98 @@ pub async fn handle_playid_command(state: &AppState, id: Option<u32>) -> String 
 ///
 /// Sets the priority for all songs within the specified position ranges.
 /// Priority is 0-255 where higher values have higher priority.
+///
+/// Mirrors MPD's `handle_prio`: ranges are applied one at a time (not
+/// validated upfront), so an out-of-bounds range only aborts the *rest* of
+/// the list — ranges already applied before it stay applied.
 pub async fn handle_prio_command(state: &AppState, priority: u8, ranges: &[(u32, u32)]) -> String {
-    let version = {
+    let mut applied = false;
+    let error = {
         let mut queue = state.queue.write().await;
-        queue.set_priority_range(priority, ranges);
-        queue.version()
+        let len = queue.len() as u32;
+        let mut error = None;
+        for &(start, end) in ranges {
+            if start > len {
+                error = Some(ResponseBuilder::error(
+                    ACK_ERROR_ARG,
+                    0,
+                    "prio",
+                    "Bad song index",
+                ));
+                break;
+            }
+            queue.set_priority_range(priority, &[(start, end)]);
+            applied = true;
+        }
+        error
     };
-    state.status.write().await.playlist_version = version;
-    state.event_bus.emit(rmpd_core::event::Event::QueueChanged);
 
-    ResponseBuilder::new().ok()
+    if applied {
+        helpers::update_playlist_version(state).await;
+    }
+    error.unwrap_or_else(|| ResponseBuilder::new().ok())
 }
 
 /// Set priority for songs in queue by ID
 ///
-/// Sets the priority for all songs with the specified IDs.
-/// Priority is 0-255 where higher values have higher priority.
+/// Sets the priority for all songs with the specified IDs. Priority is
+/// 0-255 where higher values have higher priority.
+///
+/// Mirrors MPD's `handle_prioid`: IDs are applied one at a time (not
+/// validated upfront), so a nonexistent ID only aborts the *rest* of the
+/// list — IDs already applied before it stay applied.
 pub async fn handle_prioid_command(state: &AppState, priority: u8, ids: &[u32]) -> String {
-    // Validate all IDs exist before making any changes (MPD errors on first bad ID)
-    {
-        let queue = state.queue.read().await;
+    let mut applied = false;
+    let error = {
+        let mut queue = state.queue.write().await;
+        let mut error = None;
         for &id in ids {
             if queue.get_by_id(id).is_none() {
-                return ResponseBuilder::error(ACK_ERROR_NO_EXIST, 0, "prioid", "No such song");
+                error = Some(ResponseBuilder::error(
+                    ACK_ERROR_NO_EXIST,
+                    0,
+                    "prioid",
+                    "No such song",
+                ));
+                break;
             }
+            queue.set_priority_ids(priority, &[id]);
+            applied = true;
         }
-    }
-
-    let (changed, version) = {
-        let mut queue = state.queue.write().await;
-        let changed = queue.set_priority_ids(priority, ids);
-        (changed, queue.version())
+        error
     };
 
-    if changed {
-        state.status.write().await.playlist_version = version;
-        state.event_bus.emit(rmpd_core::event::Event::QueueChanged);
+    if applied {
+        helpers::update_playlist_version(state).await;
     }
-
-    ResponseBuilder::new().ok()
+    error.unwrap_or_else(|| ResponseBuilder::new().ok())
 }
 
 /// Set playback range for a song
 ///
-/// Sets a playback range (start and end time in seconds) for a song.
-pub async fn handle_rangeid_command(state: &AppState, id: u32, range: (f64, f64)) -> String {
+/// Sets a playback range (start and end time in seconds) for a song, or
+/// clears it entirely when `range` is `None` (a bare `rangeid ID :`).
+/// Mirrors MPD's `SetSongIdRange`: the currently playing/paused song cannot
+/// be manipulated this way.
+pub async fn handle_rangeid_command(
+    state: &AppState,
+    id: u32,
+    range: Option<(f64, f64)>,
+) -> String {
+    if let Some(current) = state.status.read().await.current_song
+        && current.id == id
+    {
+        return ResponseBuilder::error(
+            ACK_ERROR_PERMISSION,
+            0,
+            "rangeid",
+            "Cannot edit the current song",
+        );
+    }
+
     let found = {
         let mut queue = state.queue.write().await;
-        queue.set_range_by_id(id, Some(range))
+        queue.set_range_by_id(id, range)
     };
 
     if found {
@@ -519,10 +772,12 @@ pub async fn handle_rangeid_command(state: &AppState, id: u32, range: (f64, f64)
 
 /// Add a tag to a queue item
 ///
-/// Adds a custom tag to a queue item.
-pub async fn handle_addtagid_command(state: &AppState, id: u32, tag: &str, _value: &str) -> String {
-    // Validate tag type
-    if rmpd_core::song::canonical_tag_name(&tag.to_lowercase()) == "Unknown" {
+/// Adds a custom tag to a queue item. Mirrors MPD's `AddSongIdTag`: only
+/// remote songs (a `scheme://` URI) may have tags edited — local/database
+/// files are rejected.
+pub async fn handle_addtagid_command(state: &AppState, id: u32, tag: &str, value: &str) -> String {
+    let canonical = rmpd_core::song::canonical_tag_name(&tag.to_lowercase());
+    if canonical == "Unknown" {
         return ResponseBuilder::error(
             ACK_ERROR_ARG,
             0,
@@ -531,44 +786,77 @@ pub async fn handle_addtagid_command(state: &AppState, id: u32, tag: &str, _valu
         );
     }
 
-    // Check song exists
-    let queue = state.queue.read().await;
-    if queue.get_by_id(id).is_none() {
-        return ResponseBuilder::error(ACK_ERROR_NO_EXIST, 0, "addtagid", "No such song");
+    {
+        let queue = state.queue.read().await;
+        match queue.get_by_id(id) {
+            Some(item) if item.song.path.as_str().contains("://") => {}
+            Some(_) => {
+                return ResponseBuilder::error(
+                    ACK_ERROR_PERMISSION,
+                    0,
+                    "addtagid",
+                    "Cannot edit tags of local file",
+                );
+            }
+            None => {
+                return ResponseBuilder::error(ACK_ERROR_NO_EXIST, 0, "addtagid", "No such song");
+            }
+        }
     }
-    drop(queue);
 
-    // MPD allows tag editing on queued songs (in-memory only)
+    state
+        .queue
+        .write()
+        .await
+        .add_tag_by_id(id, canonical.to_string(), value.to_string());
+    helpers::update_playlist_version(state).await;
     ResponseBuilder::new().ok()
 }
 
 /// Clear tags from a queue item
 ///
 /// If tag is specified, clears only that tag. Otherwise clears all tags.
+/// Mirrors MPD's `ClearSongIdTag`: only remote songs (a `scheme://` URI)
+/// may have tags edited — local/database files are rejected.
 pub async fn handle_cleartagid_command(state: &AppState, id: u32, tag: Option<&str>) -> String {
-    // Validate tag type if specified
     // Normalize empty tag to None (parser may return Some("") for missing arg)
     let tag = tag.filter(|t| !t.is_empty());
-    // Validate tag type if specified
-    if let Some(t) = tag
-        && rmpd_core::song::canonical_tag_name(&t.to_lowercase()) == "Unknown"
+    let canonical = match tag {
+        Some(t) => {
+            let c = rmpd_core::song::canonical_tag_name(&t.to_lowercase());
+            if c == "Unknown" {
+                return ResponseBuilder::error(
+                    ACK_ERROR_ARG,
+                    0,
+                    "cleartagid",
+                    &format!("Unknown tag type: {t}"),
+                );
+            }
+            Some(c)
+        }
+        None => None,
+    };
+
     {
-        return ResponseBuilder::error(
-            ACK_ERROR_ARG,
-            0,
-            "cleartagid",
-            &format!("Unknown tag type: {t}"),
-        );
+        let queue = state.queue.read().await;
+        match queue.get_by_id(id) {
+            Some(item) if item.song.path.as_str().contains("://") => {}
+            Some(_) => {
+                return ResponseBuilder::error(
+                    ACK_ERROR_PERMISSION,
+                    0,
+                    "cleartagid",
+                    "Cannot edit tags of local file",
+                );
+            }
+            None => {
+                return ResponseBuilder::error(ACK_ERROR_NO_EXIST, 0, "cleartagid", "No such song");
+            }
+        }
     }
 
-    // Check song exists
-    let queue = state.queue.read().await;
-    if queue.get_by_id(id).is_none() {
-        return ResponseBuilder::error(ACK_ERROR_NO_EXIST, 0, "cleartagid", "No such song");
-    }
-    drop(queue);
-
-    // MPD allows clearing tags on queued songs (in-memory only)
+    state.queue.write().await.clear_tags_by_id(id, canonical);
+    helpers::update_playlist_version(state).await;
     ResponseBuilder::new().ok()
 }
 
@@ -590,7 +878,8 @@ pub async fn handle_plchanges_command(
         let filtered = apply_range(items, range);
 
         for item in filtered {
-            resp.song(&item.song, Some(item.position), Some(item.id));
+            resp.song(&item.song, Some(item.position), Some(item.id), item.range);
+            add_queue_item_metadata(&mut resp, item);
         }
     }
     resp.ok()
@@ -621,33 +910,187 @@ pub async fn handle_plchangesposid_command(
     resp.ok()
 }
 
-/// Search queue for exact tag matches
-pub async fn handle_playlistfind_command(state: &AppState, tag: &str, value: &str) -> String {
-    let queue = state.queue.read().await;
-    let mut resp = ResponseBuilder::new();
-    let tag_lower = tag.to_lowercase();
-
-    for item in queue.items() {
-        if item.song.tag_eq(&tag_lower, value) {
-            resp.song(&item.song, Some(item.position), Some(item.id));
-            add_queue_item_metadata(&mut resp, item);
+/// Evaluate a `FilterExpression` against a queue item's song and priority
+/// in memory (no SQL involved — unlike the database `find`/`search`, which
+/// go through `FilterExpression::to_sql`). Mirrors `SongFilter::Match` in
+/// MPD's `song/Filter.cxx`.
+fn filter_matches_item(
+    expr: &rmpd_core::filter::FilterExpression,
+    item: &rmpd_core::queue::QueueItem,
+) -> bool {
+    use rmpd_core::filter::FilterExpression;
+    match expr {
+        FilterExpression::Compare {
+            tag,
+            op,
+            value,
+            case_sensitive,
+            negated,
+        } => {
+            let tag_lower = tag.to_lowercase();
+            let matched = if tag_lower == "file" {
+                compare_str(*op, value, item.song.path.as_str(), *case_sensitive)
+            } else if tag_lower == "any" {
+                item.song
+                    .tags
+                    .iter()
+                    .any(|(_, v)| compare_str(*op, value, v, *case_sensitive))
+            } else {
+                let values = item.song.tag_values_with_fallback(&tag_lower);
+                if value.is_empty() && *op == rmpd_core::filter::CompareOp::Equal {
+                    values.iter().all(|v| v.is_empty())
+                } else {
+                    values
+                        .iter()
+                        .any(|v| compare_str(*op, value, v, *case_sensitive))
+                }
+            };
+            matched != *negated
         }
+        FilterExpression::Base(prefix) => {
+            let path = item.song.path.as_str();
+            if prefix.is_empty() {
+                !path.is_empty()
+            } else {
+                path == prefix.as_str() || path.starts_with(&format!("{prefix}/"))
+            }
+        }
+        FilterExpression::ModifiedSince(ts) => item.song.last_modified >= *ts,
+        FilterExpression::AddedSince(ts) => item.song.added_at >= *ts,
+        FilterExpression::AudioFormat {
+            sample_rate,
+            bits,
+            channels,
+        } => {
+            item.song.sample_rate.is_some()
+                && item.song.bits_per_sample.is_some()
+                && item.song.channels.is_some()
+                && sample_rate.is_none_or(|v| item.song.sample_rate == Some(v))
+                && bits.is_none_or(|v| item.song.bits_per_sample == Some(v))
+                && channels.is_none_or(|v| item.song.channels == Some(v))
+        }
+        // Unlike database songs (never queued, implicit priority 0), a
+        // queue item's priority is real.
+        FilterExpression::Priority(n) => item.priority == *n,
+        FilterExpression::And(left, right) => {
+            filter_matches_item(left, item) && filter_matches_item(right, item)
+        }
+        FilterExpression::Not(inner) => !filter_matches_item(inner, item),
+    }
+}
+
+/// One string comparison, mirroring `compare_sql`'s semantics but evaluated
+/// directly against an in-memory value instead of building SQL.
+fn compare_str(
+    op: rmpd_core::filter::CompareOp,
+    pattern: &str,
+    candidate: &str,
+    case_sensitive: bool,
+) -> bool {
+    use rmpd_core::filter::CompareOp;
+    match op {
+        CompareOp::Equal if case_sensitive => candidate == pattern,
+        CompareOp::Equal => candidate.eq_ignore_ascii_case(pattern),
+        CompareOp::Contains if case_sensitive => candidate.contains(pattern),
+        CompareOp::Contains => candidate.to_lowercase().contains(&pattern.to_lowercase()),
+        CompareOp::StartsWith if case_sensitive => candidate.starts_with(pattern),
+        CompareOp::StartsWith => candidate
+            .to_lowercase()
+            .starts_with(&pattern.to_lowercase()),
+        CompareOp::Regex => {
+            let built = if case_sensitive {
+                regex::Regex::new(pattern)
+            } else {
+                regex::RegexBuilder::new(pattern)
+                    .case_insensitive(true)
+                    .build()
+            };
+            built.is_ok_and(|re| re.is_match(candidate))
+        }
+    }
+}
+
+/// Compare two songs by a resolved `sort` key, mirroring
+/// `commands::utils::sort_songs`'s per-key logic but over item references
+/// (queue items own `Arc<Song>`, so that helper's `&mut [Song]` signature
+/// doesn't fit here without cloning).
+fn sort_key_cmp(
+    a: &rmpd_core::song::Song,
+    b: &rmpd_core::song::Song,
+    key: &super::utils::SortKey,
+) -> std::cmp::Ordering {
+    use super::utils::SortKey;
+    match key {
+        SortKey::LastModified => a.last_modified.cmp(&b.last_modified),
+        SortKey::Added => a.added_at.cmp(&b.added_at),
+        SortKey::Tag(tag) => a.tag_with_fallback(tag).cmp(&b.tag_with_fallback(tag)),
+    }
+}
+
+/// Shared implementation of `playlistfind`/`playlistsearch`: parse the
+/// filter (modern expression or legacy `TAG VALUE` pairs — the same
+/// grammar as the database `find`/`search`), match it against the queue in
+/// memory, apply the optional `sort`/`window`, and print like
+/// `playlistinfo`/`playlistid` (Pos/Id/Prio/Range via
+/// `add_queue_item_metadata`).
+async fn handle_playlist_match(
+    state: &AppState,
+    filters: &[(String, String)],
+    sort: Option<&str>,
+    window: Option<(u32, u32)>,
+    fold_case: bool,
+    command: &str,
+) -> String {
+    let expr = match super::utils::parse_filter_args(filters, fold_case) {
+        Ok(e) => e,
+        Err(e) => return super::utils::filter_parse_ack(command, &e),
+    };
+
+    let queue = state.queue.read().await;
+    let mut matched: Vec<&rmpd_core::queue::QueueItem> = queue
+        .items()
+        .iter()
+        .filter(|item| filter_matches_item(&expr, item))
+        .collect();
+
+    if let Some(sort_arg) = sort {
+        match super::utils::parse_sort_tag(sort_arg) {
+            Some((key, descending)) => {
+                matched.sort_by(|a, b| sort_key_cmp(&a.song, &b.song, &key));
+                if descending {
+                    matched.reverse();
+                }
+            }
+            None => {
+                return ResponseBuilder::error(ACK_ERROR_ARG, 0, command, "Unknown sort tag");
+            }
+        }
+    }
+
+    let mut resp = ResponseBuilder::new();
+    for item in apply_range(&matched, window) {
+        resp.song(&item.song, Some(item.position), Some(item.id), item.range);
+        add_queue_item_metadata(&mut resp, item);
     }
     resp.ok()
 }
 
-/// Case-insensitive search in queue
-pub async fn handle_playlistsearch_command(state: &AppState, tag: &str, value: &str) -> String {
-    let queue = state.queue.read().await;
-    let mut resp = ResponseBuilder::new();
-    let value_lower = value.to_lowercase();
-    let tag_lower = tag.to_lowercase();
+/// Search the queue for songs matching a filter expression (case-sensitive).
+pub async fn handle_playlistfind_command(
+    state: &AppState,
+    filters: &[(String, String)],
+    sort: Option<&str>,
+    window: Option<(u32, u32)>,
+) -> String {
+    handle_playlist_match(state, filters, sort, window, false, "playlistfind").await
+}
 
-    for item in queue.items() {
-        if item.song.tag_contains(&tag_lower, &value_lower) {
-            resp.song(&item.song, Some(item.position), Some(item.id));
-            add_queue_item_metadata(&mut resp, item);
-        }
-    }
-    resp.ok()
+/// Search the queue for songs matching a filter expression (case-insensitive).
+pub async fn handle_playlistsearch_command(
+    state: &AppState,
+    filters: &[(String, String)],
+    sort: Option<&str>,
+    window: Option<(u32, u32)>,
+) -> String {
+    handle_playlist_match(state, filters, sort, window, true, "playlistsearch").await
 }

--- a/rmpd-protocol/src/commands/reflection.rs
+++ b/rmpd-protocol/src/commands/reflection.rs
@@ -5,30 +5,30 @@
 
 use crate::connection::{
     ConnectionState, PERMISSION_ADD, PERMISSION_ADMIN, PERMISSION_CONTROL, PERMISSION_NONE,
-    PERMISSION_READ,
+    PERMISSION_PLAYER, PERMISSION_READ,
 };
 use crate::response::ResponseBuilder;
 
 const COMMAND_PERMISSIONS: &[(&str, u8)] = &[
     ("add", PERMISSION_ADD),
     ("addid", PERMISSION_ADD),
-    ("addtagid", PERMISSION_CONTROL),
+    ("addtagid", PERMISSION_ADD),
     ("albumart", PERMISSION_READ),
     ("binarylimit", PERMISSION_NONE),
     ("channels", PERMISSION_READ),
-    ("clear", PERMISSION_CONTROL),
-    ("clearerror", PERMISSION_CONTROL),
-    ("cleartagid", PERMISSION_CONTROL),
+    ("clear", PERMISSION_PLAYER),
+    ("clearerror", PERMISSION_PLAYER),
+    ("cleartagid", PERMISSION_ADD),
     ("close", PERMISSION_NONE),
     ("commands", PERMISSION_NONE),
     ("config", PERMISSION_ADMIN),
-    ("consume", PERMISSION_CONTROL),
+    ("consume", PERMISSION_PLAYER),
     ("count", PERMISSION_READ),
-    ("crossfade", PERMISSION_CONTROL),
+    ("crossfade", PERMISSION_PLAYER),
     ("currentsong", PERMISSION_READ),
     ("decoders", PERMISSION_READ),
-    ("delete", PERMISSION_CONTROL),
-    ("deleteid", PERMISSION_CONTROL),
+    ("delete", PERMISSION_PLAYER),
+    ("deleteid", PERMISSION_PLAYER),
     ("delpartition", PERMISSION_ADMIN),
     ("disableoutput", PERMISSION_ADMIN),
     ("enableoutput", PERMISSION_ADMIN),
@@ -43,29 +43,30 @@ const COMMAND_PERMISSIONS: &[(&str, u8)] = &[
     ("listallinfo", PERMISSION_READ),
     ("listfiles", PERMISSION_READ),
     ("listmounts", PERMISSION_READ),
+    ("listneighbors", PERMISSION_READ),
     ("listpartitions", PERMISSION_READ),
     ("listplaylist", PERMISSION_READ),
     ("listplaylistinfo", PERMISSION_READ),
     ("listplaylists", PERMISSION_READ),
     ("load", PERMISSION_ADD),
     ("lsinfo", PERMISSION_READ),
-    ("mixrampdb", PERMISSION_CONTROL),
-    ("mixrampdelay", PERMISSION_CONTROL),
+    ("mixrampdb", PERMISSION_PLAYER),
+    ("mixrampdelay", PERMISSION_PLAYER),
     ("mount", PERMISSION_ADMIN),
-    ("move", PERMISSION_CONTROL),
-    ("moveid", PERMISSION_CONTROL),
+    ("move", PERMISSION_PLAYER),
+    ("moveid", PERMISSION_PLAYER),
     ("moveoutput", PERMISSION_ADMIN),
     ("newpartition", PERMISSION_ADMIN),
-    ("next", PERMISSION_CONTROL),
+    ("next", PERMISSION_PLAYER),
     ("notcommands", PERMISSION_NONE),
     ("outputset", PERMISSION_ADMIN),
     ("outputs", PERMISSION_READ),
-    ("partition", PERMISSION_CONTROL),
+    ("partition", PERMISSION_READ),
     ("password", PERMISSION_NONE),
-    ("pause", PERMISSION_CONTROL),
+    ("pause", PERMISSION_PLAYER),
     ("ping", PERMISSION_NONE),
-    ("play", PERMISSION_CONTROL),
-    ("playid", PERMISSION_CONTROL),
+    ("play", PERMISSION_PLAYER),
+    ("playid", PERMISSION_PLAYER),
     ("playlist", PERMISSION_READ),
     ("playlistadd", PERMISSION_CONTROL),
     ("playlistclear", PERMISSION_CONTROL),
@@ -78,52 +79,52 @@ const COMMAND_PERMISSIONS: &[(&str, u8)] = &[
     ("playlistsearch", PERMISSION_READ),
     ("plchanges", PERMISSION_READ),
     ("plchangesposid", PERMISSION_READ),
-    ("previous", PERMISSION_CONTROL),
-    ("prio", PERMISSION_CONTROL),
-    ("prioid", PERMISSION_CONTROL),
+    ("previous", PERMISSION_PLAYER),
+    ("prio", PERMISSION_PLAYER),
+    ("prioid", PERMISSION_PLAYER),
     ("protocol", PERMISSION_NONE),
-    ("random", PERMISSION_CONTROL),
-    ("rangeid", PERMISSION_CONTROL),
+    ("random", PERMISSION_PLAYER),
+    ("rangeid", PERMISSION_ADD),
     ("readcomments", PERMISSION_READ),
-    ("readmessages", PERMISSION_CONTROL),
+    ("readmessages", PERMISSION_READ),
     ("readpicture", PERMISSION_READ),
     ("rename", PERMISSION_CONTROL),
-    ("repeat", PERMISSION_CONTROL),
-    ("replay_gain_mode", PERMISSION_CONTROL),
+    ("repeat", PERMISSION_PLAYER),
+    ("replay_gain_mode", PERMISSION_PLAYER),
     ("replay_gain_status", PERMISSION_READ),
     ("rescan", PERMISSION_CONTROL),
     ("rm", PERMISSION_CONTROL),
     ("save", PERMISSION_CONTROL),
     ("search", PERMISSION_READ),
     ("searchadd", PERMISSION_ADD),
-    ("searchaddpl", PERMISSION_ADD),
+    ("searchaddpl", PERMISSION_CONTROL),
     ("searchcount", PERMISSION_READ),
     ("searchplaylist", PERMISSION_READ),
-    ("seek", PERMISSION_CONTROL),
-    ("seekcur", PERMISSION_CONTROL),
-    ("seekid", PERMISSION_CONTROL),
+    ("seek", PERMISSION_PLAYER),
+    ("seekcur", PERMISSION_PLAYER),
+    ("seekid", PERMISSION_PLAYER),
     ("sendmessage", PERMISSION_CONTROL),
-    ("setvol", PERMISSION_CONTROL),
-    ("shuffle", PERMISSION_CONTROL),
-    ("single", PERMISSION_CONTROL),
+    ("setvol", PERMISSION_PLAYER),
+    ("shuffle", PERMISSION_PLAYER),
+    ("single", PERMISSION_PLAYER),
     ("stats", PERMISSION_READ),
     ("status", PERMISSION_READ),
-    ("sticker", PERMISSION_CONTROL),
-    ("stickernames", PERMISSION_READ),
-    ("stickernamestypes", PERMISSION_READ),
-    ("stickertypes", PERMISSION_READ),
-    ("stop", PERMISSION_CONTROL),
+    ("sticker", PERMISSION_ADMIN),
+    ("stickernames", PERMISSION_ADMIN),
+    ("stickernamestypes", PERMISSION_ADMIN),
+    ("stickertypes", PERMISSION_ADMIN),
+    ("stop", PERMISSION_PLAYER),
     ("stringnormalization", PERMISSION_NONE),
-    ("subscribe", PERMISSION_CONTROL),
-    ("swap", PERMISSION_CONTROL),
-    ("swapid", PERMISSION_CONTROL),
+    ("subscribe", PERMISSION_READ),
+    ("swap", PERMISSION_PLAYER),
+    ("swapid", PERMISSION_PLAYER),
     ("tagtypes", PERMISSION_NONE),
     ("toggleoutput", PERMISSION_ADMIN),
     ("unmount", PERMISSION_ADMIN),
-    ("unsubscribe", PERMISSION_CONTROL),
+    ("unsubscribe", PERMISSION_READ),
     ("update", PERMISSION_CONTROL),
     ("urlhandlers", PERMISSION_READ),
-    ("volume", PERMISSION_CONTROL),
+    ("volume", PERMISSION_PLAYER),
 ];
 
 pub async fn handle_commands_command(conn_state: &ConnectionState) -> String {
@@ -154,50 +155,75 @@ pub async fn handle_tagtypes_command(
 
     let mut resp = ResponseBuilder::new();
 
-    match subcommand {
-        None | Some(TagTypesSubcommand::Available) => {
-            // List all currently enabled metadata tags for this connection.
-            // Must match MPD's tagtypes output order.
-            let all_tags = vec![
-                "Artist",
-                "ArtistSort",
-                "Album",
-                "AlbumSort",
-                "AlbumArtist",
-                "AlbumArtistSort",
-                "Title",
-                "TitleSort",
-                "Track",
-                "Name",
-                "Genre",
-                "Mood",
-                "Date",
-                "OriginalDate",
-                "Composer",
-                "ComposerSort",
-                "Performer",
-                "Conductor",
-                "Work",
-                "Movement",
-                "MovementNumber",
-                "ShowMovement",
-                "Ensemble",
-                "Location",
-                "Grouping",
-                "Disc",
-                "Label",
-                "MUSICBRAINZ_ARTISTID",
-                "MUSICBRAINZ_ALBUMID",
-                "MUSICBRAINZ_ALBUMARTISTID",
-                "MUSICBRAINZ_TRACKID",
-                "MUSICBRAINZ_RELEASETRACKID",
-                "MUSICBRAINZ_WORKID",
-                "MUSICBRAINZ_RELEASEGROUPID",
-            ];
+    // Every tag type the server supports. Order and membership must match
+    // MPD's tag/Names.cxx table.
+    const ALL_TAGS: &[&str] = &[
+        "Artist",
+        "ArtistSort",
+        "Album",
+        "AlbumSort",
+        "AlbumArtist",
+        "AlbumArtistSort",
+        "Title",
+        "TitleSort",
+        "Track",
+        "Name",
+        "Genre",
+        "Mood",
+        "Date",
+        "OriginalDate",
+        "Composer",
+        "ComposerSort",
+        "Performer",
+        "Conductor",
+        "Work",
+        "Movement",
+        "MovementNumber",
+        "ShowMovement",
+        "Ensemble",
+        "Location",
+        "Grouping",
+        "Comment",
+        "Disc",
+        "DiscSubtitle",
+        "Label",
+        "MUSICBRAINZ_ARTISTID",
+        "MUSICBRAINZ_ALBUMID",
+        "MUSICBRAINZ_ALBUMARTISTID",
+        "MUSICBRAINZ_TRACKID",
+        "MUSICBRAINZ_RELEASETRACKID",
+        "MUSICBRAINZ_WORKID",
+        "MUSICBRAINZ_RELEASEGROUPID",
+    ];
 
-            for tag in all_tags {
-                if conn_state.is_tag_enabled(tag) {
-                    resp.field("tagtype", tag);
+    // MPD's `global_tag_mask` defaults to All tags EXCEPT Comment
+    // (tag/Settings.cxx: `TagMask::All() & ~TagMask(TAG_COMMENT)`), and is
+    // ANDed into every client's effective mask (TagPrint.cxx). Only the
+    // `metadata_to_use` config directive (unimplemented here) changes it, so
+    // Comment never appears in `tagtypes` or `tagtypes available` output —
+    // even after `tagtypes enable Comment`/`all` — though it stays a valid
+    // tag name for filters and comment-reading commands.
+    fn is_globally_advertised(tag: &str) -> bool {
+        tag != "Comment"
+    }
+
+    match subcommand {
+        None => {
+            // List only the tags currently enabled for this connection,
+            // masked by the server-wide default set.
+            for tag in ALL_TAGS {
+                if is_globally_advertised(tag) && conn_state.is_tag_enabled(tag) {
+                    resp.field("tagtype", *tag);
+                }
+            }
+        }
+        Some(TagTypesSubcommand::Available) => {
+            // List every tag type the server supports, regardless of this
+            // connection's currently-enabled set (but still masked by the
+            // server-wide default set).
+            for tag in ALL_TAGS {
+                if is_globally_advertised(tag) {
+                    resp.field("tagtype", *tag);
                 }
             }
         }
@@ -298,20 +324,84 @@ pub async fn handle_protocol_command(
     resp.ok()
 }
 
-pub async fn handle_stringnormalization_command() -> String {
-    // MPD reports the active Unicode normalization form for tag comparisons.
-    // rmpd performs no normalization (same as MPD's default "None" mode).
+/// The only string-normalization option MPD (and rmpd) currently support.
+const KNOWN_STRING_NORMALIZATIONS: &[&str] = &["strip_diacritics"];
+
+pub async fn handle_stringnormalization_command(
+    conn_state: &mut ConnectionState,
+    subcommand: Option<crate::parser::StringNormalizationSubcommand>,
+) -> String {
+    use crate::commands::utils::ACK_ERROR_ARG;
+    use crate::parser::StringNormalizationSubcommand;
     let mut resp = ResponseBuilder::new();
-    resp.field("stringnormalization", "None");
+    match subcommand {
+        None => {
+            // Bare `stringnormalization` — list enabled options for this
+            // connection. None are enabled by default.
+            for option in KNOWN_STRING_NORMALIZATIONS {
+                if conn_state.is_normalization_enabled(option) {
+                    resp.field("stringnormalization", *option);
+                }
+            }
+        }
+        Some(StringNormalizationSubcommand::Available) => {
+            for option in KNOWN_STRING_NORMALIZATIONS {
+                resp.field("stringnormalization", *option);
+            }
+        }
+        Some(StringNormalizationSubcommand::All) => {
+            conn_state.set_normalizations(
+                KNOWN_STRING_NORMALIZATIONS
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+            );
+        }
+        Some(StringNormalizationSubcommand::Clear) => {
+            conn_state.clear_normalizations();
+        }
+        Some(StringNormalizationSubcommand::Enable { options }) => {
+            for option in &options {
+                if !KNOWN_STRING_NORMALIZATIONS.contains(&option.as_str()) {
+                    return ResponseBuilder::error(
+                        ACK_ERROR_ARG,
+                        0,
+                        "stringnormalization",
+                        "Unknown string normalization",
+                    );
+                }
+            }
+            conn_state.enable_normalizations(options);
+        }
+        Some(StringNormalizationSubcommand::Disable { options }) => {
+            for option in &options {
+                if !KNOWN_STRING_NORMALIZATIONS.contains(&option.as_str()) {
+                    return ResponseBuilder::error(
+                        ACK_ERROR_ARG,
+                        0,
+                        "stringnormalization",
+                        "Unknown string normalization",
+                    );
+                }
+            }
+            conn_state.disable_normalizations(options);
+        }
+    }
     resp.ok()
 }
 
-pub async fn handle_urlhandlers_command() -> String {
+pub async fn handle_urlhandlers_command(conn_state: &ConnectionState) -> String {
     let mut resp = ResponseBuilder::new();
 
-    // Supported URL schemes
-    resp.field("handler", "file://");
-    // Future: http://, https://, etc.
+    // MPD only exposes the local `file://` handler to clients connected via
+    // the local Unix socket (`Client::IsLocal`); remote clients never see it.
+    if conn_state.is_local {
+        resp.field("handler", "file://");
+    }
+    // rmpd streams audio directly over HTTP(S) via rmpd_stream::HttpSource,
+    // regardless of client locality.
+    resp.field("handler", "http://");
+    resp.field("handler", "https://");
 
     resp.ok()
 }

--- a/rmpd-protocol/src/commands/stickers.rs
+++ b/rmpd-protocol/src/commands/stickers.rs
@@ -183,7 +183,7 @@ fn sticker_matches(op: StickerCmp, sticker_value: &str, cmp_value: &str) -> bool
 }
 
 /// A `sticker` line with an unrecognized subcommand. MPD resolves the
-/// domain (args[1]) before ever checking the subcommand (StickerCommands.cxx
+/// domain (`args[1]`) before ever checking the subcommand (StickerCommands.cxx
 /// `handle_sticker`), so an invalid domain still reports "unknown sticker
 /// domain"/"not supported" here; only a valid (song) domain reaches the
 /// generic "bad request".

--- a/rmpd-protocol/src/commands/stickers.rs
+++ b/rmpd-protocol/src/commands/stickers.rs
@@ -3,11 +3,90 @@
 //! Stickers are arbitrary key-value metadata tags that can be attached to songs.
 //! They are stored persistently in the database and can be used for ratings,
 //! playback counts, or any custom metadata.
+//!
+//! Only the `song` domain is backed by storage (rmpd's `stickers` table is
+//! URI-keyed with no `type` column). MPD 0.24 also supports `playlist`,
+//! `filter`, and per-tag domains (see `sticker/AllowedTags.cxx`); requests
+//! for those return a clear "not supported" ACK instead of silently
+//! misinterpreting the domain argument as a song URI.
 
 use crate::response::ResponseBuilder;
 use crate::state::AppState;
 
-use super::utils::{ACK_ERROR_NO_EXIST, ACK_ERROR_SYS, open_db};
+use super::utils::{ACK_ERROR_ARG, ACK_ERROR_NO_EXIST, ACK_ERROR_SYS, apply_range, open_db};
+
+/// Tags MPD allows stickers on, in `sticker/AllowedTags.cxx` enum order.
+const STICKER_ALLOWED_TAGS: &[&str] = &[
+    "Artist",
+    "Album",
+    "AlbumArtist",
+    "Title",
+    "Genre",
+    "Composer",
+    "Performer",
+    "Conductor",
+    "Work",
+    "Ensemble",
+    "Location",
+    "Label",
+    "MUSICBRAINZ_ARTISTID",
+    "MUSICBRAINZ_ALBUMID",
+    "MUSICBRAINZ_ALBUMARTISTID",
+    "MUSICBRAINZ_RELEASETRACKID",
+    "MUSICBRAINZ_WORKID",
+];
+
+/// Reject sticker domains this build doesn't have storage for. `song` is the
+/// only implemented domain; `playlist`/`filter`/tag-name domains are real
+/// MPD 0.24 features we don't back yet, so callers get an honest ACK instead
+/// of the domain argument being silently treated as a song URI.
+fn require_song_domain(sticker_type: &str, command: &str) -> Result<(), String> {
+    if sticker_type == "song" {
+        return Ok(());
+    }
+    let recognized = sticker_type == "playlist"
+        || sticker_type == "filter"
+        || STICKER_ALLOWED_TAGS
+            .iter()
+            .any(|t| t.eq_ignore_ascii_case(sticker_type));
+    if recognized {
+        Err(ResponseBuilder::error(
+            ACK_ERROR_ARG,
+            0,
+            command,
+            &format!("sticker domain {sticker_type:?} is not supported (song stickers only)"),
+        ))
+    } else {
+        Err(ResponseBuilder::error(
+            ACK_ERROR_ARG,
+            0,
+            command,
+            &format!("unknown sticker domain {sticker_type:?}"),
+        ))
+    }
+}
+
+/// MPD rejects `set`/`inc`/`dec` with an empty sticker name.
+fn require_nonempty_name(name: &str, command: &str) -> Result<(), String> {
+    if name.is_empty() {
+        Err(ResponseBuilder::error(
+            ACK_ERROR_ARG,
+            0,
+            command,
+            "empty sticker name",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+/// Notify idle clients that a sticker changed, mirroring MPD's
+/// `idle_add(IDLE_STICKER)` after a successful mutation.
+fn notify_sticker_changed(state: &AppState) {
+    state
+        .event_bus
+        .emit(rmpd_core::event::Event::StickerChanged);
+}
 
 fn get_sticker_i32(db: &rmpd_library::Database, uri: &str, name: &str) -> i32 {
     db.get_sticker(uri, name)
@@ -36,14 +115,17 @@ fn require_song(db: &rmpd_library::Database, uri: &str) -> Result<(), String> {
     }
 }
 
-/// Comparison operator for `sticker find` filters.
+/// Comparison operator for `sticker find` filters (`sticker/Match.hxx`).
 #[derive(Clone, Copy)]
 enum StickerCmp {
-    Eq,
-    Ne,
-    Lt,
-    Gt,
+    Equals,
+    LessThan,
+    GreaterThan,
+    EqualsInt,
+    LessThanInt,
+    GreaterThanInt,
     Contains,
+    StartsWith,
 }
 
 /// Decode a `value` field encoded by the parser as `"op\x00val"`.
@@ -52,41 +134,75 @@ fn decode_sticker_filter(encoded: Option<&str>) -> Option<(StickerCmp, &str)> {
     let enc = encoded?;
     let sep = enc.find('\x00')?;
     let op = match &enc[..sep] {
-        "eq" => StickerCmp::Eq,
-        "ne" => StickerCmp::Ne,
-        "lt" => StickerCmp::Lt,
-        "gt" => StickerCmp::Gt,
+        "=" => StickerCmp::Equals,
+        "<" => StickerCmp::LessThan,
+        ">" => StickerCmp::GreaterThan,
+        "eq" => StickerCmp::EqualsInt,
+        "lt" => StickerCmp::LessThanInt,
+        "gt" => StickerCmp::GreaterThanInt,
         "contains" => StickerCmp::Contains,
+        "starts_with" => StickerCmp::StartsWith,
         _ => return None,
     };
     Some((op, &enc[sep + 1..]))
 }
 
+/// SQLite's `CAST(text AS INT)` reads a leading optional sign and digits and
+/// yields 0 when there is none; mirror that for the `eq`/`lt`/`gt` (`_INT`)
+/// operators instead of Rust's stricter `str::parse`.
+fn sqlite_cast_int(s: &str) -> i64 {
+    let trimmed = s.trim_start();
+    let mut end = 0;
+    for (i, c) in trimmed.char_indices() {
+        if c.is_ascii_digit() || (i == 0 && (c == '-' || c == '+')) {
+            end = i + c.len_utf8();
+        } else {
+            break;
+        }
+    }
+    trimmed[..end].parse().unwrap_or(0)
+}
+
 /// Test whether `sticker_value` satisfies `op cmp_value`.
-/// `lt`/`gt` attempt numeric comparison first, then fall back to lexicographic.
 fn sticker_matches(op: StickerCmp, sticker_value: &str, cmp_value: &str) -> bool {
     match op {
-        StickerCmp::Eq => sticker_value == cmp_value,
-        StickerCmp::Ne => sticker_value != cmp_value,
-        StickerCmp::Contains => sticker_value.contains(cmp_value),
-        StickerCmp::Lt => {
-            if let (Ok(a), Ok(b)) = (sticker_value.parse::<f64>(), cmp_value.parse::<f64>()) {
-                a < b
-            } else {
-                sticker_value < cmp_value
-            }
-        }
-        StickerCmp::Gt => {
-            if let (Ok(a), Ok(b)) = (sticker_value.parse::<f64>(), cmp_value.parse::<f64>()) {
-                a > b
-            } else {
-                sticker_value > cmp_value
-            }
-        }
+        StickerCmp::Equals => sticker_value == cmp_value,
+        StickerCmp::LessThan => sticker_value < cmp_value,
+        StickerCmp::GreaterThan => sticker_value > cmp_value,
+        StickerCmp::EqualsInt => sqlite_cast_int(sticker_value) == sqlite_cast_int(cmp_value),
+        StickerCmp::LessThanInt => sqlite_cast_int(sticker_value) < sqlite_cast_int(cmp_value),
+        StickerCmp::GreaterThanInt => sqlite_cast_int(sticker_value) > sqlite_cast_int(cmp_value),
+        // SQLite's LIKE is ASCII case-insensitive, matching MPD's CONTAINS/STARTS_WITH.
+        StickerCmp::Contains => sticker_value
+            .to_ascii_lowercase()
+            .contains(&cmp_value.to_ascii_lowercase()),
+        StickerCmp::StartsWith => sticker_value
+            .to_ascii_lowercase()
+            .starts_with(&cmp_value.to_ascii_lowercase()),
     }
 }
 
-pub async fn handle_sticker_get_command(state: &AppState, uri: &str, name: &str) -> String {
+/// A `sticker` line with an unrecognized subcommand. MPD resolves the
+/// domain (args[1]) before ever checking the subcommand (StickerCommands.cxx
+/// `handle_sticker`), so an invalid domain still reports "unknown sticker
+/// domain"/"not supported" here; only a valid (song) domain reaches the
+/// generic "bad request".
+pub fn handle_sticker_invalid_command(sticker_type: &str) -> String {
+    if let Err(e) = require_song_domain(sticker_type, "sticker") {
+        return e;
+    }
+    ResponseBuilder::error(ACK_ERROR_ARG, 0, "sticker", "bad request")
+}
+
+pub async fn handle_sticker_get_command(
+    state: &AppState,
+    sticker_type: &str,
+    uri: &str,
+    name: &str,
+) -> String {
+    if let Err(e) = require_song_domain(sticker_type, "sticker") {
+        return e;
+    }
     let state = state.clone();
     let uri = uri.to_string();
     let name = name.to_string();
@@ -122,71 +238,100 @@ pub async fn handle_sticker_get_command(state: &AppState, uri: &str, name: &str)
 
 pub async fn handle_sticker_set_command(
     state: &AppState,
+    sticker_type: &str,
     uri: &str,
     name: &str,
     value: &str,
 ) -> String {
-    let state = state.clone();
+    if let Err(e) = require_song_domain(sticker_type, "sticker") {
+        return e;
+    }
+    if let Err(e) = require_nonempty_name(name, "sticker") {
+        return e;
+    }
+    let state_owned = state.clone();
     let uri = uri.to_string();
     let name = name.to_string();
     let value = value.to_string();
-    tokio::task::spawn_blocking(move || {
-        let db = match open_db(&state, "sticker") {
+    let (changed, response) = tokio::task::spawn_blocking(move || {
+        let db = match open_db(&state_owned, "sticker") {
             Ok(d) => d,
-            Err(e) => return e,
+            Err(e) => return (false, e),
         };
 
-        // Check song exists
         if let Err(e) = require_song(&db, &uri) {
-            return e;
+            return (false, e);
         }
 
         match db.set_sticker(&uri, &name, &value) {
-            Ok(_) => ResponseBuilder::new().ok(),
-            Err(e) => ResponseBuilder::error(ACK_ERROR_SYS, 0, "sticker", &format!("Error: {e}")),
+            Ok(_) => (true, ResponseBuilder::new().ok()),
+            Err(e) => (
+                false,
+                ResponseBuilder::error(ACK_ERROR_SYS, 0, "sticker", &format!("Error: {e}")),
+            ),
         }
     })
     .await
-    .unwrap_or_else(|_| ResponseBuilder::error(ACK_ERROR_SYS, 0, "sticker", "internal error"))
+    .unwrap_or_else(|_| {
+        (
+            false,
+            ResponseBuilder::error(ACK_ERROR_SYS, 0, "sticker", "internal error"),
+        )
+    });
+    if changed {
+        notify_sticker_changed(state);
+    }
+    response
 }
 
+/// `delete TYPE URI` with no NAME removes every sticker for `uri`. When
+/// there is nothing to delete, real MPD (StickerCommands.cxx
+/// `DomainHandler::Delete`) formats `FmtError(..., "no such sticker: {:?}",
+/// name)` with `name == nullptr`, which crashes the daemon (verified against
+/// MPD master 793eb1219) — that is a real MPD bug, not a spec to match.
+/// rmpd deliberately returns `OK` here instead of reproducing the crash or
+/// inventing an error MPD itself doesn't survive to send.
 pub async fn handle_sticker_delete_command(
     state: &AppState,
+    sticker_type: &str,
     uri: &str,
     name: Option<&str>,
 ) -> String {
-    let state = state.clone();
+    if let Err(e) = require_song_domain(sticker_type, "sticker") {
+        return e;
+    }
+    let state_owned = state.clone();
     let uri = uri.to_string();
     let name = name.map(|s| s.to_string());
-    tokio::task::spawn_blocking(move || {
+    let (changed, response) = tokio::task::spawn_blocking(move || {
         let name = name.as_deref();
-        let db = match open_db(&state, "sticker") {
+        let db = match open_db(&state_owned, "sticker") {
             Ok(d) => d,
-            Err(e) => return e,
+            Err(e) => return (false, e),
         };
 
-        // Check song exists
         if let Err(e) = require_song(&db, &uri) {
-            return e;
+            return (false, e);
         }
 
         // When deleting a named sticker, check it exists first (MPD returns error if not found)
         if let Some(sticker_name) = name {
             match db.get_sticker(&uri, sticker_name) {
                 Ok(None) => {
-                    return ResponseBuilder::error(
-                        ACK_ERROR_NO_EXIST,
-                        0,
-                        "sticker",
-                        &format!("no such sticker: {:?}", sticker_name),
+                    return (
+                        false,
+                        ResponseBuilder::error(
+                            ACK_ERROR_NO_EXIST,
+                            0,
+                            "sticker",
+                            &format!("no such sticker: {:?}", sticker_name),
+                        ),
                     );
                 }
                 Err(e) => {
-                    return ResponseBuilder::error(
-                        ACK_ERROR_SYS,
-                        0,
-                        "sticker",
-                        &format!("Error: {e}"),
+                    return (
+                        false,
+                        ResponseBuilder::error(ACK_ERROR_SYS, 0, "sticker", &format!("Error: {e}")),
                     );
                 }
                 Ok(Some(_)) => {}
@@ -194,15 +339,34 @@ pub async fn handle_sticker_delete_command(
         }
 
         match db.delete_sticker(&uri, name) {
-            Ok(_) => ResponseBuilder::new().ok(),
-            Err(e) => ResponseBuilder::error(ACK_ERROR_SYS, 0, "sticker", &format!("Error: {e}")),
+            Ok(_) => (true, ResponseBuilder::new().ok()),
+            Err(e) => (
+                false,
+                ResponseBuilder::error(ACK_ERROR_SYS, 0, "sticker", &format!("Error: {e}")),
+            ),
         }
     })
     .await
-    .unwrap_or_else(|_| ResponseBuilder::error(ACK_ERROR_SYS, 0, "sticker", "internal error"))
+    .unwrap_or_else(|_| {
+        (
+            false,
+            ResponseBuilder::error(ACK_ERROR_SYS, 0, "sticker", "internal error"),
+        )
+    });
+    if changed {
+        notify_sticker_changed(state);
+    }
+    response
 }
 
-pub async fn handle_sticker_list_command(state: &AppState, uri: &str) -> String {
+pub async fn handle_sticker_list_command(
+    state: &AppState,
+    sticker_type: &str,
+    uri: &str,
+) -> String {
+    if let Err(e) = require_song_domain(sticker_type, "sticker") {
+        return e;
+    }
     let state = state.clone();
     let uri = uri.to_string();
     tokio::task::spawn_blocking(move || {
@@ -231,12 +395,50 @@ pub async fn handle_sticker_list_command(state: &AppState, uri: &str) -> String 
     .unwrap_or_else(|_| ResponseBuilder::error(ACK_ERROR_SYS, 0, "sticker", "internal error"))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn handle_sticker_find_command(
     state: &AppState,
+    sticker_type: &str,
     uri: &str,
     name: &str,
     value: Option<&str>,
+    sort: Option<&str>,
+    window: Option<(u32, u32)>,
 ) -> String {
+    if let Err(e) = require_song_domain(sticker_type, "sticker") {
+        return e;
+    }
+
+    // Validate `sort` up front so a bad tag fails before touching the DB.
+    enum SortKey {
+        Uri,
+        Value,
+        ValueInt,
+    }
+    let sort_key = match sort {
+        None => None,
+        Some(s) => {
+            let (key, descending) = match s.strip_prefix('-') {
+                Some(rest) => (rest, true),
+                None => (s, false),
+            };
+            let key = match key {
+                "uri" => SortKey::Uri,
+                "value" => SortKey::Value,
+                "value_int" => SortKey::ValueInt,
+                _ => {
+                    return ResponseBuilder::error(
+                        ACK_ERROR_ARG,
+                        0,
+                        "sticker",
+                        &format!("Unknown sort tag {:?}", s),
+                    );
+                }
+            };
+            Some((key, descending))
+        }
+    };
+
     let state = state.clone();
     let uri = uri.to_string();
     let name = name.to_string();
@@ -250,14 +452,27 @@ pub async fn handle_sticker_find_command(
         let filter = decode_sticker_filter(value.as_deref());
 
         match db.find_stickers(&uri, &name) {
-            Ok(results) => {
-                let mut resp = ResponseBuilder::new();
-                for (file_uri, sticker_value) in &results {
-                    if let Some((op, cmp_val)) = filter
-                        && !sticker_matches(op, sticker_value, cmp_val)
-                    {
-                        continue;
+            Ok(mut results) => {
+                if let Some((op, cmp_val)) = filter {
+                    results
+                        .retain(|(_, sticker_value)| sticker_matches(op, sticker_value, cmp_val));
+                }
+                if let Some((key, descending)) = sort_key {
+                    match key {
+                        SortKey::Uri => results.sort_by(|a, b| a.0.cmp(&b.0)),
+                        SortKey::Value => results.sort_by(|a, b| a.1.cmp(&b.1)),
+                        SortKey::ValueInt => {
+                            results.sort_by_key(|(_, v)| sqlite_cast_int(v));
+                        }
                     }
+                    if descending {
+                        results.reverse();
+                    }
+                }
+                let results = apply_range(&results, window);
+
+                let mut resp = ResponseBuilder::new();
+                for (file_uri, sticker_value) in results {
                     resp.field("file", file_uri);
                     resp.field("sticker", format!("{name}={sticker_value}"));
                 }
@@ -272,67 +487,96 @@ pub async fn handle_sticker_find_command(
 
 /// Shared core for `sticker inc` / `sticker dec`.
 /// `delta` is the signed change to apply (positive for inc, negative for dec).
-async fn adjust_sticker_value(state: &AppState, uri: &str, name: &str, delta: i32) -> String {
-    let state = state.clone();
+async fn adjust_sticker_value(
+    state: &AppState,
+    sticker_type: &str,
+    uri: &str,
+    name: &str,
+    delta: i32,
+) -> String {
+    if let Err(e) = require_song_domain(sticker_type, "sticker") {
+        return e;
+    }
+    if let Err(e) = require_nonempty_name(name, "sticker") {
+        return e;
+    }
+    let state_owned = state.clone();
     let uri = uri.to_string();
     let name = name.to_string();
-    tokio::task::spawn_blocking(move || {
-        let db = match open_db(&state, "sticker") {
+    let (changed, response) = tokio::task::spawn_blocking(move || {
+        let db = match open_db(&state_owned, "sticker") {
             Ok(d) => d,
-            Err(e) => return e,
+            Err(e) => return (false, e),
         };
+        if let Err(e) = require_song(&db, &uri) {
+            return (false, e);
+        }
         let new_value = get_sticker_i32(&db, &uri, &name) + delta;
         match db.set_sticker(&uri, &name, &new_value.to_string()) {
-            Ok(_) => {
-                let mut resp = ResponseBuilder::new();
-                resp.field("sticker", format!("{name}={new_value}"));
-                resp.ok()
-            }
-            Err(e) => ResponseBuilder::error(ACK_ERROR_SYS, 0, "sticker", &format!("Error: {e}")),
+            // MPD's Inc/Dec (StickerCommands.cxx) never print the new
+            // value: just OK, unlike Get/Find's `sticker_print_value`.
+            Ok(_) => (true, ResponseBuilder::new().ok()),
+            Err(e) => (
+                false,
+                ResponseBuilder::error(ACK_ERROR_SYS, 0, "sticker", &format!("Error: {e}")),
+            ),
         }
     })
     .await
-    .unwrap_or_else(|_| ResponseBuilder::error(ACK_ERROR_SYS, 0, "sticker", "internal error"))
+    .unwrap_or_else(|_| {
+        (
+            false,
+            ResponseBuilder::error(ACK_ERROR_SYS, 0, "sticker", "internal error"),
+        )
+    });
+    if changed {
+        notify_sticker_changed(state);
+    }
+    response
 }
 
 pub async fn handle_sticker_inc_command(
     state: &AppState,
+    sticker_type: &str,
     uri: &str,
     name: &str,
-    delta: Option<i32>,
+    delta: i32,
 ) -> String {
-    adjust_sticker_value(state, uri, name, delta.unwrap_or(1)).await
+    adjust_sticker_value(state, sticker_type, uri, name, delta).await
 }
 
 pub async fn handle_sticker_dec_command(
     state: &AppState,
+    sticker_type: &str,
     uri: &str,
     name: &str,
-    delta: Option<i32>,
+    delta: i32,
 ) -> String {
-    adjust_sticker_value(state, uri, name, -delta.unwrap_or(1)).await
+    adjust_sticker_value(state, sticker_type, uri, name, -delta).await
 }
 
-pub async fn handle_sticker_names_command(state: &AppState, uri: Option<&str>) -> String {
-    // List unique sticker names (optionally for specific URI)
-    let Some(uri_str) = uri else {
-        return ResponseBuilder::new().ok();
-    };
+/// `stickernames` takes no arguments: it lists every distinct sticker name
+/// across all URIs (not scoped to a single song), matching MPD's
+/// `SELECT DISTINCT name FROM sticker ORDER BY name`.
+pub async fn handle_sticker_names_command(state: &AppState) -> String {
     let state = state.clone();
-    let uri_str = uri_str.to_string();
     tokio::task::spawn_blocking(move || {
         let db = match open_db(&state, "stickernames") {
             Ok(d) => d,
             Err(e) => return e,
         };
-        if let Ok(stickers) = db.list_stickers(&uri_str) {
-            let mut resp = ResponseBuilder::new();
-            for (name, _) in stickers {
-                resp.field("sticker", &name);
+        match db.list_all_sticker_names() {
+            Ok(names) => {
+                let mut resp = ResponseBuilder::new();
+                for name in names {
+                    resp.field("name", &name);
+                }
+                resp.ok()
             }
-            return resp.ok();
+            Err(e) => {
+                ResponseBuilder::error(ACK_ERROR_SYS, 0, "stickernames", &format!("Error: {e}"))
+            }
         }
-        ResponseBuilder::new().ok()
     })
     .await
     .unwrap_or_else(|_| ResponseBuilder::error(ACK_ERROR_SYS, 0, "stickernames", "internal error"))
@@ -345,51 +589,63 @@ pub async fn handle_sticker_types_command() -> String {
     resp.field("stickertype", "filter");
     resp.field("stickertype", "playlist");
     resp.field("stickertype", "song");
-    // Sticker-allowed tags (from MPD's AllowedTags.cxx), in enum order:
-    for tag in &[
-        "Artist",
-        "Album",
-        "AlbumArtist",
-        "Title",
-        "Genre",
-        "Composer",
-        "Performer",
-        "Conductor",
-        "Work",
-        "Ensemble",
-        "Location",
-        "Label",
-        "MUSICBRAINZ_ARTISTID",
-        "MUSICBRAINZ_ALBUMID",
-        "MUSICBRAINZ_ALBUMARTISTID",
-        "MUSICBRAINZ_RELEASETRACKID",
-        "MUSICBRAINZ_WORKID",
-    ] {
+    for tag in STICKER_ALLOWED_TAGS {
         resp.field("stickertype", *tag);
     }
     resp.ok()
 }
 
-pub async fn handle_sticker_namestypes_command(state: &AppState, uri: Option<&str>) -> String {
-    // List sticker names and types
-    let Some(uri_str) = uri else {
-        return ResponseBuilder::new().ok();
-    };
+/// `stickernamestypes [TYPE]`: unique sticker names and their domain type.
+/// Mirrors MPD's `handle_sticker_names_types`: `song`, `playlist`, `filter`
+/// and any tag in `sticker_allowed_tags` are all valid TYPEs and simply
+/// filter the listing, so a domain with no stored stickers yields a bare
+/// `OK`. Only a TYPE that is not a tag name at all (`no such tag`) or a tag
+/// outside the allowed set (`unsupported tag`) is an error. rmpd stores song
+/// stickers only, so every other valid domain lists nothing.
+pub async fn handle_sticker_namestypes_command(
+    state: &AppState,
+    sticker_type: Option<&str>,
+) -> String {
+    if let Some(t) = sticker_type
+        && t != "song"
+    {
+        if t == "playlist" || t == "filter" {
+            return ResponseBuilder::new().ok();
+        }
+        if STICKER_ALLOWED_TAGS.contains(&t) {
+            return ResponseBuilder::new().ok();
+        }
+        // MPD uses the case-sensitive tag_name_parse() here, unlike the
+        // `sticker` command's case-insensitive tag_name_parse_i().
+        let msg = if rmpd_core::song::canonical_tag_name(t) == "Unknown" {
+            format!("no such tag {t:?}")
+        } else {
+            format!("unsupported tag {t:?}")
+        };
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "stickernamestypes", &msg);
+    }
     let state = state.clone();
-    let uri_str = uri_str.to_string();
     tokio::task::spawn_blocking(move || {
         let db = match open_db(&state, "stickernamestypes") {
             Ok(d) => d,
             Err(e) => return e,
         };
-        if let Ok(stickers) = db.list_stickers(&uri_str) {
-            let mut resp = ResponseBuilder::new();
-            for (name, _) in stickers {
-                resp.field("sticker", format!("{name} song"));
+        match db.list_all_sticker_names() {
+            Ok(names) => {
+                let mut resp = ResponseBuilder::new();
+                for name in names {
+                    resp.field("name", &name);
+                    resp.field("type", "song");
+                }
+                resp.ok()
             }
-            return resp.ok();
+            Err(e) => ResponseBuilder::error(
+                ACK_ERROR_SYS,
+                0,
+                "stickernamestypes",
+                &format!("Error: {e}"),
+            ),
         }
-        ResponseBuilder::new().ok()
     })
     .await
     .unwrap_or_else(|_| {

--- a/rmpd-protocol/src/commands/storage.rs
+++ b/rmpd-protocol/src/commands/storage.rs
@@ -8,7 +8,7 @@
 //! - mount/unmount/listmounts: ✅ Tier 1 (tracking) + Tier 2 (actual mounting) implemented
 
 use super::ResponseBuilder;
-use super::utils::ACK_ERROR_SYS;
+use super::utils::{ACK_ERROR_ARG, ACK_ERROR_SYS};
 use crate::state::AppState;
 use rmpd_core::storage::platform::get_default_backend;
 use std::path::PathBuf;
@@ -24,6 +24,11 @@ use std::path::PathBuf;
 /// Set `disable_actual_mount` on AppState to disable actual mounting
 /// and only track mounts in registry (Tier 1 mode).
 pub async fn handle_mount_command(state: &AppState, path: &str, uri: &str) -> String {
+    // MPD: empty mount point is always rejected ("Bad mount point").
+    if path.is_empty() {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "mount", "Bad mount point");
+    }
+
     // Validate path (no ../, no absolute paths)
     if path.contains("..") || path.starts_with('/') {
         return ResponseBuilder::error(
@@ -32,6 +37,10 @@ pub async fn handle_mount_command(state: &AppState, path: &str, uri: &str) -> St
             "mount",
             "Invalid path: no absolute paths or path traversal allowed",
         );
+    }
+
+    if state.mount_registry.is_mounted(path).await {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "mount", "Mount point busy");
     }
 
     // Check if music directory is configured
@@ -92,6 +101,7 @@ pub async fn handle_mount_command(state: &AppState, path: &str, uri: &str) -> St
                     );
                 }
 
+                state.event_bus.emit(rmpd_core::event::Event::MountsChanged);
                 ResponseBuilder::new().ok()
             }
             Ok(Err(e)) => {
@@ -110,7 +120,10 @@ pub async fn handle_mount_command(state: &AppState, path: &str, uri: &str) -> St
             .register(path.to_string(), uri.to_string())
             .await
         {
-            Ok(_) => ResponseBuilder::new().ok(),
+            Ok(_) => {
+                state.event_bus.emit(rmpd_core::event::Event::MountsChanged);
+                ResponseBuilder::new().ok()
+            }
             Err(e) => ResponseBuilder::error(
                 ACK_ERROR_SYS,
                 0,
@@ -128,6 +141,15 @@ pub async fn handle_mount_command(state: &AppState, path: &str, uri: &str) -> St
 /// Set `disable_actual_mount` on AppState to disable actual unmounting
 /// and only remove from registry (Tier 1 mode).
 pub async fn handle_unmount_command(state: &AppState, path: &str) -> String {
+    // MPD: empty mount point is always rejected ("Bad mount point").
+    if path.is_empty() {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "unmount", "Bad mount point");
+    }
+
+    if state.mount_registry.get(path).await.is_none() {
+        return ResponseBuilder::error(ACK_ERROR_ARG, 0, "unmount", "Not a mount point");
+    }
+
     // Check if music directory is configured
     let music_dir = match &state.music_dir {
         Some(dir) => dir,
@@ -165,6 +187,7 @@ pub async fn handle_unmount_command(state: &AppState, path: &str) -> String {
                     tracing::error!("failed to unregister mount: {}", e);
                 }
 
+                state.event_bus.emit(rmpd_core::event::Event::MountsChanged);
                 ResponseBuilder::new().ok()
             }
             Ok(Err(e)) => {
@@ -181,7 +204,10 @@ pub async fn handle_unmount_command(state: &AppState, path: &str) -> String {
     } else {
         // Tier 1: Only remove from registry
         match state.mount_registry.unmount(path).await {
-            Ok(_) => ResponseBuilder::new().ok(),
+            Ok(_) => {
+                state.event_bus.emit(rmpd_core::event::Event::MountsChanged);
+                ResponseBuilder::new().ok()
+            }
             Err(e) => {
                 ResponseBuilder::error(ACK_ERROR_SYS, 0, "unmount", &format!("Unmount failed: {e}"))
             }

--- a/rmpd-protocol/src/commands/utils.rs
+++ b/rmpd-protocol/src/commands/utils.rs
@@ -30,30 +30,80 @@ pub fn open_db(
 
 pub use rmpd_core::time::format_iso8601 as format_iso8601_timestamp;
 
-/// Build a FilterExpression from multiple tag/value pairs joined with AND,
-/// using `op` as the comparison for every pair (`Equal` for exact matches,
-/// `Contains` for case-insensitive substring matching as used by `search`).
-/// Panics if `filters` is empty.
-pub fn build_filter(
+/// Build a `FilterExpression` from a command's parsed argument list,
+/// detecting whether it's a single modern `(...)` expression token (per
+/// `parser::parse_find_search_filters`'s convention: `[(expr, "")]`) or
+/// legacy `TAG VALUE [TAG VALUE ...]` pairs — mirroring the dispatch
+/// `SongFilter::Parse` itself does on `args.front()[0] == '('`.
+///
+/// `fold_case`: `true` for `search`-family commands (case-insensitive),
+/// `false` for `find`-family commands (case-sensitive).
+pub fn parse_filter_args(
     filters: &[(String, String)],
-    op: rmpd_core::filter::CompareOp,
-) -> rmpd_core::filter::FilterExpression {
-    use rmpd_core::filter::FilterExpression;
+    fold_case: bool,
+) -> rmpd_core::error::Result<rmpd_core::filter::FilterExpression> {
+    if filters.len() == 1 && filters[0].0.starts_with('(') {
+        rmpd_core::filter::FilterExpression::parse(&filters[0].0, fold_case)
+    } else {
+        rmpd_core::filter::FilterExpression::from_pairs(filters, fold_case)
+    }
+}
 
-    let base = FilterExpression::Compare {
-        tag: filters[0].0.clone(),
-        op,
-        value: filters[0].1.clone(),
+/// Convert a filter-expression parse error into an `ACK_ERROR_ARG` response,
+/// using the raw MPD-style message text (stripping the `RmpdError` Display
+/// wrapper, same convention used for `RmpdError::Library` elsewhere).
+pub fn filter_parse_ack(command: &str, err: &rmpd_core::error::RmpdError) -> String {
+    let msg = err.to_string();
+    let msg = msg.strip_prefix("Parse error: ").unwrap_or(&msg);
+    ResponseBuilder::error(ACK_ERROR_ARG, 0, command, msg)
+}
+
+/// A resolved `sort TAG` clause: either one of MPD's two synthetic sort
+/// keys (`Last-Modified`, `Added`) or a real tag name (already validated
+/// and lowercased).
+pub enum SortKey {
+    LastModified,
+    Added,
+    Tag(String),
+}
+
+/// Parse a `sort TAG` argument, mirroring `ParseSortTag()`: a leading `-`
+/// requests descending order; `Last-Modified`/`Added` are synthetic sort
+/// keys, anything else must be a known tag name. Returns `None` for an
+/// unknown tag — the caller reports MPD's exact `"Unknown sort tag"` text.
+pub fn parse_sort_tag(s: &str) -> Option<(SortKey, bool)> {
+    let (descending, rest) = match s.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, s),
     };
+    let key = if rest.eq_ignore_ascii_case("last-modified") {
+        SortKey::LastModified
+    } else if rest.eq_ignore_ascii_case("added") {
+        SortKey::Added
+    } else {
+        let tag_lower = rest.to_lowercase();
+        if rmpd_core::song::canonical_tag_name(&tag_lower) == "Unknown" {
+            return None;
+        }
+        SortKey::Tag(tag_lower)
+    };
+    Some((key, descending))
+}
 
-    filters[1..].iter().fold(base, |expr, filter| {
-        let next_expr = FilterExpression::Compare {
-            tag: filter.0.clone(),
-            op,
-            value: filter.1.clone(),
-        };
-        FilterExpression::And(Box::new(expr), Box::new(next_expr))
-    })
+/// Sort songs in place by a resolved `sort` key, reversing for descending
+/// order. Only the first value of a multi-valued tag is used (matches
+/// MPD's documented behaviour).
+pub fn sort_songs(songs: &mut [rmpd_core::song::Song], key: &SortKey, descending: bool) {
+    match key {
+        SortKey::LastModified => songs.sort_by_key(|s| s.last_modified),
+        SortKey::Added => songs.sort_by_key(|s| s.added_at),
+        SortKey::Tag(tag) => {
+            songs.sort_by(|a, b| a.tag_with_fallback(tag).cmp(&b.tag_with_fallback(tag)))
+        }
+    }
+    if descending {
+        songs.reverse();
+    }
 }
 
 /// Apply a range/window filter to a slice, returning the filtered sub-slice.
@@ -69,6 +119,117 @@ pub fn apply_range<T>(items: &[T], range: Option<(u32, u32)>) -> &[T] {
     } else {
         items
     }
+}
+
+/// Append `songs` to the queue, then — if `position` is before the queue's
+/// prior end — move the newly-added block there in one pass. Mirrors MPD's
+/// `handle_match_add` (`AddFromDatabase` followed by `Partition::MoveRange`
+/// when the insert position isn't a plain append). `position` beyond the
+/// queue's prior length is rejected with MPD's `"Bad song index"` instead of
+/// silently clamping.
+pub async fn add_songs_at_position(
+    state: &crate::state::AppState,
+    songs: Vec<rmpd_core::song::Song>,
+    position: Option<u32>,
+    command: &str,
+) -> Result<(), String> {
+    let start = state.queue.read().await.len() as u32;
+    if let Some(pos) = position
+        && pos > start
+    {
+        return Err(ResponseBuilder::error(
+            ACK_ERROR_ARG,
+            0,
+            command,
+            "Bad song index",
+        ));
+    }
+    if songs.is_empty() {
+        return Ok(());
+    }
+    let added = songs.len() as u32;
+    {
+        let mut queue = state.queue.write().await;
+        for song in songs {
+            queue.add(song);
+        }
+    }
+    if let Some(pos) = position
+        && pos < start
+    {
+        let mut queue = state.queue.write().await;
+        for i in 0..added {
+            queue.move_item(start, pos + i);
+        }
+    }
+    crate::helpers::update_playlist_version(state).await;
+    Ok(())
+}
+
+/// Resolve the optional 0.24 `position` argument of `findadd`/`searchadd`/
+/// `searchaddpl` (`+N`/`-N`/absolute — same grammar as `addid`) into an
+/// absolute queue index, mirroring MPD's `ParseInsertPosition`
+/// (`PositionArg.cxx`). `None` means "append" and passes through unchanged.
+pub async fn resolve_add_position(
+    state: &crate::state::AppState,
+    spec: Option<crate::parser::InsertPosition>,
+    command: &str,
+) -> Result<Option<u32>, String> {
+    use crate::parser::InsertPosition;
+
+    let Some(spec) = spec else {
+        return Ok(None);
+    };
+    let queue_len = state.queue.read().await.len() as u32;
+    let resolved = match spec {
+        InsertPosition::Absolute(n) => {
+            if n > queue_len {
+                return Err(ResponseBuilder::error(
+                    ACK_ERROR_ARG,
+                    0,
+                    command,
+                    &format!("Number too large: {n}"),
+                ));
+            }
+            n
+        }
+        InsertPosition::After(n) | InsertPosition::Before(n) => {
+            let current = match state.status.read().await.current_song {
+                Some(pos) => pos.position,
+                None => {
+                    return Err(ResponseBuilder::error(
+                        ACK_ERROR_PLAYER_SYNC,
+                        0,
+                        command,
+                        "No current song",
+                    ));
+                }
+            };
+            if let InsertPosition::After(n) = spec {
+                let max = queue_len - current - 1;
+                if n > max {
+                    return Err(ResponseBuilder::error(
+                        ACK_ERROR_ARG,
+                        0,
+                        command,
+                        &format!("Number too large: {n}"),
+                    ));
+                }
+                current + 1 + n
+            } else {
+                if n > current {
+                    return Err(ResponseBuilder::error(
+                        ACK_ERROR_ARG,
+                        0,
+                        command,
+                        &format!("Number too large: {n}"),
+                    ));
+                }
+                current - n
+            }
+        }
+    };
+    Ok(Some(resolved))
 }
 
 /// Insert `song` into the queue at `position`, rejecting an out-of-range
@@ -97,16 +258,15 @@ pub async fn add_at_checked(
     Ok(queue.add_at(song, position))
 }
 
-/// Append queue item metadata (priority, range) to the response.
+/// Append the queue-item priority to the response (Prio, only if non-zero).
+/// Range is emitted by `ResponseBuilder::song()` itself, positioned right
+/// after the `file` field per MPD's SongPrint.cxx.
 pub fn add_queue_item_metadata(
     resp: &mut crate::response::ResponseBuilder,
     item: &rmpd_core::queue::QueueItem,
 ) {
     if item.priority > 0 {
         resp.field("Prio", item.priority);
-    }
-    if let Some((start, end)) = item.range {
-        resp.field("Range", format!("{start:.3}-{end:.3}"));
     }
 }
 

--- a/rmpd-protocol/src/connection.rs
+++ b/rmpd-protocol/src/connection.rs
@@ -11,8 +11,9 @@ pub const PERMISSION_READ: u8 = 1;
 pub const PERMISSION_ADD: u8 = 2;
 pub const PERMISSION_CONTROL: u8 = 4;
 pub const PERMISSION_ADMIN: u8 = 8;
+pub const PERMISSION_PLAYER: u8 = 16;
 pub const PERMISSION_ALL: u8 =
-    PERMISSION_READ | PERMISSION_ADD | PERMISSION_CONTROL | PERMISSION_ADMIN;
+    PERMISSION_READ | PERMISSION_ADD | PERMISSION_CONTROL | PERMISSION_ADMIN | PERMISSION_PLAYER;
 
 /// Per-client connection state
 ///
@@ -33,6 +34,11 @@ pub struct ConnectionState {
     /// Some(set) means only features in the set are enabled
     pub enabled_features: Option<HashSet<String>>,
 
+    /// Set of enabled string-normalization options for this connection
+    /// (e.g. `strip_diacritics`). None means all are enabled; MPD starts
+    /// with none enabled, so `ConnectionState::new()` uses `Some(empty)`.
+    pub enabled_normalizations: Option<HashSet<String>>,
+
     /// Channels this client is subscribed to
     pub subscribed_channels: Vec<String>,
 
@@ -41,6 +47,17 @@ pub struct ConnectionState {
 
     /// MPD permissions bitmask for this connection
     pub permissions: u8,
+
+    /// Whether this connection came in over the local Unix domain socket.
+    /// Mirrors MPD's `Client::IsLocal()` (true only when peer credentials
+    /// are available, i.e. AF_UNIX — never for TCP, including loopback).
+    /// Gates `config` and the `file://` line of `urlhandlers`.
+    pub is_local: bool,
+
+    /// Maximum size in bytes of a binary payload chunk (`albumart`,
+    /// `readpicture`), settable via `binarylimit`. Matches MPD's
+    /// `Client::binary_limit` default of 8192.
+    pub binary_limit: u32,
 }
 
 impl ConnectionState {
@@ -50,11 +67,14 @@ impl ConnectionState {
     /// starts in the "default" partition
     pub fn new() -> Self {
         Self {
-            enabled_tags: None,                     // All tags enabled
-            enabled_features: Some(HashSet::new()), // No protocol features enabled by default
+            enabled_tags: None,                           // All tags enabled
+            enabled_features: Some(HashSet::new()),       // No protocol features enabled by default
+            enabled_normalizations: Some(HashSet::new()), // None enabled by default
             subscribed_channels: Vec::new(),
             current_partition: "default".to_string(),
             permissions: PERMISSION_ALL,
+            is_local: false,
+            binary_limit: 8192,
         }
     }
 
@@ -85,8 +105,13 @@ impl ConnectionState {
         self.permissions = PERMISSION_ALL;
     }
 
-    /// OR-in additional permission bits.
+    /// OR-in additional permission bits. For backwards compatibility with
+    /// MPD 0.22 and older, `control` implies `player` (see Permission.cxx).
     pub fn grant_permissions(&mut self, perms: u8) {
+        let mut perms = perms;
+        if perms & PERMISSION_CONTROL != 0 {
+            perms |= PERMISSION_PLAYER;
+        }
         self.permissions |= perms;
     }
 
@@ -191,6 +216,7 @@ impl ConnectionState {
         tags.insert("Grouping".to_string());
         // Comment is excluded by default (matches MPD's global_tag_mask)
         tags.insert("Disc".to_string());
+        tags.insert("DiscSubtitle".to_string());
         tags.insert("Label".to_string());
         tags.insert("MUSICBRAINZ_ARTISTID".to_string());
         tags.insert("MUSICBRAINZ_ALBUMID".to_string());
@@ -262,6 +288,39 @@ impl ConnectionState {
     fn default_features() -> HashSet<String> {
         HashSet::new()
     }
+
+    /// Check if a string-normalization option is enabled for this connection
+    pub fn is_normalization_enabled(&self, name: &str) -> bool {
+        match &self.enabled_normalizations {
+            None => true,
+            Some(names) => names.contains(name),
+        }
+    }
+
+    /// Disable all string-normalization options (`stringnormalization clear`)
+    pub fn clear_normalizations(&mut self) {
+        self.enabled_normalizations = Some(HashSet::new());
+    }
+
+    /// Set exactly these string-normalization options (`stringnormalization all`)
+    pub fn set_normalizations(&mut self, names: Vec<String>) {
+        self.enabled_normalizations = Some(names.into_iter().collect());
+    }
+
+    /// Enable specific string-normalization options
+    pub fn enable_normalizations(&mut self, names: Vec<String>) {
+        self.enabled_normalizations
+            .get_or_insert_with(HashSet::new)
+            .extend(names);
+    }
+
+    /// Disable specific string-normalization options
+    pub fn disable_normalizations(&mut self, names: Vec<String>) {
+        let set = self.enabled_normalizations.get_or_insert_with(HashSet::new);
+        for name in names {
+            set.remove(&name);
+        }
+    }
 }
 
 impl Default for ConnectionState {
@@ -322,5 +381,30 @@ mod tests {
         state.enable_features(vec!["binary".to_string()]);
         assert!(state.is_feature_enabled("binary"));
         assert!(!state.is_feature_enabled("idle"));
+    }
+
+    #[test]
+    fn test_control_implies_player() {
+        // MPD 0.22 backwards compatibility: granting `control` also grants
+        // `player` (see Permission.cxx::parsePermissions).
+        let mut state = ConnectionState::new();
+        state.permissions = PERMISSION_NONE;
+        state.grant_permissions(PERMISSION_CONTROL);
+        assert!(state.has_permission(PERMISSION_CONTROL));
+        assert!(state.has_permission(PERMISSION_PLAYER));
+    }
+
+    #[test]
+    fn test_permission_all_includes_player() {
+        let state = ConnectionState::new();
+        assert!(state.has_permission(PERMISSION_PLAYER));
+        assert_eq!(
+            PERMISSION_ALL,
+            PERMISSION_READ
+                | PERMISSION_ADD
+                | PERMISSION_CONTROL
+                | PERMISSION_ADMIN
+                | PERMISSION_PLAYER
+        );
     }
 }

--- a/rmpd-protocol/src/helpers.rs
+++ b/rmpd-protocol/src/helpers.rs
@@ -1,6 +1,6 @@
 //! Shared `pub(crate)` helpers for protocol command handlers.
 
-use crate::commands::utils::{ACK_ERROR_ARG, ACK_ERROR_SYS, build_filter};
+use crate::commands::utils::{ACK_ERROR_SYS, filter_parse_ack, parse_filter_args};
 use crate::response::ResponseBuilder;
 use crate::state::AppState;
 use rmpd_core::event::Event;
@@ -91,60 +91,20 @@ pub(crate) fn extract_audio_format(song: &Song) -> Option<AudioFormat> {
     }
 }
 
-/// `case_sensitive=true` → exact match (`find`), `false` → substring/FTS (`search`).
+/// `case_sensitive=true` → `find`-family semantics (case-sensitive equality
+/// by default), `false` → `search`-family (case-insensitive substring by
+/// default). Accepts both the modern `(...)` expression syntax and the
+/// legacy `TAG VALUE [TAG VALUE ...]` pair syntax; see
+/// [`rmpd_core::filter::FilterExpression`] for the shared grammar.
 pub(crate) fn resolve_filters(
     db: &rmpd_library::Database,
     filters: &[(String, String)],
     command: &str,
     case_sensitive: bool,
 ) -> Result<Vec<Song>, String> {
-    if filters.is_empty() {
-        return Err(ResponseBuilder::error(
-            ACK_ERROR_ARG,
-            0,
-            command,
-            "missing arguments",
-        ));
-    }
-
-    if filters[0].0.starts_with('(') {
-        match rmpd_core::filter::FilterExpression::parse(&filters[0].0) {
-            Ok(filter) => db.find_songs_filter(&filter).map_err(|e| {
-                ResponseBuilder::error(ACK_ERROR_SYS, 0, command, &format!("query error: {e}"))
-            }),
-            Err(e) => Err(ResponseBuilder::error(
-                ACK_ERROR_ARG,
-                0,
-                command,
-                &format!("filter parse error: {e}"),
-            )),
-        }
-    } else if filters.len() == 1 {
-        if case_sensitive {
-            db.find_songs(&filters[0].0, &filters[0].1).map_err(|e| {
-                ResponseBuilder::error(ACK_ERROR_SYS, 0, command, &format!("query error: {e}"))
-            })
-        } else {
-            let tag = &filters[0].0;
-            let value = &filters[0].1;
-            if tag.eq_ignore_ascii_case("any") {
-                db.search_songs(value).map_err(|e| {
-                    ResponseBuilder::error(ACK_ERROR_SYS, 0, command, &format!("search error: {e}"))
-                })
-            } else {
-                db.search_songs_by_tag(tag, value).map_err(|e| {
-                    ResponseBuilder::error(ACK_ERROR_SYS, 0, command, &format!("query error: {e}"))
-                })
-            }
-        }
-    } else {
-        let expr = if case_sensitive {
-            build_filter(filters, rmpd_core::filter::CompareOp::Equal)
-        } else {
-            build_filter(filters, rmpd_core::filter::CompareOp::Contains)
-        };
-        db.find_songs_filter(&expr).map_err(|e| {
-            ResponseBuilder::error(ACK_ERROR_SYS, 0, command, &format!("query error: {e}"))
-        })
-    }
+    let expr =
+        parse_filter_args(filters, !case_sensitive).map_err(|e| filter_parse_ack(command, &e))?;
+    db.find_songs_filter(&expr).map_err(|e| {
+        ResponseBuilder::error(ACK_ERROR_SYS, 0, command, &format!("query error: {e}"))
+    })
 }

--- a/rmpd-protocol/src/parser.rs
+++ b/rmpd-protocol/src/parser.rs
@@ -357,8 +357,8 @@ pub enum Command {
     },
     /// A `sticker` line whose subcommand isn't recognized. Carries
     /// `sticker_type` through so the handler validates the domain first
-    /// (MPD's `handle_sticker` resolves args[1] into a domain handler
-    /// before ever checking args[0]) and only reports "bad request" once
+    /// (MPD's `handle_sticker` resolves `args[1]` into a domain handler
+    /// before ever checking `args[0]`) and only reports "bad request" once
     /// the domain itself is valid.
     #[command(name = "sticker", permission = 8)]
     StickerInvalid { sticker_type: String },

--- a/rmpd-protocol/src/parser.rs
+++ b/rmpd-protocol/src/parser.rs
@@ -10,45 +10,51 @@ type PResult<O> = Result<O, ErrMode<ContextError>>;
 #[derive(Debug, Clone, PartialEq, rmpd_macros::CommandMetadata)]
 pub enum Command {
     // Playback control
-    #[command(name = "play", permission = 4)]
+    #[command(name = "play", permission = 16)]
     Play { position: Option<u32> },
-    #[command(name = "playid", permission = 4)]
+    #[command(name = "playid", permission = 16)]
     PlayId { id: Option<u32> },
-    #[command(name = "pause", permission = 4)]
+    #[command(name = "pause", permission = 16)]
     Pause { state: Option<bool> },
-    #[command(name = "stop", permission = 4)]
+    #[command(name = "stop", permission = 16)]
     Stop,
-    #[command(name = "next", permission = 4)]
+    #[command(name = "next", permission = 16)]
     Next,
-    #[command(name = "previous", permission = 4)]
+    #[command(name = "previous", permission = 16)]
     Previous,
-    #[command(name = "seek", permission = 4)]
+    #[command(name = "seek", permission = 16)]
     Seek { position: u32, time: f64 },
-    #[command(name = "seekid", permission = 4)]
+    #[command(name = "seekid", permission = 16)]
     SeekId { id: u32, time: f64 },
-    #[command(name = "seekcur", permission = 4)]
+    #[command(name = "seekcur", permission = 16)]
     SeekCur { time: f64, relative: bool },
 
     // Queue management
     #[command(name = "add", permission = 2)]
-    Add { uri: String, position: Option<u32> },
+    Add {
+        uri: String,
+        position: Option<InsertPosition>,
+    },
     #[command(name = "addid", permission = 2)]
-    AddId { uri: String, position: Option<u32> },
-    #[command(name = "delete", permission = 4)]
+    AddId {
+        uri: String,
+        position: Option<InsertPosition>,
+    },
+    #[command(name = "delete", permission = 16)]
     Delete { target: DeleteTarget },
-    #[command(name = "deleteid", permission = 4)]
+    #[command(name = "deleteid", permission = 16)]
     DeleteId { id: u32 },
-    #[command(name = "clear", permission = 4)]
+    #[command(name = "clear", permission = 16)]
     Clear,
-    #[command(name = "move", permission = 4)]
-    Move { from: MoveFrom, to: u32 },
-    #[command(name = "moveid", permission = 4)]
-    MoveId { id: u32, to: u32 },
-    #[command(name = "shuffle", permission = 4)]
+    #[command(name = "move", permission = 16)]
+    Move { from: MoveFrom, to: InsertPosition },
+    #[command(name = "moveid", permission = 16)]
+    MoveId { id: u32, to: InsertPosition },
+    #[command(name = "shuffle", permission = 16)]
     Shuffle { range: Option<(u32, u32)> },
-    #[command(name = "swap", permission = 4)]
+    #[command(name = "swap", permission = 16)]
     Swap { pos1: u32, pos2: u32 },
-    #[command(name = "swapid", permission = 4)]
+    #[command(name = "swapid", permission = 16)]
     SwapId { id1: u32, id2: u32 },
 
     // Status
@@ -58,7 +64,7 @@ pub enum Command {
     CurrentSong,
     #[command(name = "stats", permission = 1)]
     Stats,
-    #[command(name = "clearerror", permission = 4)]
+    #[command(name = "clearerror", permission = 16)]
     ClearError,
 
     // Queue inspection
@@ -79,30 +85,38 @@ pub enum Command {
         range: Option<(u32, u32)>,
     },
     #[command(name = "playlistfind", permission = 1)]
-    PlaylistFind { tag: String, value: String },
+    PlaylistFind {
+        filters: Vec<(String, String)>,
+        sort: Option<String>,
+        window: Option<(u32, u32)>,
+    },
     #[command(name = "playlistsearch", permission = 1)]
-    PlaylistSearch { tag: String, value: String },
+    PlaylistSearch {
+        filters: Vec<(String, String)>,
+        sort: Option<String>,
+        window: Option<(u32, u32)>,
+    },
 
     // Volume
-    #[command(name = "setvol", permission = 4)]
+    #[command(name = "setvol", permission = 16)]
     SetVol { volume: u8 },
-    #[command(name = "volume", permission = 4)]
+    #[command(name = "volume", permission = 16)]
     Volume { change: i32 },
     #[command(name = "getvol", permission = 1)]
     GetVol,
 
     // Options
-    #[command(name = "repeat", permission = 4)]
+    #[command(name = "repeat", permission = 16)]
     Repeat { enabled: bool },
-    #[command(name = "random", permission = 4)]
+    #[command(name = "random", permission = 16)]
     Random { enabled: bool },
-    #[command(name = "single", permission = 4)]
+    #[command(name = "single", permission = 16)]
     Single { mode: String },
-    #[command(name = "consume", permission = 4)]
+    #[command(name = "consume", permission = 16)]
     Consume { mode: String },
-    #[command(name = "crossfade", permission = 4)]
+    #[command(name = "crossfade", permission = 16)]
     Crossfade { seconds: u32 },
-    #[command(name = "replay_gain_mode", permission = 4)]
+    #[command(name = "replay_gain_mode", permission = 16)]
     ReplayGainMode { mode: String },
     #[command(name = "replay_gain_status", permission = 1)]
     ReplayGainStatus,
@@ -135,7 +149,9 @@ pub enum Command {
     #[command(name = "decoders", permission = 1)]
     Decoders,
     #[command(name = "stringnormalization")]
-    StringNormalization,
+    StringNormalization {
+        subcommand: Option<StringNormalizationSubcommand>,
+    },
 
     // Database
     #[command(name = "update", permission = 4)]
@@ -157,9 +173,9 @@ pub enum Command {
     #[command(name = "list", permission = 1)]
     List {
         tag: String,
-        filter_tag: Option<String>,
-        filter_value: Option<String>,
-        group: Option<String>,
+        filters: Vec<(String, String)>,
+        groups: Vec<String>,
+        window: Option<(u32, u32)>,
     },
     #[command(name = "listall", permission = 1)]
     ListAll { path: Option<String> },
@@ -174,8 +190,7 @@ pub enum Command {
     },
     #[command(name = "searchcount", permission = 1)]
     SearchCount {
-        tag: String,
-        value: String,
+        filters: Vec<(String, String)>,
         group: Option<String>,
     },
     #[command(name = "getfingerprint", permission = 1)]
@@ -191,15 +206,12 @@ pub enum Command {
 
     // Stored playlists
     #[command(name = "save", permission = 4)]
-    Save {
-        name: String,
-        mode: Option<SaveMode>,
-    },
+    Save { name: String, mode: Option<String> },
     #[command(name = "load", permission = 2)]
     Load {
         name: String,
         range: Option<(u32, u32)>,
-        position: Option<u32>,
+        position: Option<InsertPosition>,
     },
     #[command(name = "listplaylists", permission = 1)]
     ListPlaylists,
@@ -222,9 +234,13 @@ pub enum Command {
     #[command(name = "playlistclear", permission = 4)]
     PlaylistClear { name: String },
     #[command(name = "playlistdelete", permission = 4)]
-    PlaylistDelete { name: String, position: u32 },
+    PlaylistDelete { name: String, range: (u32, u32) },
     #[command(name = "playlistmove", permission = 4)]
-    PlaylistMove { name: String, from: u32, to: u32 },
+    PlaylistMove {
+        name: String,
+        from: (u32, u32),
+        to: u32,
+    },
     #[command(name = "rm", permission = 4)]
     Rm { name: String },
     #[command(name = "rename", permission = 4)]
@@ -232,14 +248,14 @@ pub enum Command {
     #[command(name = "searchplaylist", permission = 1)]
     SearchPlaylist {
         name: String,
-        tag: String,
-        value: String,
+        filters: Vec<(String, String)>,
+        window: Option<(u32, u32)>,
     },
     #[command(name = "playlistlength", permission = 1)]
     PlaylistLength { name: String },
 
     // Idle notifications
-    #[command(name = "idle")]
+    #[command(name = "idle", permission = 1)]
     Idle { subsystems: Vec<String> },
     #[command(name = "noidle")]
     NoIdle,
@@ -270,58 +286,91 @@ pub enum Command {
 
     // Advanced database
     #[command(name = "searchadd", permission = 2)]
-    SearchAdd { tag: String, value: String },
-    #[command(name = "searchaddpl", permission = 2)]
+    SearchAdd {
+        filters: Vec<(String, String)>,
+        sort: Option<String>,
+        window: Option<(u32, u32)>,
+        position: Option<InsertPosition>,
+    },
+    #[command(name = "searchaddpl", permission = 4)]
     SearchAddPl {
         name: String,
-        tag: String,
-        value: String,
+        filters: Vec<(String, String)>,
+        sort: Option<String>,
+        window: Option<(u32, u32)>,
+        position: Option<u32>,
     },
     #[command(name = "findadd", permission = 2)]
-    FindAdd { tag: String, value: String },
+    FindAdd {
+        filters: Vec<(String, String)>,
+        sort: Option<String>,
+        window: Option<(u32, u32)>,
+        position: Option<InsertPosition>,
+    },
     #[command(name = "listfiles", permission = 1)]
     ListFiles { uri: Option<String> },
 
     // Sticker database
-    #[command(name = "sticker", permission = 4)]
-    StickerGet { uri: String, name: String },
-    #[command(name = "sticker", permission = 4)]
+    #[command(name = "sticker", permission = 8)]
+    StickerGet {
+        sticker_type: String,
+        uri: String,
+        name: String,
+    },
+    #[command(name = "sticker", permission = 8)]
     StickerSet {
+        sticker_type: String,
         uri: String,
         name: String,
         value: String,
     },
-    #[command(name = "sticker", permission = 4)]
-    StickerDelete { uri: String, name: Option<String> },
-    #[command(name = "sticker", permission = 4)]
-    StickerList { uri: String },
-    #[command(name = "sticker", permission = 4)]
+    #[command(name = "sticker", permission = 8)]
+    StickerDelete {
+        sticker_type: String,
+        uri: String,
+        name: Option<String>,
+    },
+    #[command(name = "sticker", permission = 8)]
+    StickerList { sticker_type: String, uri: String },
+    #[command(name = "sticker", permission = 8)]
     StickerFind {
+        sticker_type: String,
         uri: String,
         name: String,
         value: Option<String>,
+        sort: Option<String>,
+        window: Option<(u32, u32)>,
     },
-    #[command(name = "sticker", permission = 4)]
+    #[command(name = "sticker", permission = 8)]
     StickerInc {
+        sticker_type: String,
         uri: String,
         name: String,
-        delta: Option<i32>,
+        delta: i32,
     },
-    #[command(name = "sticker", permission = 4)]
+    #[command(name = "sticker", permission = 8)]
     StickerDec {
+        sticker_type: String,
         uri: String,
         name: String,
-        delta: Option<i32>,
+        delta: i32,
     },
-    #[command(name = "stickernames", permission = 1)]
-    StickerNames { uri: Option<String> },
-    #[command(name = "stickertypes", permission = 1)]
+    /// A `sticker` line whose subcommand isn't recognized. Carries
+    /// `sticker_type` through so the handler validates the domain first
+    /// (MPD's `handle_sticker` resolves args[1] into a domain handler
+    /// before ever checking args[0]) and only reports "bad request" once
+    /// the domain itself is valid.
+    #[command(name = "sticker", permission = 8)]
+    StickerInvalid { sticker_type: String },
+    #[command(name = "stickernames", permission = 8)]
+    StickerNames,
+    #[command(name = "stickertypes", permission = 8)]
     StickerTypes,
-    #[command(name = "stickernamestypes", permission = 1)]
-    StickerNamesTypes { uri: Option<String> },
+    #[command(name = "stickernamestypes", permission = 8)]
+    StickerNamesTypes { sticker_type: Option<String> },
 
     // Partitions
-    #[command(name = "partition", permission = 4)]
+    #[command(name = "partition", permission = 1)]
     Partition { name: String },
     #[command(name = "listpartitions", permission = 1)]
     ListPartitions,
@@ -343,30 +392,30 @@ pub enum Command {
     ListNeighbors,
 
     // Client-to-client messaging
-    #[command(name = "subscribe", permission = 4)]
+    #[command(name = "subscribe", permission = 1)]
     Subscribe { channel: String },
-    #[command(name = "unsubscribe", permission = 4)]
+    #[command(name = "unsubscribe", permission = 1)]
     Unsubscribe { channel: String },
     #[command(name = "channels", permission = 1)]
     Channels,
-    #[command(name = "readmessages", permission = 4)]
+    #[command(name = "readmessages", permission = 1)]
     ReadMessages,
     #[command(name = "sendmessage", permission = 4)]
     SendMessage { channel: String, message: String },
 
     // Advanced queue operations
-    #[command(name = "prio", permission = 4)]
+    #[command(name = "prio", permission = 16)]
     Prio {
         priority: u8,
         ranges: Vec<(u32, u32)>,
     },
-    #[command(name = "prioid", permission = 4)]
+    #[command(name = "prioid", permission = 16)]
     PrioId { priority: u8, ids: Vec<u32> },
-    #[command(name = "rangeid", permission = 4)]
-    RangeId { id: u32, range: (f64, f64) },
-    #[command(name = "addtagid", permission = 4)]
+    #[command(name = "rangeid", permission = 2)]
+    RangeId { id: u32, range: Option<(f64, f64)> },
+    #[command(name = "addtagid", permission = 2)]
     AddTagId { id: u32, tag: String, value: String },
-    #[command(name = "cleartagid", permission = 4)]
+    #[command(name = "cleartagid", permission = 2)]
     ClearTagId { id: u32, tag: Option<String> },
 
     // Miscellaneous
@@ -374,9 +423,9 @@ pub enum Command {
     Config,
     #[command(name = "kill", permission = 8)]
     Kill,
-    #[command(name = "mixrampdb", permission = 4)]
+    #[command(name = "mixrampdb", permission = 16)]
     MixRampDb { decibels: f32 },
-    #[command(name = "mixrampdelay", permission = 4)]
+    #[command(name = "mixrampdelay", permission = 16)]
     MixRampDelay { seconds: f32 },
 
     // Unknown/Invalid
@@ -407,6 +456,15 @@ pub enum ProtocolSubcommand {
     Available,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum StringNormalizationSubcommand {
+    All,
+    Clear,
+    Enable { options: Vec<String> },
+    Disable { options: Vec<String> },
+    Available,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum DeleteTarget {
     Position(u32),
@@ -426,42 +484,148 @@ pub enum SaveMode {
     Replace, // Replace existing playlist
 }
 
+/// `load`'s POSITION argument: an absolute queue index, or a position
+/// relative to the currently playing song (`+N` after, `-N` before), as
+/// described for `addid` in the protocol docs. Resolved against the queue's
+/// length and current song by `resolve_insert_position` in the handler.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum InsertPosition {
+    Absolute(u32),
+    After(u32),
+    Before(u32),
+}
+
+thread_local! {
+    /// The exact MPD-style message for the most recent argument-*value*
+    /// failure (e.g. "Boolean (0/1) expected: X"), recorded by the token
+    /// parsers below via `arg_error`/`record_arg_error` right before they
+    /// fail. `parse_command`'s fallback surfaces it verbatim instead of a
+    /// generic arity message whenever the argument count is otherwise in
+    /// bounds — mirroring MPD's `command_check_request` (arity) running
+    /// before the handler's own `Request::ParseXxx` (value) calls.
+    static ARG_ERROR: std::cell::RefCell<Option<String>> = const { std::cell::RefCell::new(None) };
+}
+
+/// Record `msg` as the pending argument-value error without failing (used
+/// by helpers like `range_parts` that report failure via `Option`, not
+/// `PResult`).
+fn record_arg_error(msg: String) {
+    ARG_ERROR.with(|cell| *cell.borrow_mut() = Some(msg));
+}
+
+/// Record `msg` and return a `Cut` failure. `Cut` (unlike `Backtrack`) is
+/// never silently swallowed by `opt()`, so an optional argument that is
+/// *present but invalid* still surfaces as a real error rather than being
+/// treated as absent.
+fn arg_error(msg: String) -> ErrMode<ContextError> {
+    record_arg_error(msg);
+    ErrMode::Cut(ContextError::default())
+}
+
 pub fn parse_command(input: &str) -> Result<Command, String> {
     let input = input.trim();
     if input.is_empty() {
         return Err("Empty command".to_string());
     }
 
+    ARG_ERROR.with(|cell| *cell.borrow_mut() = None);
     command_parser.parse(input).map_err(|_| {
-        // Extract just the command name (first token) for a useful error message.
-        // If parsing fails after the command name is known, it is almost always an
-        // arg-count mismatch, so report "wrong number of arguments for \"cmd\"".
         let cmd_name = input.split_whitespace().next().unwrap_or(input);
-        // Commands with min=max args use "wrong number"; those with min<max use
-        // "too few". We use a small lookup table to match MPD exactly.
-        let too_few = matches!(
-            cmd_name,
-            "addid"
-                | "add"
-                | "find"
-                | "search"
-                | "list"
-                | "findadd"
-                | "searchadd"
-                | "searchaddpl"
-                | "listplaylist"
-                | "listplaylistinfo"
-                | "searchplaylist"
-                | "load"
-                | "save"
-                | "playlistfind"
-                | "playlistsearch"
-        );
-        if too_few {
-            format!("too few arguments for \"{cmd_name}\"")
-        } else {
-            format!("wrong number of arguments for \"{cmd_name}\"")
+        let rest = &input[cmd_name.len()..];
+        let Some((min, max)) = command_arity(cmd_name) else {
+            // Not a real MPD command (e.g. `command_list_begin` with extra
+            // arguments, or encountered a second time inside an active
+            // command list): MPD looks it up in `commands[]`, finds
+            // nothing, and reports it as unknown rather than a bad count.
+            return format!("unknown command \"{cmd_name}\"");
+        };
+        let take_value_error = || ARG_ERROR.with(|cell| cell.borrow_mut().take());
+        // MPD's `command_check_request` (arity) always runs before the
+        // handler's own value parsing, so a genuine count mismatch wins
+        // over any value error a token parser happened to record while
+        // walking the (too long/too short) argument list.
+        match count_args(rest) {
+            // `count_args` itself couldn't tokenize the argument list (e.g.
+            // an unquoted token containing a literal quote character,
+            // mirroring `Tokenizer::NextUnquoted`) — the count is unknown,
+            // so surface whatever specific error a primitive recorded.
+            None => take_value_error()
+                .unwrap_or_else(|| format!("wrong number of arguments for \"{cmd_name}\"")),
+            Some(n) => {
+                let n = n as i32;
+                if min == max && n != min {
+                    format!("wrong number of arguments for \"{cmd_name}\"")
+                } else if n < min {
+                    format!("too few arguments for \"{cmd_name}\"")
+                } else if max >= 0 && n > max {
+                    format!("too many arguments for \"{cmd_name}\"")
+                } else {
+                    // Argument count is within bounds: the failure is a bad
+                    // argument value, not an arity error. Use the specific
+                    // message a token parser recorded, if any.
+                    take_value_error()
+                        .unwrap_or_else(|| format!("wrong number of arguments for \"{cmd_name}\""))
+                }
+            }
         }
+    })
+}
+
+/// Counts argument tokens after the command name, using the same
+/// quote-aware tokenization as the real parsers. Returns `None` if the
+/// argument list itself is malformed (e.g. an unterminated quote).
+fn count_args(rest: &str) -> Option<usize> {
+    let mut rest = rest;
+    let mut n = 0usize;
+    loop {
+        let _: PResult<&str> = space0.parse_next(&mut rest);
+        if rest.is_empty() {
+            return Some(n);
+        }
+        parse_quoted_or_unquoted.parse_next(&mut rest).ok()?;
+        n += 1;
+    }
+}
+
+/// Per-command `(min, max)` argument-count bounds, mirroring the `commands[]`
+/// table in MPD's `src/command/AllCommands.cxx` (`max == -1` means
+/// unlimited). `close` and `kill` have unchecked arity in MPD (`min: -1`,
+/// "don't check args") and are omitted; their parser arms consume any
+/// trailing arguments instead of failing on them.
+fn command_arity(name: &str) -> Option<(i32, i32)> {
+    Some(match name {
+        "add" | "addid" | "cleartagid" | "listplaylist" | "listplaylistinfo" => (1, 2),
+        "addtagid" | "outputset" => (3, 3),
+        "albumart" | "readpicture" => (2, 2),
+        "binarylimit" | "consume" | "crossfade" | "delete" | "deleteid" | "delpartition"
+        | "disableoutput" | "enableoutput" | "getfingerprint" | "mixrampdb" | "mixrampdelay"
+        | "moveoutput" | "newpartition" | "partition" | "password" | "playlistclear"
+        | "playlistlength" | "random" | "readcomments" | "repeat" | "replay_gain_mode" | "rm"
+        | "setvol" | "single" | "subscribe" | "toggleoutput" | "unmount" | "unsubscribe"
+        | "volume" => (1, 1),
+        "channels" | "clear" | "clearerror" | "commands" | "config" | "currentsong"
+        | "decoders" | "getvol" | "listmounts" | "listneighbors" | "listpartitions"
+        | "listplaylists" | "next" | "notcommands" | "outputs" | "playlist" | "previous"
+        | "ping" | "readmessages" | "replay_gain_status" | "stats" | "status" | "stickernames"
+        | "stickertypes" | "stop" | "urlhandlers" => (0, 0),
+        "count" | "find" | "findadd" | "list" | "playlistfind" | "playlistsearch" | "search"
+        | "searchadd" | "searchcount" => (1, -1),
+        "idle" | "protocol" | "stringnormalization" | "tagtypes" => (0, -1),
+        "listall" | "listallinfo" | "listfiles" | "lsinfo" | "pause" | "play" | "playid"
+        | "playlistid" | "playlistinfo" | "rescan" | "shuffle" | "stickernamestypes" | "update" => {
+            (0, 1)
+        }
+        "load" => (1, 3),
+        "mount" | "move" | "moveid" | "playlistdelete" | "rangeid" | "rename" | "seek"
+        | "seekid" | "sendmessage" | "swap" | "swapid" => (2, 2),
+        "plchanges" | "plchangesposid" | "save" => (1, 2),
+        "playlistadd" => (2, 3),
+        "playlistmove" => (3, 3),
+        "sticker" => (3, -1),
+        "prio" | "prioid" | "searchaddpl" => (2, -1),
+        "searchplaylist" => (2, 4),
+        "seekcur" => (1, 1),
+        _ => return None,
     })
 }
 
@@ -534,13 +698,13 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
         "add" => {
             let uri = parse_quoted_or_unquoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
-            let position = opt(parse_u32_or_quoted).parse_next(input)?;
+            let position = opt(parse_insert_position).parse_next(input)?;
             Ok(Command::Add { uri, position })
         }
         "addid" => {
             let uri = parse_quoted_or_unquoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
-            let position = opt(parse_u32_or_quoted).parse_next(input)?;
+            let position = opt(parse_insert_position).parse_next(input)?;
             Ok(Command::AddId { uri, position })
         }
         "delete" => {
@@ -555,13 +719,13 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
         "move" => {
             let from = parse_move_from.parse_next(input)?;
             let _ = space0.parse_next(input)?;
-            let to = parse_u32_or_quoted.parse_next(input)?;
+            let to = parse_insert_position.parse_next(input)?;
             Ok(Command::Move { from, to })
         }
         "moveid" => {
             let id = parse_u32_or_quoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
-            let to = parse_u32_or_quoted.parse_next(input)?;
+            let to = parse_insert_position.parse_next(input)?;
             Ok(Command::MoveId { id, to })
         }
         "shuffle" => {
@@ -569,15 +733,15 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
             Ok(Command::Shuffle { range })
         }
         "swap" => {
-            let pos1 = parse_u32.parse_next(input)?;
+            let pos1 = parse_u32_or_quoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
-            let pos2 = parse_u32.parse_next(input)?;
+            let pos2 = parse_u32_or_quoted.parse_next(input)?;
             Ok(Command::Swap { pos1, pos2 })
         }
         "swapid" => {
-            let id1 = parse_u32.parse_next(input)?;
+            let id1 = parse_u32_or_quoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
-            let id2 = parse_u32.parse_next(input)?;
+            let id2 = parse_u32_or_quoted.parse_next(input)?;
             Ok(Command::SwapId { id1, id2 })
         }
         "status" => Ok(Command::Status),
@@ -606,16 +770,20 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
             Ok(Command::PlChangesPosId { version, range })
         }
         "playlistfind" => {
-            let tag = parse_string.parse_next(input)?;
-            let _ = space0.parse_next(input)?;
-            let value = parse_quoted_or_unquoted.parse_next(input)?;
-            Ok(Command::PlaylistFind { tag, value })
+            let (filters, sort, window) = parse_find_search_filters(input)?;
+            Ok(Command::PlaylistFind {
+                filters,
+                sort,
+                window,
+            })
         }
         "playlistsearch" => {
-            let tag = parse_string.parse_next(input)?;
-            let _ = space0.parse_next(input)?;
-            let value = parse_quoted_or_unquoted.parse_next(input)?;
-            Ok(Command::PlaylistSearch { tag, value })
+            let (filters, sort, window) = parse_find_search_filters(input)?;
+            Ok(Command::PlaylistSearch {
+                filters,
+                sort,
+                window,
+            })
         }
         "setvol" => {
             let val_str = parse_quoted_or_unquoted.parse_next(input)?;
@@ -628,7 +796,7 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
                 )),
                 Err(_) => Ok(Command::ArgError(
                     "setvol".into(),
-                    format!("Number too large: {val_str}"),
+                    format!("Integer expected: {val_str}"),
                     val_str,
                 )),
             }
@@ -699,15 +867,21 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
             }
         }
         "replay_gain_mode" => {
-            let mode = parse_string.parse_next(input)?;
+            let mode = parse_quoted_or_unquoted.parse_next(input)?;
             Ok(Command::ReplayGainMode { mode })
         }
         "replay_gain_status" => Ok(Command::ReplayGainStatus),
-        "close" => Ok(Command::Close),
+        // MPD's `close`/`kill` have unchecked arity (`AllCommands.cxx`:
+        // min = -1, "don't check args"): they accept and ignore any number
+        // of trailing arguments instead of failing on them.
+        "close" => {
+            *input = "";
+            Ok(Command::Close)
+        }
         "ping" => Ok(Command::Ping),
         "password" => {
-            let password = parse_string.parse_next(input)?;
-            Ok(Command::Password { password })
+            let secret = parse_quoted_or_unquoted.parse_next(input)?;
+            Ok(Command::Password { password: secret })
         }
         "binarylimit" => {
             let size = parse_u32_or_quoted.parse_next(input)?;
@@ -823,13 +997,58 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
         }
         "urlhandlers" => Ok(Command::UrlHandlers),
         "decoders" => Ok(Command::Decoders),
-        "stringnormalization" => Ok(Command::StringNormalization),
+        "stringnormalization" => {
+            if input.is_empty() {
+                Ok(Command::StringNormalization { subcommand: None })
+            } else {
+                let subcommand_str = parse_quoted_or_unquoted.parse_next(input)?;
+                let _ = space0.parse_next(input)?;
+
+                match subcommand_str.as_str() {
+                    "all" => Ok(Command::StringNormalization {
+                        subcommand: Some(StringNormalizationSubcommand::All),
+                    }),
+                    "clear" => Ok(Command::StringNormalization {
+                        subcommand: Some(StringNormalizationSubcommand::Clear),
+                    }),
+                    "available" => Ok(Command::StringNormalization {
+                        subcommand: Some(StringNormalizationSubcommand::Available),
+                    }),
+                    "enable" => {
+                        let mut options = Vec::new();
+                        while !input.is_empty() {
+                            let option = parse_quoted_or_unquoted.parse_next(input)?;
+                            options.push(option);
+                            let _ = space0.parse_next(input)?;
+                        }
+                        Ok(Command::StringNormalization {
+                            subcommand: Some(StringNormalizationSubcommand::Enable { options }),
+                        })
+                    }
+                    "disable" => {
+                        let mut options = Vec::new();
+                        while !input.is_empty() {
+                            let option = parse_quoted_or_unquoted.parse_next(input)?;
+                            options.push(option);
+                            let _ = space0.parse_next(input)?;
+                        }
+                        Ok(Command::StringNormalization {
+                            subcommand: Some(StringNormalizationSubcommand::Disable { options }),
+                        })
+                    }
+                    _ => Ok(Command::UnknownSubcmd(
+                        "stringnormalization".to_string(),
+                        subcommand_str,
+                    )),
+                }
+            }
+        }
         "update" => {
-            let path = opt(parse_string).parse_next(input)?;
+            let path = opt(parse_quoted_or_unquoted).parse_next(input)?;
             Ok(Command::Update { path })
         }
         "rescan" => {
-            let path = opt(parse_string).parse_next(input)?;
+            let path = opt(parse_quoted_or_unquoted).parse_next(input)?;
             Ok(Command::Rescan { path })
         }
         "find" => {
@@ -852,119 +1071,67 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
             let tag = parse_quoted_or_unquoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
 
-            // Try to parse optional filter or group
-            let saved_input = *input;
-            let next_token = opt(parse_quoted_or_unquoted)
-                .parse_next(input)?
-                .filter(|s| !s.is_empty()); // Filter out empty strings
-
-            let (filter_tag, filter_value, group) = if next_token.as_deref() == Some("group") {
-                // Format: list TAG group GROUPTYPE
+            // Collect the rest as a flat token list, then apply MPD's exact
+            // order of operations: strip trailing "window", then check the
+            // legacy 3-arg form, then strip repeated trailing "group TAG".
+            let mut tokens: Vec<String> = Vec::new();
+            loop {
                 let _ = space0.parse_next(input)?;
-                let group_type = opt(parse_quoted_or_unquoted)
-                    .parse_next(input)?
-                    .filter(|s| !s.is_empty());
-                (None, None, group_type)
-            } else if let Some(ft) = next_token.clone() {
-                if ft.starts_with('(') {
-                    // Filter expression: list TAG "(expr)" [group GROUPTYPE]
-                    let _ = space0.parse_next(input)?;
-
-                    // Check for optional "group" keyword
-                    let saved_input2 = *input;
-                    let group_keyword = opt(parse_quoted_or_unquoted)
-                        .parse_next(input)?
-                        .filter(|s| !s.is_empty());
-
-                    let group_type = if group_keyword.as_deref() == Some("group") {
-                        let _ = space0.parse_next(input)?;
-                        opt(parse_quoted_or_unquoted)
-                            .parse_next(input)?
-                            .filter(|s| !s.is_empty())
-                    } else {
-                        *input = saved_input2;
-                        None
-                    };
-
-                    (Some(ft), None, group_type)
-                } else {
-                    // Traditional: list TAG FILTER_TAG FILTER_VALUE [t2 v2 ...] [group GROUPTYPE]
-                    let _ = space0.parse_next(input)?;
-                    let fv = parse_quoted_or_unquoted.parse_next(input)?;
-                    let _ = space0.parse_next(input)?;
-
-                    // Collect additional filter pairs (MPD legacy multi-filter support)
-                    let mut extra_pairs: Vec<(String, String)> = Vec::new();
-                    loop {
-                        let saved_loop = *input;
-                        let maybe_tag = opt(parse_quoted_or_unquoted)
-                            .parse_next(input)?
-                            .filter(|s| !s.is_empty());
-                        match maybe_tag {
-                            None => break,
-                            Some(ref t) if t == "group" => {
-                                *input = saved_loop;
-                                break;
-                            }
-                            Some(t) => {
-                                // looks like another filter tag - read its value
-                                let _ = space0.parse_next(input)?;
-                                match opt(parse_quoted_or_unquoted).parse_next(input)? {
-                                    Some(v) if !v.is_empty() => {
-                                        extra_pairs.push((t, v));
-                                        let _ = space0.parse_next(input)?;
-                                    }
-                                    _ => {
-                                        // Couldn't read value; backtrack and stop
-                                        *input = saved_loop;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    // Check for optional "group" keyword
-                    let saved_input2 = *input;
-                    let group_keyword = opt(parse_quoted_or_unquoted)
-                        .parse_next(input)?
-                        .filter(|s| !s.is_empty());
-
-                    let group_type = if group_keyword.as_deref() == Some("group") {
-                        let _ = space0.parse_next(input)?;
-                        opt(parse_quoted_or_unquoted)
-                            .parse_next(input)?
-                            .filter(|s| !s.is_empty())
-                    } else {
-                        *input = saved_input2;
-                        None
-                    };
-
-                    // If we have extra pairs, build a combined expression string
-                    let (ft_out, fv_out) = if extra_pairs.is_empty() {
-                        (Some(ft.clone()), Some(fv))
-                    } else {
-                        // Build AND filter expression from all pairs
-                        let mut expr = format!("({} == {:?})", ft, fv);
-                        for (et, ev) in &extra_pairs {
-                            expr.push_str(&format!(" AND ({} == {:?})", et, ev));
-                        }
-                        (Some(expr), None)
-                    };
-
-                    (ft_out, fv_out, group_type)
+                if input.is_empty() {
+                    break;
                 }
+                tokens.push(parse_quoted_or_unquoted.parse_next(input)?);
+            }
+
+            let window = if tokens.len() >= 2 && tokens[tokens.len() - 2] == "window" {
+                let range_tok = tokens.pop().expect("checked len >= 2");
+                tokens.pop();
+                Some(range_parts(&range_tok).ok_or_else(|| ErrMode::Cut(ContextError::default()))?)
             } else {
-                // Format: list TAG
-                *input = saved_input;
-                (None, None, None)
+                None
+            };
+
+            // Legacy (< 0.12) 3-arg form: `list album ARTIST` — a single
+            // bare (non-expression) remaining token with no tag name.
+            if tokens.len() == 1 && !tokens[0].starts_with('(') {
+                if !tag.eq_ignore_ascii_case("album") {
+                    return Err(ErrMode::Cut(ContextError::default()));
+                }
+                let value = tokens.pop().expect("checked len == 1");
+                return Ok(Command::List {
+                    tag,
+                    filters: vec![("artist".to_string(), value)],
+                    groups: Vec::new(),
+                    window,
+                });
+            }
+
+            let mut groups = Vec::new();
+            while tokens.len() >= 2 && tokens[tokens.len() - 2] == "group" {
+                groups.push(tokens.pop().expect("checked len >= 2"));
+                tokens.pop();
+            }
+            groups.reverse();
+
+            let filters = if tokens.len() == 1 && tokens[0].starts_with('(') {
+                vec![(tokens.pop().expect("checked len == 1"), String::new())]
+            } else {
+                let mut pairs = Vec::new();
+                let mut it = tokens.into_iter();
+                while let Some(t) = it.next() {
+                    let Some(v) = it.next() else {
+                        return Err(ErrMode::Cut(ContextError::default()));
+                    };
+                    pairs.push((t, v));
+                }
+                pairs
             };
 
             Ok(Command::List {
                 tag,
-                filter_tag,
-                filter_value,
-                group,
+                filters,
+                groups,
+                window,
             })
         }
         "listall" => {
@@ -980,100 +1147,12 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
             Ok(Command::LsInfo { path })
         }
         "count" => {
-            let first = parse_quoted_or_unquoted.parse_next(input)?;
-            let _ = space0.parse_next(input)?;
-
-            // Check if this is a filter expression (starts with '(')
-            if first.starts_with('(') {
-                // Filter expression - treat as single filter
-                let filters = vec![(first, String::new())];
-
-                // Parse optional group
-                let group = if !input.is_empty() {
-                    let saved = *input;
-                    let keyword = opt(parse_quoted_or_unquoted).parse_next(input)?;
-                    if keyword.as_deref() == Some("group") {
-                        let _ = space0.parse_next(input)?;
-                        opt(parse_quoted_or_unquoted).parse_next(input)?
-                    } else {
-                        *input = saved;
-                        None
-                    }
-                } else {
-                    None
-                };
-
-                Ok(Command::Count { filters, group })
-            } else {
-                // Traditional syntax: TAG VALUE [TAG VALUE ...] [group GROUPTAG]
-                let mut filters = Vec::new();
-                // Check for "group" keyword on the first token
-                if first == "group" {
-                    let _ = space0.parse_next(input)?;
-                    let group = opt(parse_quoted_or_unquoted).parse_next(input)?;
-                    return Ok(Command::Count { filters, group });
-                }
-                let value = parse_quoted_or_unquoted.parse_next(input)?;
-                filters.push((first, value));
-
-                // Parse additional tag-value pairs
-                loop {
-                    let _ = space0.parse_next(input)?;
-                    if input.is_empty() {
-                        break;
-                    }
-                    let saved_input = *input;
-                    let tag = match opt(parse_quoted_or_unquoted).parse_next(input)? {
-                        Some(t) if !t.is_empty() => t,
-                        _ => break,
-                    };
-                    if tag == "group" {
-                        *input = saved_input;
-                        break;
-                    }
-
-                    let _ = space0.parse_next(input)?;
-                    let next_value = parse_quoted_or_unquoted.parse_next(input)?;
-                    filters.push((tag, next_value));
-                }
-
-                // Parse optional group
-                let _ = space0.parse_next(input)?;
-                let group = if !input.is_empty() {
-                    let keyword = opt(parse_quoted_or_unquoted).parse_next(input)?;
-                    if keyword.as_deref() == Some("group") {
-                        let _ = space0.parse_next(input)?;
-                        opt(parse_quoted_or_unquoted).parse_next(input)?
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
-
-                Ok(Command::Count { filters, group })
-            }
+            let (filters, group) = parse_count_filters(input)?;
+            Ok(Command::Count { filters, group })
         }
         "searchcount" => {
-            let tag = parse_string.parse_next(input)?;
-            let _ = space0.parse_next(input)?;
-            let value = parse_quoted_or_unquoted.parse_next(input)?;
-            let _ = space0.parse_next(input)?;
-            // Parse optional "group GROUPTAG" at end
-            let group = if !input.is_empty() {
-                let saved = *input;
-                let keyword = opt(parse_quoted_or_unquoted).parse_next(input)?;
-                if keyword.as_deref() == Some("group") {
-                    let _ = space0.parse_next(input)?;
-                    opt(parse_quoted_or_unquoted).parse_next(input)?
-                } else {
-                    *input = saved;
-                    None
-                }
-            } else {
-                None
-            };
-            Ok(Command::SearchCount { tag, value, group })
+            let (filters, group) = parse_count_filters(input)?;
+            Ok(Command::SearchCount { filters, group })
         }
         "getfingerprint" => {
             let uri = parse_quoted_or_unquoted.parse_next(input)?;
@@ -1105,15 +1184,11 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
             let name = parse_quoted_or_unquoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
 
-            // Try to parse optional mode
+            // The mode token is captured verbatim here; `handle_save_command`
+            // validates it against 'create'/'append'/'replace' (case-sensitive,
+            // matching MPD) and reports MPD's exact ACK text on a bad value.
             let mode = if !input.is_empty() {
-                let mode_str = parse_quoted_or_unquoted.parse_next(input)?;
-                match mode_str.to_lowercase().as_str() {
-                    "create" => Some(SaveMode::Create),
-                    "append" => Some(SaveMode::Append),
-                    "replace" => Some(SaveMode::Replace),
-                    _ => return Err(ErrMode::Cut(ContextError::default())),
-                }
+                Some(parse_quoted_or_unquoted.parse_next(input)?.to_string())
             } else {
                 None
             };
@@ -1124,13 +1199,14 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
             let name = parse_quoted_or_unquoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
 
-            // Try to parse optional range (START:END) — must contain colon
-            // to distinguish from the optional position argument that follows.
-            let range = opt(parse_colon_range).parse_next(input)?;
+            // RANGE and POSITION are purely positional, matching MPD's
+            // `Request::ParseOptional(1, RangeArg::All())`: a bare number in
+            // the second slot is a single-song range (e.g. "5" -> [5,6)),
+            // not a position — POSITION only exists once RANGE is present.
+            let range = opt(parse_range).parse_next(input)?;
             let _ = space0.parse_next(input)?;
 
-            // Try to parse optional position
-            let position = opt(parse_u32).parse_next(input)?;
+            let position = opt(parse_insert_position).parse_next(input)?;
 
             Ok(Command::Load {
                 name,
@@ -1156,7 +1232,7 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
             let _ = space0.parse_next(input)?;
             let uri = parse_quoted_or_unquoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
-            let position = opt(parse_u32).parse_next(input)?;
+            let position = opt(parse_u32_or_quoted).parse_next(input)?;
             Ok(Command::PlaylistAdd {
                 name,
                 uri,
@@ -1170,15 +1246,18 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
         "playlistdelete" => {
             let name = parse_quoted_or_unquoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
-            let position = parse_u32.parse_next(input)?;
-            Ok(Command::PlaylistDelete { name, position })
+            // MPD 0.24 accepts a range here, not just a single index; a bare
+            // number is a single-song range (matching `playlistmove`/list*).
+            let range = parse_range.parse_next(input)?;
+            Ok(Command::PlaylistDelete { name, range })
         }
         "playlistmove" => {
             let name = parse_quoted_or_unquoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
-            let from = parse_u32.parse_next(input)?;
+            // MPD 0.24 accepts a range for FROM, not just a single index.
+            let from = parse_range.parse_next(input)?;
             let _ = space0.parse_next(input)?;
-            let to = parse_u32.parse_next(input)?;
+            let to = parse_u32_or_quoted.parse_next(input)?;
             Ok(Command::PlaylistMove { name, from, to })
         }
         "rm" => {
@@ -1197,10 +1276,14 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
         "searchplaylist" => {
             let name = parse_quoted_or_unquoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
-            let tag = parse_string.parse_next(input)?;
-            let _ = space0.parse_next(input)?;
-            let value = parse_quoted_or_unquoted.parse_next(input)?;
-            Ok(Command::SearchPlaylist { name, tag, value })
+            // Same filter grammar as `find`/`search`; `searchplaylist` has no
+            // `sort` clause, so the parsed sort (if any) is simply discarded.
+            let (filters, _sort, window) = parse_find_search_filters(input)?;
+            Ok(Command::SearchPlaylist {
+                name,
+                filters,
+                window,
+            })
         }
         "playlistlength" => {
             let name = parse_quoted_or_unquoted.parse_next(input)?;
@@ -1214,7 +1297,7 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
                 if input.is_empty() {
                     break;
                 }
-                let subsystem = parse_string.parse_next(input)?;
+                let subsystem = parse_quoted_or_unquoted.parse_next(input)?;
                 if !subsystem.is_empty() {
                     subsystems.push(subsystem);
                 }
@@ -1248,24 +1331,34 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
         "command_list_end" => Ok(Command::CommandListEnd),
         // Advanced database
         "searchadd" => {
-            let tag = parse_string.parse_next(input)?;
-            let _ = space0.parse_next(input)?;
-            let value = parse_quoted_or_unquoted.parse_next(input)?;
-            Ok(Command::SearchAdd { tag, value })
+            let (filters, sort, window, position) = parse_add_filters(input)?;
+            Ok(Command::SearchAdd {
+                filters,
+                sort,
+                window,
+                position,
+            })
         }
         "searchaddpl" => {
             let name = parse_quoted_or_unquoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
-            let tag = parse_string.parse_next(input)?;
-            let _ = space0.parse_next(input)?;
-            let value = parse_quoted_or_unquoted.parse_next(input)?;
-            Ok(Command::SearchAddPl { name, tag, value })
+            let (filters, sort, window, position) = parse_searchaddpl_filters(input)?;
+            Ok(Command::SearchAddPl {
+                name,
+                filters,
+                sort,
+                window,
+                position,
+            })
         }
         "findadd" => {
-            let tag = parse_string.parse_next(input)?;
-            let _ = space0.parse_next(input)?;
-            let value = parse_quoted_or_unquoted.parse_next(input)?;
-            Ok(Command::FindAdd { tag, value })
+            let (filters, sort, window, position) = parse_add_filters(input)?;
+            Ok(Command::FindAdd {
+                filters,
+                sort,
+                window,
+                position,
+            })
         }
         "listfiles" => {
             let uri = opt(parse_quoted_or_unquoted).parse_next(input)?;
@@ -1275,7 +1368,7 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
         "sticker" => {
             let operation = parse_quoted_or_unquoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
-            let _type_str = parse_quoted_or_unquoted.parse_next(input)?; // "song" for now
+            let sticker_type = parse_quoted_or_unquoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
             let uri = parse_quoted_or_unquoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
@@ -1283,76 +1376,122 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
             match operation.as_str() {
                 "get" => {
                     let name = parse_quoted_or_unquoted.parse_next(input)?;
-                    Ok(Command::StickerGet { uri, name })
+                    Ok(Command::StickerGet {
+                        sticker_type,
+                        uri,
+                        name,
+                    })
                 }
                 "set" => {
                     let name = parse_quoted_or_unquoted.parse_next(input)?;
                     let _ = space0.parse_next(input)?;
                     let value = parse_quoted_or_unquoted.parse_next(input)?;
-                    Ok(Command::StickerSet { uri, name, value })
+                    Ok(Command::StickerSet {
+                        sticker_type,
+                        uri,
+                        name,
+                        value,
+                    })
                 }
                 "delete" => {
                     let name = opt(parse_quoted_or_unquoted).parse_next(input)?;
-                    Ok(Command::StickerDelete { uri, name })
+                    Ok(Command::StickerDelete {
+                        sticker_type,
+                        uri,
+                        name,
+                    })
                 }
-                "list" => Ok(Command::StickerList { uri }),
+                "list" => Ok(Command::StickerList { sticker_type, uri }),
                 "find" => {
                     let name = parse_quoted_or_unquoted.parse_next(input)?;
                     let _ = space0.parse_next(input)?;
-                    // Optional filter: [eq|ne|lt|gt|contains VALUE]
-                    // Known operators are encoded as "op\x00val" in the value field
-                    // so the handler can decode them without a Command enum change.
-                    let first = opt(parse_quoted_or_unquoted).parse_next(input)?;
-                    let _ = space0.parse_next(input)?;
-                    let second = opt(parse_quoted_or_unquoted).parse_next(input)?;
-                    let value = match (first, second) {
-                        (Some(op), Some(val))
-                            if matches!(op.as_str(), "eq" | "ne" | "lt" | "gt" | "contains") =>
+                    // Optional filter `OP VALUE` (`sticker/Match.hxx`'s
+                    // StickerOperator): "=" | "<" | ">" | "eq" | "lt" | "gt" |
+                    // "contains" | "starts_with". Anything else at this
+                    // position (including "sort"/"window") means no filter.
+                    // Known operators are encoded as "op\x00val" in the value
+                    // field so the handler can decode them without another
+                    // Command enum change.
+                    let saved = *input;
+                    let value = match opt(parse_quoted_or_unquoted).parse_next(input)? {
+                        Some(op)
+                            if matches!(
+                                op.as_str(),
+                                "=" | "<" | ">" | "eq" | "lt" | "gt" | "contains" | "starts_with"
+                            ) =>
                         {
-                            // Encode operator+value; handler decodes on '\x00' boundary.
+                            let _ = space0.parse_next(input)?;
+                            let val = parse_quoted_or_unquoted.parse_next(input)?;
                             Some(format!("{op}\x00{val}"))
                         }
-                        (Some(_), Some(val)) => Some(val),
-                        (Some(v), None) => Some(v),
-                        (None, _) => None,
+                        Some(tok) if tok == "sort" || tok == "window" || tok.is_empty() => {
+                            *input = saved;
+                            None
+                        }
+                        Some(_) => return Err(ErrMode::Cut(ContextError::default())),
+                        None => None,
                     };
-                    Ok(Command::StickerFind { uri, name, value })
+                    let (sort, window) = parse_sort_window(input)?;
+                    Ok(Command::StickerFind {
+                        sticker_type,
+                        uri,
+                        name,
+                        value,
+                        sort,
+                        window,
+                    })
                 }
                 "inc" => {
                     let name = parse_quoted_or_unquoted.parse_next(input)?;
                     let _ = space0.parse_next(input)?;
-                    let delta = opt(|input: &mut &str| {
-                        parse_quoted_or_unquoted
-                            .parse_next(input)?
-                            .parse::<i32>()
-                            .map_err(|_| ErrMode::Cut(ContextError::default()))
-                    })
-                    .parse_next(input)?;
-                    Ok(Command::StickerInc { uri, name, delta })
+                    // The delta argument is mandatory in real MPD (missing it
+                    // falls through to "bad request", matching an unrecognized
+                    // subcommand); a present-but-non-numeric value is still a
+                    // valid call, coerced like SQLite's `value + ?` (0 for junk).
+                    match opt(parse_quoted_or_unquoted).parse_next(input)? {
+                        Some(value_str) => Ok(Command::StickerInc {
+                            sticker_type,
+                            uri,
+                            name,
+                            delta: sticker_delta_cast(&value_str),
+                        }),
+                        None => {
+                            *input = "";
+                            Ok(Command::StickerInvalid { sticker_type })
+                        }
+                    }
                 }
                 "dec" => {
                     let name = parse_quoted_or_unquoted.parse_next(input)?;
                     let _ = space0.parse_next(input)?;
-                    let delta = opt(|input: &mut &str| {
-                        parse_quoted_or_unquoted
-                            .parse_next(input)?
-                            .parse::<i32>()
-                            .map_err(|_| ErrMode::Cut(ContextError::default()))
-                    })
-                    .parse_next(input)?;
-                    Ok(Command::StickerDec { uri, name, delta })
+                    match opt(parse_quoted_or_unquoted).parse_next(input)? {
+                        Some(value_str) => Ok(Command::StickerDec {
+                            sticker_type,
+                            uri,
+                            name,
+                            delta: sticker_delta_cast(&value_str),
+                        }),
+                        None => {
+                            *input = "";
+                            Ok(Command::StickerInvalid { sticker_type })
+                        }
+                    }
                 }
-                _ => Ok(Command::Unknown(format!("sticker {operation}"))),
+                _ => {
+                    // Domain is validated before the subcommand in real MPD
+                    // (StickerCommands.cxx resolves args[1] first); consume
+                    // any trailing tokens since the handler now owns the
+                    // "unknown domain" vs "bad request" distinction.
+                    *input = "";
+                    Ok(Command::StickerInvalid { sticker_type })
+                }
             }
         }
-        "stickernames" => {
-            let uri = opt(parse_quoted_or_unquoted).parse_next(input)?;
-            Ok(Command::StickerNames { uri })
-        }
+        "stickernames" => Ok(Command::StickerNames),
         "stickertypes" => Ok(Command::StickerTypes),
         "stickernamestypes" => {
-            let uri = opt(parse_quoted_or_unquoted).parse_next(input)?;
-            Ok(Command::StickerNamesTypes { uri })
+            let sticker_type = opt(parse_quoted_or_unquoted).parse_next(input)?;
+            Ok(Command::StickerNamesTypes { sticker_type })
         }
         // Partitions
         "partition" => {
@@ -1404,7 +1543,7 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
         }
         // Advanced queue
         "prio" => {
-            let priority = parse_u8.parse_next(input)?;
+            let priority = parse_u8_or_quoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
 
             // Parse first range (required)
@@ -1426,11 +1565,11 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
             Ok(Command::Prio { priority, ranges })
         }
         "prioid" => {
-            let priority = parse_u8.parse_next(input)?;
+            let priority = parse_u8_or_quoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
 
             // Parse first ID (required)
-            let first_id = parse_u32.parse_next(input)?;
+            let first_id = parse_u32_or_quoted.parse_next(input)?;
             let mut ids = vec![first_id];
 
             // Parse additional IDs (optional)
@@ -1439,7 +1578,7 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
                 if input.is_empty() {
                     break;
                 }
-                match opt(parse_u32).parse_next(input)? {
+                match opt(parse_u32_or_quoted).parse_next(input)? {
                     Some(id) => ids.push(id),
                     None => break,
                 }
@@ -1448,71 +1587,55 @@ fn command_parser(input: &mut &str) -> PResult<Command> {
             Ok(Command::PrioId { priority, ids })
         }
         "rangeid" => {
-            let id = parse_u32.parse_next(input)?;
+            let id = parse_u32_or_quoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
-            // MPD format: start:end (floats with colon separator)
-            // Both parts optional: ":" means clear range, "0.5:" means start only, etc.
-            let rest = input.trim();
-            let range = if let Some(colon_pos) = rest.find(':') {
-                let start_str = &rest[..colon_pos];
-                let end_str = &rest[colon_pos + 1..];
-                let start: Option<f64> = if start_str.is_empty() {
-                    None
-                } else {
-                    Some(start_str.parse().map_err(|_| {
-                        winnow::error::ErrMode::Backtrack(winnow::error::ContextError::new())
-                    })?)
-                };
-                let end: Option<f64> = if end_str.is_empty() {
-                    None
-                } else {
-                    Some(end_str.parse().map_err(|_| {
-                        winnow::error::ErrMode::Backtrack(winnow::error::ContextError::new())
-                    })?)
-                };
-                *input = "";
-                (start.unwrap_or(0.0), end.unwrap_or(0.0))
-            } else {
-                return Err(winnow::error::ErrMode::Backtrack(
-                    winnow::error::ContextError::new(),
-                ));
-            };
+            let tok = parse_quoted_or_unquoted.parse_next(input)?;
+            let range = parse_song_range(&tok).ok_or_else(|| arg_error("Bad range".to_string()))?;
             Ok(Command::RangeId { id, range })
         }
         "addtagid" => {
-            let id = parse_u32.parse_next(input)?;
+            let id = parse_u32_or_quoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
-            let tag = parse_string.parse_next(input)?;
+            let tag = parse_quoted_or_unquoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
             let value = parse_quoted_or_unquoted.parse_next(input)?;
             Ok(Command::AddTagId { id, tag, value })
         }
         "cleartagid" => {
-            let id = parse_u32.parse_next(input)?;
+            let id = parse_u32_or_quoted.parse_next(input)?;
             let _ = space0.parse_next(input)?;
-            let tag = opt(parse_string).parse_next(input)?;
+            let tag = opt(parse_quoted_or_unquoted).parse_next(input)?;
             Ok(Command::ClearTagId { id, tag })
         }
         // Miscellaneous
         "config" => Ok(Command::Config),
-        "kill" => Ok(Command::Kill),
+        "kill" => {
+            *input = "";
+            Ok(Command::Kill)
+        }
         "mixrampdb" => {
-            let decibels = parse_f64.parse_next(input)? as f32;
+            let decibels = parse_f64_or_quoted.parse_next(input)? as f32;
             Ok(Command::MixRampDb { decibels })
         }
         "mixrampdelay" => {
-            let seconds = parse_f64.parse_next(input)? as f32;
+            let seconds = parse_f64_or_quoted.parse_next(input)? as f32;
             Ok(Command::MixRampDelay { seconds })
         }
         _ => Ok(Command::Unknown(cmd.to_string())),
     }
 }
 
-fn parse_u32(input: &mut &str) -> PResult<u32> {
-    take_while(1.., |c: char| c.is_ascii_digit())
-        .parse_next(input)?
-        .parse()
-        .map_err(|_| ErrMode::Cut(ContextError::default()))
+/// Build MPD's exact message for a failed unsigned-integer parse ("Integer
+/// expected: X" for non-numeric, "Number too large: X" for overflow),
+/// matching `ParseCommandArgUnsigned` (ArgParser.cxx). `s` is always the
+/// whole original token, matching MPD's `MakeArgError`.
+fn integer_error(s: &str, kind: &std::num::IntErrorKind) -> String {
+    match kind {
+        std::num::IntErrorKind::PosOverflow | std::num::IntErrorKind::NegOverflow => {
+            format!("Number too large: {s}")
+        }
+        _ => format!("Integer expected: {s}"),
+    }
 }
 
 fn parse_u32_or_quoted(input: &mut &str) -> PResult<u32> {
@@ -1520,14 +1643,17 @@ fn parse_u32_or_quoted(input: &mut &str) -> PResult<u32> {
     if s.is_empty() {
         return Err(ErrMode::Backtrack(ContextError::default()));
     }
-    s.parse().map_err(|_| ErrMode::Cut(ContextError::default()))
+    s.parse()
+        .map_err(|e: std::num::ParseIntError| arg_error(integer_error(&s, e.kind())))
 }
 
-fn parse_u8(input: &mut &str) -> PResult<u8> {
-    take_while(1.., |c: char| c.is_ascii_digit())
-        .parse_next(input)?
-        .parse()
-        .map_err(|_| ErrMode::Cut(ContextError::default()))
+fn parse_u8_or_quoted(input: &mut &str) -> PResult<u8> {
+    let s = parse_quoted_or_unquoted.parse_next(input)?;
+    if s.is_empty() {
+        return Err(ErrMode::Backtrack(ContextError::default()));
+    }
+    s.parse()
+        .map_err(|e: std::num::ParseIntError| arg_error(integer_error(&s, e.kind())))
 }
 
 /// Parse a range argument (quote-aware): `START:END`, `START:`, or a bare
@@ -1540,61 +1666,74 @@ fn parse_range(input: &mut &str) -> PResult<(u32, u32)> {
     range_parts(&tok).ok_or(ErrMode::Cut(ContextError::default()))
 }
 
-/// Parse a range that requires a colon (for commands where a bare number
-/// is ambiguous with a following positional argument, e.g. `load`).
-fn parse_colon_range(input: &mut &str) -> PResult<(u32, u32)> {
+/// Parse a POSITION argument shared by `add`/`addid` (insert position) and
+/// the `move`/`moveid` destination: `+N`/`-N` (relative to the current
+/// song, as `ParseInsertPosition`/`ParseMoveDestination` do in MPD's
+/// `PositionArg.cxx`) or a plain absolute index. Resolved to an absolute
+/// queue index by the caller (`commands::queue`, `commands::playlists`).
+fn parse_insert_position(input: &mut &str) -> PResult<InsertPosition> {
     let tok = parse_quoted_or_unquoted.parse_next(input)?;
-    if !tok.contains(':') {
+    if tok.is_empty() {
         return Err(ErrMode::Backtrack(ContextError::default()));
     }
-    range_parts(&tok).ok_or(ErrMode::Cut(ContextError::default()))
+    let num = |digits: &str| -> Result<u32, ErrMode<ContextError>> {
+        digits
+            .parse()
+            .map_err(|e: std::num::ParseIntError| arg_error(integer_error(&tok, e.kind())))
+    };
+    if let Some(rest) = tok.strip_prefix('+') {
+        num(rest).map(InsertPosition::After)
+    } else if let Some(rest) = tok.strip_prefix('-') {
+        num(rest).map(InsertPosition::Before)
+    } else {
+        num(&tok).map(InsertPosition::Absolute)
+    }
 }
 
 fn parse_delete_target(input: &mut &str) -> PResult<DeleteTarget> {
     let tok = parse_quoted_or_unquoted.parse_next(input)?;
-    match tok.split_once(':') {
-        Some((a, b)) => {
-            let start: u32 = a
-                .parse()
-                .map_err(|_| ErrMode::Cut(ContextError::default()))?;
-            let end: u32 = b
-                .parse()
-                .map_err(|_| ErrMode::Cut(ContextError::default()))?;
-            if start > end {
-                return Err(ErrMode::Cut(ContextError::default()));
-            }
-            Ok(DeleteTarget::Range(start, end))
-        }
-        None => {
-            let pos = tok
-                .parse()
-                .map_err(|_| ErrMode::Cut(ContextError::default()))?;
-            Ok(DeleteTarget::Position(pos))
-        }
+    let (start, end) = range_parts(&tok).ok_or_else(|| ErrMode::Cut(ContextError::default()))?;
+    if tok.contains(':') {
+        Ok(DeleteTarget::Range(start, end))
+    } else {
+        Ok(DeleteTarget::Position(start))
     }
 }
 
 fn parse_move_from(input: &mut &str) -> PResult<MoveFrom> {
     let tok = parse_quoted_or_unquoted.parse_next(input)?;
-    match tok.split_once(':') {
-        Some((a, b)) => {
-            let start: u32 = a
-                .parse()
-                .map_err(|_| ErrMode::Cut(ContextError::default()))?;
-            let end: u32 = b
-                .parse()
-                .map_err(|_| ErrMode::Cut(ContextError::default()))?;
-            if start > end {
-                return Err(ErrMode::Cut(ContextError::default()));
-            }
-            Ok(MoveFrom::Range(start, end))
-        }
-        None => {
-            let pos = tok
-                .parse()
-                .map_err(|_| ErrMode::Cut(ContextError::default()))?;
-            Ok(MoveFrom::Position(pos))
-        }
+    let (start, end) = range_parts(&tok).ok_or_else(|| ErrMode::Cut(ContextError::default()))?;
+    if tok.contains(':') {
+        Ok(MoveFrom::Range(start, end))
+    } else {
+        Ok(MoveFrom::Position(start))
+    }
+}
+
+/// Parse `rangeid`'s `START:END` token: fractional-second offsets, both
+/// optional, mirroring MPD's `parse_time_range` (QueueCommands.cxx). An
+/// omitted side defaults to `0`; `end == 0` means "no upper bound". A token
+/// that resolves to `(0, 0)` (e.g. a bare `":"`) means "clear the range,
+/// play the whole song" and is reported as `None`.
+fn parse_song_range(s: &str) -> Option<Option<(f64, f64)>> {
+    let (start_str, end_str) = s.split_once(':')?;
+    let start: f64 = if start_str.is_empty() {
+        0.0
+    } else {
+        start_str.parse().ok()?
+    };
+    let end: f64 = if end_str.is_empty() {
+        0.0
+    } else {
+        end_str.parse().ok()?
+    };
+    if start < 0.0 || end < 0.0 || !(end == 0.0 || end > start) {
+        return None;
+    }
+    if start == 0.0 && end == 0.0 {
+        Some(None)
+    } else {
+        Some(Some((start, end)))
     }
 }
 
@@ -1602,24 +1741,42 @@ fn parse_move_from(input: &mut &str) -> PResult<MoveFrom> {
 /// `"NUM"`) into a half-open `[start, end)` pair. A bare number yields
 /// `[NUM, NUM+1)`. Returns `None` on malformed input or when `start > end`.
 fn range_parts(s: &str) -> Option<(u32, u32)> {
+    // A range token is unambiguous once present, so any failure below
+    // records MPD's exact `ParseCommandArgRange` (ArgParser.cxx) message;
+    // callers turn `None` into a `Cut` failure so `opt()` never swallows it.
+    let parse_component = |tok: &str| -> Option<u32> {
+        match tok.parse::<u32>() {
+            Ok(v) => Some(v),
+            Err(e) => {
+                let msg = if *e.kind() == std::num::IntErrorKind::PosOverflow {
+                    format!("Number too large: {s}")
+                } else {
+                    format!("Integer or range expected: {s}")
+                };
+                record_arg_error(msg);
+                None
+            }
+        }
+    };
     let (start, end) = match s.split_once(':') {
         Some((a, b)) => {
-            let start: u32 = a.parse().ok()?;
+            let start = parse_component(a)?;
             let end = if b.is_empty() {
                 u32::MAX
             } else {
-                b.parse().ok()?
+                parse_component(b)?
             };
             (start, end)
         }
         None => {
-            let start: u32 = s.parse().ok()?;
+            let start = parse_component(s)?;
             (start, start.saturating_add(1))
         }
     };
     // MPD rejects inverted ranges (e.g. "5:2") rather than treating them as
     // empty or auto-swapping the bounds.
     if start > end {
+        record_arg_error(format!("Malformed range: {s}"));
         return None;
     }
     Some((start, end))
@@ -1640,7 +1797,9 @@ fn parse_find_search_filters(
     } else {
         // Traditional syntax: tag value [tag value ...] [sort TAG] [window START:END]
         let mut filters = Vec::new();
-        let value = parse_quoted_or_unquoted.parse_next(input)?;
+        let value = parse_quoted_or_unquoted
+            .parse_next(input)
+            .map_err(|_| arg_error("Incorrect number of filter arguments".to_string()))?;
         filters.push((tag, value));
 
         loop {
@@ -1658,7 +1817,9 @@ fn parse_find_search_filters(
                 break;
             }
             let _ = space0.parse_next(input)?;
-            let next_value = parse_quoted_or_unquoted.parse_next(input)?;
+            let next_value = parse_quoted_or_unquoted
+                .parse_next(input)
+                .map_err(|_| arg_error("Incorrect number of filter arguments".to_string()))?;
             filters.push((next_token, next_value));
         }
         filters
@@ -1666,6 +1827,21 @@ fn parse_find_search_filters(
 
     let (sort, window) = parse_sort_window(input)?;
     Ok((filters, sort, window))
+}
+
+/// Coerce a `sticker inc`/`dec` value token the way SQLite's `value + ?`
+/// arithmetic does: a leading optional sign plus digits, 0 for anything else.
+fn sticker_delta_cast(s: &str) -> i32 {
+    let trimmed = s.trim_start();
+    let mut end = 0;
+    for (i, c) in trimmed.char_indices() {
+        if c.is_ascii_digit() || (i == 0 && (c == '-' || c == '+')) {
+            end = i + c.len_utf8();
+        } else {
+            break;
+        }
+    }
+    trimmed[..end].parse().unwrap_or(0)
 }
 
 /// Parse optional trailing `sort TAG` and `window START:END` clauses
@@ -1687,10 +1863,22 @@ fn parse_sort_window(input: &mut &str) -> PResult<(Option<String>, Option<(u32, 
         match keyword.as_str() {
             "sort" => {
                 let _ = space0.parse_next(input)?;
+                if input.is_empty() {
+                    // Mirrors MPD's song::Filter treating a bare trailing
+                    // `sort`/`window` keyword as an unpaired filter tag.
+                    return Err(arg_error(
+                        "Incorrect number of filter arguments".to_string(),
+                    ));
+                }
                 sort = Some(parse_quoted_or_unquoted.parse_next(input)?);
             }
             "window" => {
                 let _ = space0.parse_next(input)?;
+                if input.is_empty() {
+                    return Err(arg_error(
+                        "Incorrect number of filter arguments".to_string(),
+                    ));
+                }
                 window = Some(parse_range.parse_next(input)?);
             }
             _ => {
@@ -1702,13 +1890,276 @@ fn parse_sort_window(input: &mut &str) -> PResult<(Option<String>, Option<(u32, 
     Ok((sort, window))
 }
 
-fn parse_f64(input: &mut &str) -> PResult<f64> {
-    take_while(1.., |c: char| {
-        c.is_ascii_digit() || c == '.' || c == '-' || c == '+'
-    })
-    .parse_next(input)?
-    .parse()
-    .map_err(|_| ErrMode::Cut(ContextError::default()))
+/// Parse the filters and optional trailing `group GROUPTYPE` for `count`
+/// and `searchcount`. Filter grammar is identical to `find`/`search`; MPD's
+/// `count` accepts no `sort`/`window`, only `group`.
+fn parse_count_filters(input: &mut &str) -> PResult<(Vec<(String, String)>, Option<String>)> {
+    let tag = parse_quoted_or_unquoted.parse_next(input)?;
+    let _ = space0.parse_next(input)?;
+
+    if tag == "group" && !input.is_empty() {
+        // MPD only recognizes `group` as the trailing-clause marker when a
+        // tag name follows it (`args[size - 2] == "group"` in
+        // `handle_count_internal`); a bare "count group" with nothing after
+        // falls through to filter parsing instead, where the lone "group"
+        // token becomes a valueless filter tag.
+        let group = parse_quoted_or_unquoted.parse_next(input)?;
+        return Ok((Vec::new(), Some(group)));
+    }
+
+    let filters = if tag.starts_with('(') {
+        vec![(tag, String::new())]
+    } else {
+        let mut filters = Vec::new();
+        let value = parse_quoted_or_unquoted
+            .parse_next(input)
+            .map_err(|_| arg_error("Incorrect number of filter arguments".to_string()))?;
+        filters.push((tag, value));
+
+        loop {
+            let _ = space0.parse_next(input)?;
+            if input.is_empty() {
+                break;
+            }
+            let saved_input = *input;
+            let next_token = match opt(parse_quoted_or_unquoted).parse_next(input)? {
+                Some(t) if !t.is_empty() => t,
+                _ => break,
+            };
+            if next_token == "group" && !input.trim_start().is_empty() {
+                *input = saved_input;
+                break;
+            }
+            let _ = space0.parse_next(input)?;
+            let next_value = parse_quoted_or_unquoted
+                .parse_next(input)
+                .map_err(|_| arg_error("Incorrect number of filter arguments".to_string()))?;
+            filters.push((next_token, next_value));
+        }
+        filters
+    };
+
+    let _ = space0.parse_next(input)?;
+    let group = if !input.is_empty() {
+        let saved = *input;
+        let keyword = opt(parse_quoted_or_unquoted).parse_next(input)?;
+        if keyword.as_deref() == Some("group") && !input.trim_start().is_empty() {
+            let _ = space0.parse_next(input)?;
+            Some(parse_quoted_or_unquoted.parse_next(input)?)
+        } else {
+            *input = saved;
+            None
+        }
+    } else {
+        None
+    };
+
+    Ok((filters, group))
+}
+
+/// Parse the filter (parenthesized expression or legacy `TAG VALUE [...]`
+/// pairs), plus trailing `sort`/`window`/`position` clauses — shared by
+/// `findadd`/`searchadd`/`searchaddpl`. Filter grammar is identical to
+/// `find`/`search`; 0.24 adds the optional `position` clause.
+fn parse_add_filters(
+    input: &mut &str,
+) -> PResult<(
+    Vec<(String, String)>,
+    Option<String>,
+    Option<(u32, u32)>,
+    Option<InsertPosition>,
+)> {
+    let tag = parse_quoted_or_unquoted.parse_next(input)?;
+    let _ = space0.parse_next(input)?;
+
+    let filters = if tag.starts_with('(') {
+        vec![(tag, String::new())]
+    } else {
+        let mut filters = Vec::new();
+        let value = parse_quoted_or_unquoted
+            .parse_next(input)
+            .map_err(|_| arg_error("Incorrect number of filter arguments".to_string()))?;
+        filters.push((tag, value));
+
+        loop {
+            let _ = space0.parse_next(input)?;
+            if input.is_empty() {
+                break;
+            }
+            let saved_input = *input;
+            let next_token = match opt(parse_quoted_or_unquoted).parse_next(input)? {
+                Some(t) if !t.is_empty() => t,
+                _ => break,
+            };
+            if next_token == "sort" || next_token == "window" || next_token == "position" {
+                *input = saved_input;
+                break;
+            }
+            let _ = space0.parse_next(input)?;
+            let next_value = parse_quoted_or_unquoted
+                .parse_next(input)
+                .map_err(|_| arg_error("Incorrect number of filter arguments".to_string()))?;
+            filters.push((next_token, next_value));
+        }
+        filters
+    };
+
+    let (sort, window, position) = parse_sort_window_position(input)?;
+    Ok((filters, sort, window, position))
+}
+
+/// Parse optional trailing `sort TAG`, `window START:END`, and `position
+/// POS` clauses (quote-aware, any order); like [`parse_sort_window`] but
+/// also accepts the 0.24 `position` clause used by `findadd`/`searchadd`/
+/// `searchaddpl`.
+fn parse_sort_window_position(
+    input: &mut &str,
+) -> PResult<(Option<String>, Option<(u32, u32)>, Option<InsertPosition>)> {
+    let mut sort = None;
+    let mut window = None;
+    let mut position = None;
+    loop {
+        let _ = space0.parse_next(input)?;
+        if input.is_empty() {
+            break;
+        }
+        let saved_input = *input;
+        let keyword = match opt(parse_quoted_or_unquoted).parse_next(input)? {
+            Some(k) if !k.is_empty() => k,
+            _ => break,
+        };
+        match keyword.as_str() {
+            "sort" => {
+                let _ = space0.parse_next(input)?;
+                if input.is_empty() {
+                    return Err(arg_error(
+                        "Incorrect number of filter arguments".to_string(),
+                    ));
+                }
+                sort = Some(parse_quoted_or_unquoted.parse_next(input)?);
+            }
+            "window" => {
+                let _ = space0.parse_next(input)?;
+                if input.is_empty() {
+                    return Err(arg_error(
+                        "Incorrect number of filter arguments".to_string(),
+                    ));
+                }
+                window = Some(parse_range.parse_next(input)?);
+            }
+            "position" => {
+                let _ = space0.parse_next(input)?;
+                if input.is_empty() {
+                    return Err(arg_error(
+                        "Incorrect number of filter arguments".to_string(),
+                    ));
+                }
+                position = Some(parse_insert_position.parse_next(input)?);
+            }
+            _ => {
+                *input = saved_input;
+                break;
+            }
+        }
+    }
+    Ok((sort, window, position))
+}
+
+/// Like [`parse_add_filters`], but for `searchaddpl`: `position` is a plain
+/// absolute index (no `+N`/`-N`) since it inserts into a stored playlist
+/// file, not the queue — there's no "current song" to be relative to
+/// (unlike `searchadd`/`findadd`, `playlistadd` uses a plain index too).
+fn parse_searchaddpl_filters(
+    input: &mut &str,
+) -> PResult<(
+    Vec<(String, String)>,
+    Option<String>,
+    Option<(u32, u32)>,
+    Option<u32>,
+)> {
+    let tag = parse_quoted_or_unquoted.parse_next(input)?;
+    let _ = space0.parse_next(input)?;
+
+    let filters = if tag.starts_with('(') {
+        vec![(tag, String::new())]
+    } else {
+        let mut filters = Vec::new();
+        let value = parse_quoted_or_unquoted
+            .parse_next(input)
+            .map_err(|_| arg_error("Incorrect number of filter arguments".to_string()))?;
+        filters.push((tag, value));
+
+        loop {
+            let _ = space0.parse_next(input)?;
+            if input.is_empty() {
+                break;
+            }
+            let saved_input = *input;
+            let next_token = match opt(parse_quoted_or_unquoted).parse_next(input)? {
+                Some(t) if !t.is_empty() => t,
+                _ => break,
+            };
+            if next_token == "sort" || next_token == "window" || next_token == "position" {
+                *input = saved_input;
+                break;
+            }
+            let _ = space0.parse_next(input)?;
+            let next_value = parse_quoted_or_unquoted
+                .parse_next(input)
+                .map_err(|_| arg_error("Incorrect number of filter arguments".to_string()))?;
+            filters.push((next_token, next_value));
+        }
+        filters
+    };
+
+    let mut sort = None;
+    let mut window = None;
+    let mut position = None;
+    loop {
+        let _ = space0.parse_next(input)?;
+        if input.is_empty() {
+            break;
+        }
+        let saved_input = *input;
+        let keyword = match opt(parse_quoted_or_unquoted).parse_next(input)? {
+            Some(k) if !k.is_empty() => k,
+            _ => break,
+        };
+        match keyword.as_str() {
+            "sort" => {
+                let _ = space0.parse_next(input)?;
+                if input.is_empty() {
+                    return Err(arg_error(
+                        "Incorrect number of filter arguments".to_string(),
+                    ));
+                }
+                sort = Some(parse_quoted_or_unquoted.parse_next(input)?);
+            }
+            "window" => {
+                let _ = space0.parse_next(input)?;
+                if input.is_empty() {
+                    return Err(arg_error(
+                        "Incorrect number of filter arguments".to_string(),
+                    ));
+                }
+                window = Some(parse_range.parse_next(input)?);
+            }
+            "position" => {
+                let _ = space0.parse_next(input)?;
+                if input.is_empty() {
+                    return Err(arg_error(
+                        "Incorrect number of filter arguments".to_string(),
+                    ));
+                }
+                position = Some(parse_u32_or_quoted.parse_next(input)?);
+            }
+            _ => {
+                *input = saved_input;
+                break;
+            }
+        }
+    }
+    Ok((filters, sort, window, position))
 }
 
 fn parse_f64_or_quoted(input: &mut &str) -> PResult<f64> {
@@ -1716,7 +2167,8 @@ fn parse_f64_or_quoted(input: &mut &str) -> PResult<f64> {
     if s.is_empty() {
         return Err(ErrMode::Backtrack(ContextError::default()));
     }
-    s.parse().map_err(|_| ErrMode::Cut(ContextError::default()))
+    s.parse()
+        .map_err(|_| arg_error(format!("Float expected: {s}")))
 }
 
 fn parse_bool_or_quoted(input: &mut &str) -> PResult<bool> {
@@ -1725,14 +2177,19 @@ fn parse_bool_or_quoted(input: &mut &str) -> PResult<bool> {
         "0" => Ok(false),
         "1" => Ok(true),
         "" => Err(ErrMode::Backtrack(ContextError::default())),
-        _ => Err(ErrMode::Cut(ContextError::default())),
+        _ => Err(arg_error(format!("Boolean (0/1) expected: {s}"))),
     }
 }
 
 fn parse_string(input: &mut &str) -> PResult<String> {
-    take_till(1.., |c: char| c.is_whitespace() || c == '\n' || c == '\r')
-        .map(|s: &str| s.to_string())
-        .parse_next(input)
+    let tok =
+        take_till(1.., |c: char| c.is_whitespace() || c == '\n' || c == '\r').parse_next(input)?;
+    if tok.contains(['"', '\'']) {
+        // Mirrors `Tokenizer::NextUnquoted`: an unquoted token may not
+        // contain a literal quote character.
+        return Err(arg_error("Invalid unquoted character".to_string()));
+    }
+    Ok(tok.to_string())
 }
 
 fn parse_quoted_or_unquoted(input: &mut &str) -> PResult<String> {
@@ -1762,17 +2219,22 @@ fn parse_quoted_string(input: &mut &str) -> PResult<String> {
                         consumed += c.len_utf8();
                         result.push(c);
                     }
-                    None => return Err(ErrMode::Cut(ContextError::default())),
+                    None => return Err(arg_error("Missing closing '\"'".to_string())),
                 }
             }
             Some(c) => {
                 consumed += c.len_utf8();
                 result.push(c);
             }
-            None => return Err(ErrMode::Cut(ContextError::default())),
+            None => return Err(arg_error("Missing closing '\"'".to_string())),
         }
     }
     *input = &input[consumed..];
+    // Mirrors `Tokenizer::NextString`: a closing quote must be followed by
+    // whitespace or end-of-line, e.g. `"foo"bar` is rejected.
+    if !input.is_empty() && !input.starts_with(|c: char| c.is_whitespace()) {
+        return Err(arg_error("Space expected after closing '\"'".to_string()));
+    }
     Ok(result)
 }
 
@@ -2087,7 +2549,7 @@ mod tests {
             parse_command("move \"5:10\" \"2\"").unwrap(),
             Command::Move {
                 from: MoveFrom::Range(5, 10),
-                to: 2
+                to: InsertPosition::Absolute(2)
             }
         ));
         assert_eq!(
@@ -2125,12 +2587,14 @@ mod tests {
         assert_eq!(
             parse_command("sticker \"list\" \"song\" \"foo/bar.flac\"").unwrap(),
             Command::StickerList {
+                sticker_type: "song".to_string(),
                 uri: "foo/bar.flac".to_string()
             }
         );
         assert_eq!(
             parse_command("sticker \"set\" \"song\" \"foo.flac\" \"rating\" \"10\"").unwrap(),
             Command::StickerSet {
+                sticker_type: "song".to_string(),
                 uri: "foo.flac".to_string(),
                 name: "rating".to_string(),
                 value: "10".to_string(),
@@ -2139,6 +2603,7 @@ mod tests {
         assert_eq!(
             parse_command("sticker \"get\" \"song\" \"foo.flac\" \"rating\"").unwrap(),
             Command::StickerGet {
+                sticker_type: "song".to_string(),
                 uri: "foo.flac".to_string(),
                 name: "rating".to_string(),
             }

--- a/rmpd-protocol/src/response.rs
+++ b/rmpd-protocol/src/response.rs
@@ -133,7 +133,12 @@ impl ResponseBuilder {
         self
     }
 
-    pub fn status(&mut self, status: &PlayerStatus) -> &mut Self {
+    pub fn status(
+        &mut self,
+        status: &PlayerStatus,
+        partition: &str,
+        last_loaded_playlist: &str,
+    ) -> &mut Self {
         self.field("volume", status.volume);
         self.field("repeat", if status.repeat { 1 } else { 0 });
         self.field("random", if status.random { 1 } else { 0 });
@@ -152,14 +157,11 @@ impl ResponseBuilder {
         };
         self.field("consume", consume_val);
 
-        self.field("partition", "default");
+        self.field("partition", partition);
 
         self.field("playlist", status.playlist_version);
         self.field("playlistlength", status.playlist_length);
         self.field("mixrampdb", status.mixramp_db);
-        if status.mixramp_delay > 0.0 {
-            self.field("mixrampdelay", status.mixramp_delay);
-        }
 
         let state_str = match status.state {
             rmpd_core::state::PlayerState::Stop => "stop",
@@ -167,30 +169,35 @@ impl ResponseBuilder {
             rmpd_core::state::PlayerState::Pause => "pause",
         };
         self.field("state", state_str);
-        self.field("lastloadedplaylist", "");
+        self.field("lastloadedplaylist", last_loaded_playlist);
+
+        // MPD order: xfade then mixrampdelay, both only when non-default
+        // (PlayerCommands.cxx handle_status).
+        if status.crossfade > 0 {
+            self.field("xfade", status.crossfade);
+        }
+        if status.mixramp_delay > 0.0 {
+            self.field("mixrampdelay", status.mixramp_delay);
+        }
 
         if let Some(pos) = &status.current_song {
             self.field("song", pos.position);
             self.field("songid", pos.id);
         }
 
-        // Show time/elapsed/duration/bitrate/audio only when playing or paused (not stopped)
+        // time/elapsed/bitrate/duration/audio only when playing or paused
+        // (not stopped). time/elapsed/bitrate are unconditional in that
+        // state per MPD; duration and audio are individually optional.
         if !matches!(status.state, rmpd_core::state::PlayerState::Stop) {
-            if let Some(elapsed) = status.elapsed {
-                if let Some(duration) = status.duration {
-                    self.field(
-                        "time",
-                        format!("{}:{}", elapsed.as_secs(), duration.as_secs()),
-                    );
-                }
-                self.field("elapsed", format!("{:.3}", elapsed.as_secs_f64()));
-            }
-
+            let elapsed = status.elapsed.unwrap_or_default();
+            let duration_secs = status.duration.map(|d| d.as_secs()).unwrap_or(0);
+            self.field("time", format!("{}:{duration_secs}", elapsed.as_secs()));
+            self.field("elapsed", format!("{:.3}", elapsed.as_secs_f64()));
+            self.field("bitrate", status.bitrate.unwrap_or(0));
             self.optional_field(
                 "duration",
                 status.duration.map(|d| format!("{:.3}", d.as_secs_f64())),
             );
-            self.optional_field("bitrate", status.bitrate);
 
             if let Some(fmt) = status.audio_format {
                 self.field(
@@ -203,24 +210,40 @@ impl ResponseBuilder {
             }
         }
 
-        if let Some(next) = &status.next_song {
+        self.optional_field("updating_db", status.updating_db);
+        self.optional_field("error", status.error.as_ref());
+
+        // nextsong/nextsongid are printed last, matching handle_status, and
+        // only when there is a current song: MPD derives them from
+        // playlist::GetNextPosition(), which returns -1 whenever
+        // `current < 0` (Playlist.cxx:320), so a stopped player never
+        // reports a next song.
+        if let (Some(_), Some(next)) = (&status.current_song, &status.next_song) {
             self.field("nextsong", next.position);
             self.field("nextsongid", next.id);
         }
 
-        if status.crossfade > 0 {
-            self.field("xfade", status.crossfade);
-        }
-
-        self.optional_field("updating_db", status.updating_db);
-        self.optional_field("error", status.error.as_ref());
-
         self
     }
 
-    pub fn song(&mut self, song: &Song, position: Option<u32>, id: Option<u32>) -> &mut Self {
+    pub fn song(
+        &mut self,
+        song: &Song,
+        position: Option<u32>,
+        id: Option<u32>,
+        range: Option<(f64, f64)>,
+    ) -> &mut Self {
         self.field("file", &song.path);
-        // MPD order: Last-Modified, Added, Format, tags in file insertion order, Time/duration, Pos/Id
+        // MPD order (SongPrint.cxx song_print_info): Range, Last-Modified,
+        // Added, Format, tags in file insertion order, Time/duration, then
+        // Pos/Id/Prio appended by the caller (queue/Print.cxx).
+        if let Some((start, end)) = range {
+            if end > 0.0 {
+                self.field("Range", format!("{start:.3}-{end:.3}"));
+            } else if start > 0.0 {
+                self.field("Range", format!("{start:.3}-"));
+            }
+        }
         if song.last_modified > 0 {
             let ts = crate::commands::utils::format_iso8601_timestamp(song.last_modified);
             self.field("Last-Modified", &ts);
@@ -269,7 +292,11 @@ impl ResponseBuilder {
         self.field("albums", stats.albums);
         self.field("songs", stats.songs);
         self.field("db_playtime", stats.db_playtime);
-        self.field("db_update", stats.db_update);
+        // MPD omits db_update when the database has never been updated
+        // (db.GetUpdateStamp() negative -> Stats.cxx db_stats_print).
+        if stats.db_update > 0 {
+            self.field("db_update", stats.db_update);
+        }
         self
     }
 }
@@ -314,7 +341,7 @@ mod tests {
     #[test]
     fn source_song_emits_format_line_and_keeps_extension() {
         let mut rb = ResponseBuilder::new();
-        rb.song(&source_song(), None, None);
+        rb.song(&source_song(), None, None, None);
         let out = rb.ok();
 
         assert!(
@@ -325,5 +352,174 @@ mod tests {
             out.contains("file: alarm-music/Artist/Album/song-1.flac"),
             "expected mount-style file line with .flac extension, got:\n{out}"
         );
+    }
+
+    fn base_status() -> PlayerStatus {
+        PlayerStatus::default()
+    }
+
+    /// Regression: `mixrampdelay` and `xfade` must be emitted after `state`
+    /// and `lastloadedplaylist`, and `nextsong`/`nextsongid` must be the
+    /// very last fields — matching PlayerCommands.cxx handle_status, not
+    /// the previous interleaved order.
+    #[test]
+    fn status_field_order_matches_mpd() {
+        let mut status = base_status();
+        status.state = rmpd_core::state::PlayerState::Play;
+        status.crossfade = 5;
+        status.mixramp_delay = 2.5;
+        status.current_song = Some(rmpd_core::state::QueuePosition { position: 0, id: 1 });
+        status.next_song = Some(rmpd_core::state::QueuePosition { position: 1, id: 2 });
+        status.elapsed = Some(std::time::Duration::from_secs(10));
+        status.duration = Some(std::time::Duration::from_secs(200));
+        status.bitrate = Some(320);
+        status.updating_db = Some(3);
+        status.error = Some("boom".to_string());
+
+        let mut rb = ResponseBuilder::new();
+        rb.status(&status, "default", "");
+        let out = rb.ok();
+
+        let idx = |name: &str| {
+            out.find(&format!("{name}:"))
+                .unwrap_or_else(|| panic!("missing '{name}' in:\n{out}"))
+        };
+
+        assert!(idx("state") < idx("xfade"), "state before xfade:\n{out}");
+        assert!(
+            idx("xfade") < idx("mixrampdelay"),
+            "xfade before mixrampdelay:\n{out}"
+        );
+        assert!(
+            idx("mixrampdelay") < idx("song"),
+            "mixrampdelay before song:\n{out}"
+        );
+        assert!(idx("song") < idx("time"), "song before time:\n{out}");
+        assert!(idx("time") < idx("bitrate"), "time before bitrate:\n{out}");
+        assert!(
+            idx("bitrate") < idx("duration"),
+            "bitrate before duration:\n{out}"
+        );
+        assert!(
+            idx("error") < idx("nextsong"),
+            "error before nextsong:\n{out}"
+        );
+        assert!(
+            idx("nextsong") < idx("nextsongid"),
+            "nextsong before nextsongid:\n{out}"
+        );
+    }
+
+    /// While playing/paused, MPD always emits `time`/`elapsed`/`bitrate`
+    /// (defaulting duration to 0, bitrate to 0) even when the decoder hasn't
+    /// reported them yet; `duration` itself stays omitted when unknown.
+    #[test]
+    fn status_playing_defaults_time_and_bitrate_when_unknown() {
+        let mut status = base_status();
+        status.state = rmpd_core::state::PlayerState::Play;
+        status.elapsed = Some(std::time::Duration::from_secs(5));
+        status.duration = None;
+        status.bitrate = None;
+
+        let mut rb = ResponseBuilder::new();
+        rb.status(&status, "default", "");
+        let out = rb.ok();
+
+        assert!(out.contains("time: 5:0\n"), "got:\n{out}");
+        assert!(out.contains("elapsed: 5.000\n"), "got:\n{out}");
+        assert!(out.contains("bitrate: 0\n"), "got:\n{out}");
+        assert!(!out.contains("duration:"), "got:\n{out}");
+    }
+
+    /// Stopped state omits every playback-only field.
+    #[test]
+    fn status_stopped_omits_playback_fields() {
+        let status = base_status();
+        let mut rb = ResponseBuilder::new();
+        rb.status(&status, "default", "");
+        let out = rb.ok();
+
+        for field in [
+            "time:",
+            "elapsed:",
+            "bitrate:",
+            "duration:",
+            "audio:",
+            "song:",
+            "songid:",
+            "nextsong:",
+            "xfade:",
+            "mixrampdelay:",
+            "updating_db:",
+            "error:",
+        ] {
+            assert!(
+                !out.contains(field),
+                "unexpected '{field}' when stopped:\n{out}"
+            );
+        }
+    }
+
+    /// `Range` is positioned right after `file` (SongPrint.cxx PrintRange),
+    /// and formats an open-ended range without a trailing bound.
+    #[test]
+    fn song_range_field_placement_and_format() {
+        let mut rb = ResponseBuilder::new();
+        rb.song(&source_song(), Some(3), Some(7), Some((12.5, 60.0)));
+        let out = rb.ok();
+        assert!(out.contains("Range: 12.500-60.000\n"), "got:\n{out}");
+        let file_idx = out.find("file:").unwrap();
+        let range_idx = out.find("Range:").unwrap();
+        let format_idx = out.find("Format:").unwrap();
+        assert!(
+            file_idx < range_idx && range_idx < format_idx,
+            "got:\n{out}"
+        );
+
+        let mut rb2 = ResponseBuilder::new();
+        rb2.song(&source_song(), None, None, Some((12.5, 0.0)));
+        let out2 = rb2.ok();
+        assert!(out2.contains("Range: 12.500-\n"), "got:\n{out2}");
+
+        let mut rb3 = ResponseBuilder::new();
+        rb3.song(&source_song(), None, None, None);
+        let out3 = rb3.ok();
+        assert!(!out3.contains("Range:"), "got:\n{out3}");
+    }
+
+    /// MPD omits `db_update` entirely when the database has never been
+    /// updated (Stats.cxx db_stats_print: `IsNegative(update_stamp)`).
+    #[test]
+    fn stats_omits_db_update_when_never_updated() {
+        let stats = Stats {
+            artists: 0,
+            albums: 0,
+            songs: 0,
+            uptime: 10,
+            db_playtime: 0,
+            db_update: 0,
+            playtime: 0,
+        };
+        let mut rb = ResponseBuilder::new();
+        rb.stats(&stats);
+        let out = rb.ok();
+        assert!(!out.contains("db_update"), "got:\n{out}");
+    }
+
+    #[test]
+    fn stats_includes_db_update_when_present() {
+        let stats = Stats {
+            artists: 1,
+            albums: 1,
+            songs: 1,
+            uptime: 10,
+            db_playtime: 100,
+            db_update: 1_700_000_000,
+            playtime: 0,
+        };
+        let mut rb = ResponseBuilder::new();
+        rb.stats(&stats);
+        let out = rb.ok();
+        assert!(out.contains("db_update: 1700000000\n"), "got:\n{out}");
     }
 }

--- a/rmpd-protocol/src/server.rs
+++ b/rmpd-protocol/src/server.rs
@@ -39,30 +39,28 @@ const MAX_LINE_BYTES: usize = 64 * 1024;
 const MAX_COMMAND_LIST_BYTES: usize = 2 * 1024 * 1024;
 
 /// Convert a `parse_command` error into the correct ACK response string.
-/// Arg-count errors ("wrong number / too few arguments") → code 2;
-/// unknown-command errors → code 5.
+/// `parse_command` returns one of three message shapes: the complete,
+/// final `unknown command "X"` text (an unrecognized command name,
+/// including a nested command-list token or an empty line); a raw
+/// tokenizer failure mirroring MPD's `Tokenizer` exceptions ("Invalid
+/// unquoted character", "Missing closing '\"'", "Space expected after
+/// closing '\"'") — both of these are thrown/caught before the command name
+/// is ever looked up, so they get code 5 with an empty `{}` field, matching
+/// MPD's `Response::command` defaulting to ""; or anything else — an arity
+/// mismatch ("wrong number / too few / too many arguments for ...") or a
+/// handler-level value error a token parser recorded ("Boolean (0/1)
+/// expected: X", "Malformed range: X", "Incorrect number of filter
+/// arguments", ...) — which gets code 2 against the real command name.
 fn parse_error_to_ack(cmd_line: &str, err: &str, index: i32) -> String {
-    if err.starts_with("wrong number of arguments for") || err.starts_with("too few arguments for")
+    if err.starts_with("unknown command \"")
+        || err == "Invalid unquoted character"
+        || err == "Missing closing '\"'"
+        || err == "Space expected after closing '\"'"
     {
-        // Extract the command name from the double-quoted portion of `err`.
-        let cmd_name = err
-            .find('"')
-            .and_then(|s| {
-                let rest = &err[s + 1..];
-                rest.find('"').map(|e| &rest[..e])
-            })
-            .unwrap_or(cmd_line);
-        ResponseBuilder::error(ACK_ERROR_ARG, index, cmd_name, err)
-    } else {
-        // Unknown command or malformed syntax.
-        let cmd_name = cmd_line.split_whitespace().next().unwrap_or(cmd_line);
-        ResponseBuilder::error(
-            ACK_ERROR_UNKNOWN,
-            index,
-            cmd_name,
-            &format!("unknown command \"{cmd_name}\""),
-        )
+        return ResponseBuilder::error(ACK_ERROR_UNKNOWN, index, "", err);
     }
+    let cmd_name = cmd_line.split_whitespace().next().unwrap_or(cmd_line);
+    ResponseBuilder::error(ACK_ERROR_ARG, index, cmd_name, err)
 }
 
 /// Convert Unix timestamp to ISO 8601 format (RFC 3339)
@@ -276,7 +274,14 @@ async fn handle_client(
         .await?;
 
     let (reader, writer) = stream.into_split();
-    handle_client_inner(tokio::io::BufReader::new(reader), writer, state, timeout).await
+    handle_client_inner(
+        tokio::io::BufReader::new(reader),
+        writer,
+        state,
+        timeout,
+        false,
+    )
+    .await
 }
 
 async fn handle_unix_client(
@@ -290,7 +295,14 @@ async fn handle_unix_client(
         .await?;
 
     let (reader, writer) = stream.into_split();
-    handle_client_inner(tokio::io::BufReader::new(reader), writer, state, timeout).await
+    handle_client_inner(
+        tokio::io::BufReader::new(reader),
+        writer,
+        state,
+        timeout,
+        true,
+    )
+    .await
 }
 
 async fn handle_client_inner(
@@ -298,6 +310,7 @@ async fn handle_client_inner(
     mut writer: impl tokio::io::AsyncWrite + Unpin,
     state: AppState,
     timeout: std::time::Duration,
+    is_local: bool,
 ) -> Result<()> {
     let mut line = String::new();
 
@@ -306,6 +319,9 @@ async fn handle_client_inner(
 
     // Per-client connection state
     let mut conn_state = crate::ConnectionState::new();
+    // Mirrors MPD's Client::IsLocal(): true only for the Unix domain socket,
+    // never for TCP (gates `config` and the `file://` line of `urlhandlers`).
+    conn_state.is_local = is_local;
     // Grant full permissions immediately when no password is configured;
     // otherwise the client starts with zero permissions and must `password` in.
     if state.password.is_none() {
@@ -362,22 +378,40 @@ async fn handle_client_inner(
             break;
         }
 
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
+        let stripped = line.trim_end();
+        if !stripped
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_lowercase())
+        {
+            // MPD closes the connection immediately on any line that doesn't
+            // start with a lowercase ASCII letter — empty lines, leading
+            // whitespace, stray HTTP probes, etc. (Client::ProcessLine's
+            // IsLowerAlphaASCII check; no ACK is sent for this).
+            debug!("malformed command line, closing connection: {:?}", stripped);
+            break;
         }
 
+        if batch_mode && (stripped == "idle" || stripped == "noidle") {
+            // MPD: idle/noidle are async commands that can't be used inside a
+            // command list; the connection is closed immediately with no ACK
+            // (Client::ProcessLine's IsAsyncCommmand check).
+            debug!("async command {stripped:?} not allowed inside command list, closing");
+            break;
+        }
+
+        let trimmed = stripped;
         debug!("received command: {}", trimmed);
 
         let response = match parse_command(trimmed) {
-            Ok(Command::CommandListBegin) => {
+            Ok(Command::CommandListBegin) if !batch_mode => {
                 batch_mode = true;
                 batch_ok_mode = false;
                 batch_commands.clear();
                 batch_bytes = 0;
                 continue; // Don't send response yet
             }
-            Ok(Command::CommandListOkBegin) => {
+            Ok(Command::CommandListOkBegin) if !batch_mode => {
                 batch_mode = true;
                 batch_ok_mode = true;
                 batch_commands.clear();
@@ -386,14 +420,18 @@ async fn handle_client_inner(
             }
             Ok(Command::CommandListEnd) => {
                 if !batch_mode {
+                    // Real MPD has no dedicated "not in list" error:
+                    // `command_list_end` isn't in the `commands[]` table, so
+                    // outside a list it's looked up like any other name and
+                    // reported as unknown, same as a typo'd command.
                     Response::Text(ResponseBuilder::error(
-                        5,
+                        ACK_ERROR_UNKNOWN,
                         0,
-                        "command_list_end",
-                        "not in command list",
+                        "",
+                        "unknown command \"command_list_end\"",
                     ))
                 } else {
-                    let response = execute_command_list(
+                    let (response, should_close) = execute_command_list(
                         &batch_commands,
                         &state,
                         &mut conn_state,
@@ -404,11 +442,32 @@ async fn handle_client_inner(
                     batch_ok_mode = false;
                     batch_commands.clear();
                     batch_bytes = 0;
+                    if should_close {
+                        // `close` ran inside the list: send whatever partial
+                        // output preceded it, then drop the connection —
+                        // there's no final "OK" for a list that never
+                        // finished (matches MPD's `CommandResult::FINISH`).
+                        writer.write_all(response.as_bytes()).await?;
+                        writer.flush().await?;
+                        break;
+                    }
                     response
                 }
             }
             Ok(Command::Idle { subsystems }) if !batch_mode => {
-                Response::Text(handle_idle(&mut reader, &mut event_rx, subsystems).await)
+                // idle bypasses handle_command's generic permission check
+                // because it needs raw reader/event_rx access for long-poll;
+                // enforce the same PERMISSION_READ MPD requires here.
+                if !conn_state.has_permission(crate::connection::PERMISSION_READ) {
+                    Response::Text(ResponseBuilder::error(
+                        ACK_ERROR_PERMISSION,
+                        0,
+                        "idle",
+                        "you don't have permission for \"idle\"",
+                    ))
+                } else {
+                    Response::Text(handle_idle(&mut reader, &mut event_rx, subsystems).await)
+                }
             }
             Ok(_cmd) if batch_mode => {
                 // Accumulate commands in batch, capped so an unterminated
@@ -464,22 +523,53 @@ async fn execute_command_list(
     state: &AppState,
     conn_state: &mut crate::ConnectionState,
     ok_mode: bool,
-) -> Response {
+) -> (Response, bool) {
     let mut response = String::new();
 
     for (index, cmd_str) in commands.iter().enumerate() {
         match parse_command(cmd_str) {
             Ok(Command::Idle { .. }) => {
-                return Response::Text(ResponseBuilder::error(
-                    5,
-                    index as i32,
-                    "idle",
-                    "cannot be used inside a command list",
-                ));
+                return (
+                    Response::Text(ResponseBuilder::error(
+                        5,
+                        index as i32,
+                        "idle",
+                        "cannot be used inside a command list",
+                    )),
+                    false,
+                );
             }
             Ok(Command::NoIdle) => {
                 // Silently ignore noidle inside command list
                 continue;
+            }
+            Ok(Command::Close) => {
+                // MPD terminates the connection immediately when `close` runs
+                // inside a command list (`CommandResult::FINISH` short-circuits
+                // `ProcessCommandList`), emitting no further list output; the
+                // real `handle_command` dispatch for `Close` is unreachable by
+                // design, so it must never receive it here.
+                return (Response::Text(response), true);
+            }
+            Ok(
+                Command::CommandListBegin | Command::CommandListOkBegin | Command::CommandListEnd,
+            ) => {
+                // None of these are in MPD's `commands[]` table either — the
+                // top level treats them specially only when *not* already
+                // inside a list (`Client::ProcessLine` appends every other
+                // line verbatim once a list is active, with no nesting
+                // check). Encountered here, they're looked up like any
+                // other name and reported as unknown, aborting the list.
+                let name = cmd_str.split_whitespace().next().unwrap_or(cmd_str);
+                return (
+                    Response::Text(ResponseBuilder::error(
+                        5,
+                        index as i32,
+                        "",
+                        &format!("unknown command \"{name}\""),
+                    )),
+                    false,
+                );
             }
             Ok(cmd) => {
                 let cmd_response = handle_command(cmd, state, conn_state).await;
@@ -487,12 +577,15 @@ async fn execute_command_list(
                 let cmd_response_str = match cmd_response {
                     Response::Text(s) => s,
                     Response::Binary(_) => {
-                        return Response::Text(ResponseBuilder::error(
-                            5,
-                            index as i32,
-                            cmd_str,
-                            "binary commands not allowed in command list",
-                        ));
+                        return (
+                            Response::Text(ResponseBuilder::error(
+                                5,
+                                index as i32,
+                                cmd_str,
+                                "binary commands not allowed in command list",
+                            )),
+                            false,
+                        );
                     }
                 };
 
@@ -519,7 +612,7 @@ async fn execute_command_list(
                         cmd_response_str.clone()
                     };
                     response.push_str(&fixed);
-                    return Response::Text(response);
+                    return (Response::Text(response), false);
                 }
 
                 // Successful command: append response body (strip trailing "OK\n") to buffer
@@ -535,14 +628,17 @@ async fn execute_command_list(
             }
             Err(e) => {
                 // Parse error - return ACK with index
-                return Response::Text(parse_error_to_ack(cmd_str, &e, index as i32));
+                return (
+                    Response::Text(parse_error_to_ack(cmd_str, &e, index as i32)),
+                    false,
+                );
             }
         }
     }
 
     // All commands succeeded
     response.push_str("OK\n");
-    Response::Text(response)
+    (Response::Text(response), false)
 }
 
 async fn handle_idle(
@@ -552,6 +648,23 @@ async fn handle_idle(
 ) -> String {
     use rmpd_core::event::Subsystem;
     use tokio::sync::broadcast::error::RecvError;
+
+    const ALL_SUBSYSTEMS: [Subsystem; 14] = [
+        Subsystem::Database,
+        Subsystem::Update,
+        Subsystem::StoredPlaylist,
+        Subsystem::Playlist,
+        Subsystem::Player,
+        Subsystem::Mixer,
+        Subsystem::Output,
+        Subsystem::Options,
+        Subsystem::Partition,
+        Subsystem::Sticker,
+        Subsystem::Subscription,
+        Subsystem::Message,
+        Subsystem::Neighbor,
+        Subsystem::Mount,
+    ];
 
     // Convert string subsystems to enum
     let filter_subsystems: Vec<Subsystem> = if subsystems.is_empty() {
@@ -590,31 +703,58 @@ async fn handle_idle(
                 match event_result {
                     Ok(event) => {
                         debug!("idle received event: {:?}", event);
-                        let event_subsystems = event.subsystems();
 
-                        // Check if event matches any subscribed subsystem
-                        let matches = if filter_subsystems.is_empty() {
-                            // No filter - return any event
-                            !event_subsystems.is_empty()
-                        } else {
-                            // Check if event matches any filtered subsystem
-                            event_subsystems.iter().any(|s| filter_subsystems.contains(s))
-                        };
+                        // MPD accumulates every pending change and reports
+                        // them all in one reply ("lists all changed systems
+                        // in a line", protocol.rst command_idle). Drain any
+                        // further events already queued so simultaneous
+                        // changes produce multiple `changed:` lines instead
+                        // of one idle reply per event.
+                        let mut raw_subsystems: Vec<Subsystem> = event.subsystems().to_vec();
+                        while let Ok(next_event) = event_rx.try_recv() {
+                            raw_subsystems.extend_from_slice(next_event.subsystems());
+                        }
 
-                        debug!("event matches filter: {}, subsystems: {:?}", matches, event_subsystems);
+                        let mut changed: Vec<Subsystem> = Vec::new();
+                        for s in raw_subsystems {
+                            let included =
+                                filter_subsystems.is_empty() || filter_subsystems.contains(&s);
+                            if included && !changed.contains(&s) {
+                                changed.push(s);
+                            }
+                        }
 
-                        if matches {
-                            // Return changed subsystem
-                            let subsystem_name = subsystem_to_string(event_subsystems[0]);
-                            debug!("idle returning: changed: {}", subsystem_name);
-                            return format!("changed: {subsystem_name}\nOK\n");
+                        if !changed.is_empty() {
+                            debug!("idle returning changed: {:?}", changed);
+                            let mut resp = String::new();
+                            for s in &changed {
+                                resp.push_str("changed: ");
+                                resp.push_str(subsystem_to_string(*s));
+                                resp.push('\n');
+                            }
+                            resp.push_str("OK\n");
+                            return resp;
                         }
                     }
                     Err(RecvError::Lagged(skipped)) => {
-                        // Channel lagged - messages were dropped
-                        // Return immediately to notify client of changes
+                        // The channel overflowed; we no longer know exactly
+                        // which subsystems changed. Report every subsystem
+                        // the client is watching (or the full set when
+                        // unfiltered) rather than lose events.
                         debug!("idle: channel lagged, skipped {} messages", skipped);
-                        return "changed: player\nOK\n".to_owned();
+                        let reported: &[Subsystem] = if filter_subsystems.is_empty() {
+                            &ALL_SUBSYSTEMS
+                        } else {
+                            &filter_subsystems
+                        };
+                        let mut resp = String::new();
+                        for s in reported {
+                            resp.push_str("changed: ");
+                            resp.push_str(subsystem_to_string(*s));
+                            resp.push('\n');
+                        }
+                        resp.push_str("OK\n");
+                        return resp;
                     }
                     Err(RecvError::Closed) => {
                         // Channel closed - should not happen, but handle gracefully
@@ -698,9 +838,11 @@ async fn handle_command(
         Command::TagTypes { subcommand } => {
             reflection::handle_tagtypes_command(conn_state, subcommand).await
         }
-        Command::UrlHandlers => reflection::handle_urlhandlers_command().await,
+        Command::UrlHandlers => reflection::handle_urlhandlers_command(conn_state).await,
         Command::Decoders => reflection::handle_decoders_command().await,
-        Command::StringNormalization => reflection::handle_stringnormalization_command().await,
+        Command::StringNormalization { subcommand } => {
+            reflection::handle_stringnormalization_command(conn_state, subcommand).await
+        }
         Command::Status => {
             let status = {
                 let mut guard = state.status.write().await;
@@ -714,8 +856,13 @@ async fn handle_command(
                 guard.clone()
             };
 
+            let last_loaded_playlist = state.queue.read().await.last_loaded_playlist().to_string();
             let mut resp = ResponseBuilder::new();
-            resp.status(&status);
+            resp.status(
+                &status,
+                &conn_state.current_partition,
+                &last_loaded_playlist,
+            );
             resp.ok()
         }
         Command::Stats => {
@@ -752,8 +899,11 @@ async fn handle_command(
             state.status.write().await.error = None;
             ResponseBuilder::new().ok()
         }
-        Command::Update { path } | Command::Rescan { path } => {
-            database::handle_update_command(state, path.as_deref()).await
+        Command::Update { path } => {
+            database::handle_update_command(state, path.as_deref(), false).await
+        }
+        Command::Rescan { path } => {
+            database::handle_update_command(state, path.as_deref(), true).await
         }
         Command::Find {
             filters,
@@ -767,19 +917,10 @@ async fn handle_command(
         } => database::handle_search_command(state, &filters, sort.as_deref(), window).await,
         Command::List {
             tag,
-            filter_tag,
-            filter_value,
-            group,
-        } => {
-            database::handle_list_command(
-                state,
-                &tag,
-                filter_tag.as_deref(),
-                filter_value.as_deref(),
-                group.as_deref(),
-            )
-            .await
-        }
+            filters,
+            groups,
+            window,
+        } => database::handle_list_command(state, &tag, &filters, &groups, window).await,
         Command::Count { filters, group } => {
             database::handle_count_command(state, &filters, group.as_deref()).await
         }
@@ -800,12 +941,16 @@ async fn handle_command(
         Command::PlChangesPosId { version, range } => {
             queue::handle_plchangesposid_command(state, version, range).await
         }
-        Command::PlaylistFind { tag, value } => {
-            queue::handle_playlistfind_command(state, &tag, &value).await
-        }
-        Command::PlaylistSearch { tag, value } => {
-            queue::handle_playlistsearch_command(state, &tag, &value).await
-        }
+        Command::PlaylistFind {
+            filters,
+            sort,
+            window,
+        } => queue::handle_playlistfind_command(state, &filters, sort.as_deref(), window).await,
+        Command::PlaylistSearch {
+            filters,
+            sort,
+            window,
+        } => queue::handle_playlistsearch_command(state, &filters, sort.as_deref(), window).await,
         // Playback commands
         Command::Play { position } => playback::handle_play_command(state, position).await,
         Command::Pause { state: pause_state } => {
@@ -875,10 +1020,14 @@ async fn handle_command(
         }
         Command::ReplayGainStatus => options::handle_replaygain_status_command(state).await,
         Command::BinaryLimit { size } => {
-            // Set binary limit (for large responses like images)
-            // Store in connection state if needed, for now just acknowledge
-            let _ = size;
-            ResponseBuilder::new().ok()
+            // MPD (ClientCommands.cxx handle_binary_limit): rejects sizes
+            // below 64 bytes with "Value too small".
+            if size < 64 {
+                ResponseBuilder::error(ACK_ERROR_ARG, 0, "binarylimit", "Value too small")
+            } else {
+                conn_state.binary_limit = size;
+                ResponseBuilder::new().ok()
+            }
         }
         Command::Protocol { subcommand } => {
             reflection::handle_protocol_command(conn_state, subcommand).await
@@ -905,74 +1054,152 @@ async fn handle_command(
         Command::PlaylistClear { name } => {
             playlists::handle_playlistclear_command(state, &name).await
         }
-        Command::PlaylistDelete { name, position } => {
-            playlists::handle_playlistdelete_command(state, &name, position).await
+        Command::PlaylistDelete { name, range } => {
+            playlists::handle_playlistdelete_command(state, &name, range).await
         }
         Command::PlaylistMove { name, from, to } => {
             playlists::handle_playlistmove_command(state, &name, from, to).await
         }
         Command::Rm { name } => playlists::handle_rm_command(state, &name).await,
         Command::Rename { from, to } => playlists::handle_rename_command(state, &from, &to).await,
-        Command::SearchPlaylist { name, tag, value } => {
-            playlists::handle_searchplaylist_command(state, &name, &tag, &value).await
-        }
+        Command::SearchPlaylist {
+            name,
+            filters,
+            window,
+        } => playlists::handle_searchplaylist_command(state, &name, &filters, window).await,
         Command::PlaylistLength { name } => {
             playlists::handle_playlistlength_command(state, &name).await
         }
         // Output control
-        Command::Outputs => outputs::handle_outputs_command(state).await,
-        Command::EnableOutput { id } => outputs::handle_enableoutput_command(state, id).await,
-        Command::DisableOutput { id } => outputs::handle_disableoutput_command(state, id).await,
-        Command::ToggleOutput { id } => outputs::handle_toggleoutput_command(state, id).await,
+        Command::Outputs => {
+            outputs::handle_outputs_command(state, &conn_state.current_partition).await
+        }
+        Command::EnableOutput { id } => {
+            outputs::handle_enableoutput_command(state, &conn_state.current_partition, id).await
+        }
+        Command::DisableOutput { id } => {
+            outputs::handle_disableoutput_command(state, &conn_state.current_partition, id).await
+        }
+        Command::ToggleOutput { id } => {
+            outputs::handle_toggleoutput_command(state, &conn_state.current_partition, id).await
+        }
         Command::OutputSet { id, name, value } => {
-            outputs::handle_outputset_command(state, id, &name, &value).await
+            outputs::handle_outputset_command(
+                state,
+                &conn_state.current_partition,
+                id,
+                &name,
+                &value,
+            )
+            .await
         }
         // Advanced database
-        Command::SearchAdd { tag, value } => {
-            database::handle_searchadd_command(state, &tag, &value).await
+        Command::SearchAdd {
+            filters,
+            sort,
+            window,
+            position,
+        } => {
+            database::handle_searchadd_command(state, &filters, sort.as_deref(), window, position)
+                .await
         }
-        Command::SearchAddPl { name, tag, value } => {
-            playlists::handle_searchaddpl_command(state, &name, &tag, &value).await
+        Command::SearchAddPl {
+            name,
+            filters,
+            sort,
+            window,
+            position,
+        } => {
+            playlists::handle_searchaddpl_command(
+                state,
+                &name,
+                &filters,
+                sort.as_deref(),
+                window,
+                position,
+            )
+            .await
         }
-        Command::FindAdd { tag, value } => {
-            database::handle_findadd_command(state, &tag, &value).await
+        Command::FindAdd {
+            filters,
+            sort,
+            window,
+            position,
+        } => {
+            database::handle_findadd_command(state, &filters, sort.as_deref(), window, position)
+                .await
         }
         Command::ListFiles { uri } => {
             database::handle_listfiles_command(state, uri.as_deref()).await
         }
-        Command::SearchCount { tag, value, group } => {
-            database::handle_searchcount_command(state, &tag, &value, group.as_deref()).await
+        Command::SearchCount { filters, group } => {
+            database::handle_searchcount_command(state, &filters, group.as_deref()).await
         }
         Command::GetFingerprint { uri } => {
             fingerprint::handle_getfingerprint_command(state, &uri).await
         }
         Command::ReadComments { uri } => database::handle_readcomments_command(state, &uri).await,
         // Stickers
-        Command::StickerGet { uri, name } => {
-            stickers::handle_sticker_get_command(state, &uri, &name).await
+        Command::StickerGet {
+            sticker_type,
+            uri,
+            name,
+        } => stickers::handle_sticker_get_command(state, &sticker_type, &uri, &name).await,
+        Command::StickerSet {
+            sticker_type,
+            uri,
+            name,
+            value,
+        } => stickers::handle_sticker_set_command(state, &sticker_type, &uri, &name, &value).await,
+        Command::StickerDelete {
+            sticker_type,
+            uri,
+            name,
+        } => {
+            stickers::handle_sticker_delete_command(state, &sticker_type, &uri, name.as_deref())
+                .await
         }
-        Command::StickerSet { uri, name, value } => {
-            stickers::handle_sticker_set_command(state, &uri, &name, &value).await
+        Command::StickerList { sticker_type, uri } => {
+            stickers::handle_sticker_list_command(state, &sticker_type, &uri).await
         }
-        Command::StickerDelete { uri, name } => {
-            stickers::handle_sticker_delete_command(state, &uri, name.as_deref()).await
+        Command::StickerFind {
+            sticker_type,
+            uri,
+            name,
+            value,
+            sort,
+            window,
+        } => {
+            stickers::handle_sticker_find_command(
+                state,
+                &sticker_type,
+                &uri,
+                &name,
+                value.as_deref(),
+                sort.as_deref(),
+                window,
+            )
+            .await
         }
-        Command::StickerList { uri } => stickers::handle_sticker_list_command(state, &uri).await,
-        Command::StickerFind { uri, name, value } => {
-            stickers::handle_sticker_find_command(state, &uri, &name, value.as_deref()).await
+        Command::StickerInc {
+            sticker_type,
+            uri,
+            name,
+            delta,
+        } => stickers::handle_sticker_inc_command(state, &sticker_type, &uri, &name, delta).await,
+        Command::StickerDec {
+            sticker_type,
+            uri,
+            name,
+            delta,
+        } => stickers::handle_sticker_dec_command(state, &sticker_type, &uri, &name, delta).await,
+        Command::StickerInvalid { sticker_type } => {
+            stickers::handle_sticker_invalid_command(&sticker_type)
         }
-        Command::StickerInc { uri, name, delta } => {
-            stickers::handle_sticker_inc_command(state, &uri, &name, delta).await
-        }
-        Command::StickerDec { uri, name, delta } => {
-            stickers::handle_sticker_dec_command(state, &uri, &name, delta).await
-        }
-        Command::StickerNames { uri } => {
-            stickers::handle_sticker_names_command(state, uri.as_deref()).await
-        }
+        Command::StickerNames => stickers::handle_sticker_names_command(state).await,
         Command::StickerTypes => stickers::handle_sticker_types_command().await,
-        Command::StickerNamesTypes { uri } => {
-            stickers::handle_sticker_namestypes_command(state, uri.as_deref()).await
+        Command::StickerNamesTypes { sticker_type } => {
+            stickers::handle_sticker_namestypes_command(state, sticker_type.as_deref()).await
         }
         // Partitions
         Command::Partition { name } => {
@@ -1020,7 +1247,7 @@ async fn handle_command(
             queue::handle_cleartagid_command(state, id, tag.as_deref()).await
         }
         // Miscellaneous
-        Command::Config => connection::handle_config_command(state).await,
+        Command::Config => connection::handle_config_command(state, conn_state).await,
         Command::Kill => connection::handle_kill_command(state).await,
         Command::MixRampDb { decibels } => options::handle_mixrampdb_command(state, decibels).await,
         Command::MixRampDelay { seconds } => {

--- a/rmpd-protocol/src/state.rs
+++ b/rmpd-protocol/src/state.rs
@@ -182,38 +182,58 @@ impl AppState {
 
     /// Spawn a background library scan of the configured music directory.
     ///
-    /// Shared by the `update`/`rescan` commands and by auto-update on startup.
-    /// Returns immediately; the scan runs on a blocking task and reports
-    /// progress/results via the event bus and the tracing log. Does nothing if
-    /// the database or music directory is not configured.
-    pub fn spawn_library_update(&self) {
+    /// Shared by the `update`/`rescan` commands and by auto-update on
+    /// startup. `discard` forces re-reading every file's tags even if its
+    /// mtime hasn't advanced (MPD's `rescan`; `update` passes `false`).
+    ///
+    /// Persists an incrementing job id to `status.updating_db` for the scan's
+    /// duration (matching MPD's `status` response while a job is running)
+    /// and returns it, or `None` if the database/music directory isn't
+    /// configured. `Scanner::scan_directory` itself emits the
+    /// `update`/`database` idle events.
+    pub async fn spawn_library_update(&self, discard: bool) -> Option<u32> {
         let (Some(db_path), Some(music_dir)) = (self.db_path.clone(), self.music_dir.clone())
         else {
             tracing::warn!("library update requested but database/music_dir not configured");
-            return;
+            return None;
         };
-        let event_bus = self.event_bus.clone();
         let follow_symlinks = self.follow_symlinks;
+        let event_bus = self.event_bus.clone();
+        let status = self.status.clone();
 
-        tokio::task::spawn_blocking(move || {
-            tracing::info!("starting library update");
-            match rmpd_library::Database::open(&db_path) {
-                Ok(db) => {
-                    let scanner = rmpd_library::Scanner::new(event_bus.clone(), follow_symlinks);
-                    match scanner.scan_directory(&db, std::path::Path::new(&music_dir)) {
-                        Ok(stats) => tracing::info!(
-                            "library scan complete: {} scanned, {} added, {} updated, {} errors",
-                            stats.scanned,
-                            stats.added,
-                            stats.updated,
-                            stats.errors
-                        ),
-                        Err(e) => tracing::error!("library scan error: {}", e),
-                    }
-                }
-                Err(e) => tracing::error!("failed to open database for update: {}", e),
+        let job_id = {
+            let mut status_guard = self.status.write().await;
+            let next = status_guard.updating_db.map_or(1, |j| j + 1);
+            status_guard.updating_db = Some(next);
+            next
+        };
+
+        tokio::spawn(async move {
+            tracing::info!("starting library update (job {job_id})");
+            let result = tokio::task::spawn_blocking(move || {
+                let db = rmpd_library::Database::open(&db_path)?;
+                let scanner = rmpd_library::Scanner::new(event_bus, follow_symlinks)
+                    .with_force_rescan(discard);
+                scanner.scan_directory(&db, std::path::Path::new(&music_dir))
+            })
+            .await;
+
+            match result {
+                Ok(Ok(stats)) => tracing::info!(
+                    "library scan complete: {} scanned, {} added, {} updated, {} errors",
+                    stats.scanned,
+                    stats.added,
+                    stats.updated,
+                    stats.errors
+                ),
+                Ok(Err(e)) => tracing::error!("library update failed: {}", e),
+                Err(e) => tracing::error!("library update task panicked: {}", e),
             }
+
+            status.write().await.updating_db = None;
         });
+
+        Some(job_id)
     }
 
     /// Spawn a background source sync for every enabled music source.

--- a/rmpd-protocol/src/statefile.rs
+++ b/rmpd-protocol/src/statefile.rs
@@ -78,6 +78,13 @@ impl StateFile {
             content.push_str(&format!("audio_device_state:0:{name}\n"));
         }
 
+        // Last stored playlist loaded via `load` (MPD: PlaylistState.cxx,
+        // written unconditionally, empty when none has been loaded).
+        content.push_str(&format!(
+            "lastloadedplaylist: {}\n",
+            queue.last_loaded_playlist()
+        ));
+
         // Playlist
         content.push_str("playlist_begin\n");
         for item in queue.items() {
@@ -211,6 +218,9 @@ impl StateFile {
                         "replay_gain_mode" => {
                             state.replay_gain_mode = ReplayGainMode::parse_mode(value);
                         }
+                        "lastloadedplaylist" => {
+                            state.last_loaded_playlist = value.to_string();
+                        }
                         "audio_device_state" => {
                             // value is "STATE:NAME" where NAME may contain ':'
                             if let Some((state_str, name)) = value.split_once(':')
@@ -249,6 +259,9 @@ pub struct SavedState {
     pub replay_gain_mode: ReplayGainMode,
     pub playlist_paths: Vec<String>,
     pub disabled_outputs: Vec<String>,
+    /// Last stored playlist loaded via `load` before the state was saved
+    /// (MPD's `lastloadedplaylist`); empty when none had been loaded.
+    pub last_loaded_playlist: String,
 }
 
 #[cfg(test)]
@@ -269,6 +282,7 @@ mod tests {
         let mut queue = Queue::new();
         queue.add(make_test_song("/music/song1.mp3", 0));
         queue.add(make_test_song("/music/song2.mp3", 1));
+        queue.set_last_loaded_playlist("favorites");
 
         let status = PlayerStatus {
             volume: 75,
@@ -309,6 +323,7 @@ mod tests {
         assert_eq!(loaded.playlist_paths.len(), 2);
         assert_eq!(loaded.playlist_paths[0], "/music/song1.mp3");
         assert_eq!(loaded.playlist_paths[1], "/music/song2.mp3");
+        assert_eq!(loaded.last_loaded_playlist, "favorites");
     }
 
     #[tokio::test]

--- a/rmpd-protocol/tests/advanced_commands.rs
+++ b/rmpd-protocol/tests/advanced_commands.rs
@@ -1,6 +1,8 @@
 //! Integration tests for advanced commands (partitions, storage, messaging)
 
 mod common;
+#[path = "common/tcp_harness.rs"]
+mod tcp_harness;
 
 use common::TestClient;
 
@@ -74,39 +76,101 @@ fn test_listneighbors_command() {
 }
 
 // Client messaging commands
-#[test]
-fn test_subscribe_command() {
-    // subscribe should subscribe to a channel
-    let response = "OK\n";
-    assert!(TestClient::is_ok(response));
+
+#[tokio::test]
+async fn test_subscribe_command() {
+    let (_server, mut client) = tcp_harness::setup().await;
+    let response = client.command("subscribe test-channel").await;
+    tcp_harness::assert_ok(&response);
 }
 
-#[test]
-fn test_unsubscribe_command() {
-    // unsubscribe should unsubscribe from a channel
-    let response = "OK\n";
-    assert!(TestClient::is_ok(response));
+#[tokio::test]
+async fn test_subscribe_invalid_channel_name_rejected() {
+    let (_server, mut client) = tcp_harness::setup().await;
+    let response = client.command("subscribe \"bad channel!\"").await;
+    assert!(response.starts_with("ACK [2@0]"), "got: {response}");
 }
 
-#[test]
-fn test_channels_command() {
-    // channels should list available channels
-    let response = "OK\n";
-    assert!(TestClient::is_ok(response));
+#[tokio::test]
+async fn test_subscribe_duplicate_rejected() {
+    let (_server, mut client) = tcp_harness::setup().await;
+    tcp_harness::assert_ok(&client.command("subscribe test-channel").await);
+    let response = client.command("subscribe test-channel").await;
+    assert!(response.starts_with("ACK [56@0]"), "got: {response}");
 }
 
-#[test]
-fn test_readmessages_command() {
-    // readmessages should return messages
-    let response = "OK\n";
-    assert!(TestClient::is_ok(response));
+#[tokio::test]
+async fn test_subscribe_full_rejected() {
+    let (_server, mut client) = tcp_harness::setup().await;
+    for i in 0..16 {
+        tcp_harness::assert_ok(&client.command(&format!("subscribe chan{i}")).await);
+    }
+    let response = client.command("subscribe chan16").await;
+    assert!(response.starts_with("ACK [56@0]"), "got: {response}");
+    assert!(
+        response.contains("subscription list is full"),
+        "got: {response}"
+    );
 }
 
-#[test]
-fn test_sendmessage_command() {
-    // sendmessage should send a message to channel
-    let response = "OK\n";
-    assert!(TestClient::is_ok(response));
+#[tokio::test]
+async fn test_unsubscribe_command() {
+    let (_server, mut client) = tcp_harness::setup().await;
+    tcp_harness::assert_ok(&client.command("subscribe test-channel").await);
+    let response = client.command("unsubscribe test-channel").await;
+    tcp_harness::assert_ok(&response);
+}
+
+#[tokio::test]
+async fn test_unsubscribe_not_subscribed_rejected() {
+    let (_server, mut client) = tcp_harness::setup().await;
+    let response = client.command("unsubscribe never-subscribed").await;
+    assert!(response.starts_with("ACK [50@0]"), "got: {response}");
+}
+
+#[tokio::test]
+async fn test_channels_command_lists_subscriptions() {
+    let server = tcp_harness::MpdTestServer::start().await;
+    let mut a = tcp_harness::MpdTestClient::connect(server.port()).await;
+    tcp_harness::assert_ok(&a.command("subscribe test-channel").await);
+
+    let mut b = tcp_harness::MpdTestClient::connect(server.port()).await;
+    let response = b.command("channels").await;
+    assert!(
+        response.contains("channel: test-channel"),
+        "got: {response}"
+    );
+}
+
+#[tokio::test]
+async fn test_sendmessage_and_readmessages_roundtrip() {
+    let server = tcp_harness::MpdTestServer::start().await;
+    let mut receiver = tcp_harness::MpdTestClient::connect(server.port()).await;
+    tcp_harness::assert_ok(&receiver.command("subscribe test-channel").await);
+
+    let mut sender = tcp_harness::MpdTestClient::connect(server.port()).await;
+    tcp_harness::assert_ok(&sender.command("sendmessage test-channel \"hello\"").await);
+
+    let response = receiver.command("readmessages").await;
+    assert_eq!(response, "channel: test-channel\nmessage: hello\nOK\n");
+
+    // The queue is drained: a second read returns nothing.
+    let response = receiver.command("readmessages").await;
+    assert_eq!(response, "OK\n");
+}
+
+#[tokio::test]
+async fn test_sendmessage_no_subscribers_rejected() {
+    let (_server, mut client) = tcp_harness::setup().await;
+    let response = client.command("sendmessage nobody-here \"hi\"").await;
+    assert!(response.starts_with("ACK [50@0]"), "got: {response}");
+}
+
+#[tokio::test]
+async fn test_sendmessage_invalid_channel_name_rejected() {
+    let (_server, mut client) = tcp_harness::setup().await;
+    let response = client.command("sendmessage \"bad channel!\" \"hi\"").await;
+    assert!(response.starts_with("ACK [2@0]"), "got: {response}");
 }
 
 // Output commands

--- a/rmpd-protocol/tests/command_metadata.rs
+++ b/rmpd-protocol/tests/command_metadata.rs
@@ -1,10 +1,11 @@
-use rmpd_protocol::parser::{Command, DeleteTarget, MoveFrom};
+use rmpd_protocol::parser::{Command, DeleteTarget, InsertPosition, MoveFrom};
 
 const PERMISSION_NONE: u8 = 0;
 const PERMISSION_READ: u8 = 1;
 const PERMISSION_ADD: u8 = 2;
 const PERMISSION_CONTROL: u8 = 4;
 const PERMISSION_ADMIN: u8 = 8;
+const PERMISSION_PLAYER: u8 = 16;
 
 fn s(v: &str) -> String {
     v.to_string()
@@ -29,28 +30,24 @@ fn check(cmd: &Command, expected_name: &str, expected_perm: u8) {
 
 #[test]
 fn playback_control_metadata() {
-    check(
-        &Command::Play { position: None },
-        "play",
-        PERMISSION_CONTROL,
-    );
-    check(&Command::PlayId { id: None }, "playid", PERMISSION_CONTROL);
-    check(&Command::Pause { state: None }, "pause", PERMISSION_CONTROL);
-    check(&Command::Stop, "stop", PERMISSION_CONTROL);
-    check(&Command::Next, "next", PERMISSION_CONTROL);
-    check(&Command::Previous, "previous", PERMISSION_CONTROL);
+    check(&Command::Play { position: None }, "play", PERMISSION_PLAYER);
+    check(&Command::PlayId { id: None }, "playid", PERMISSION_PLAYER);
+    check(&Command::Pause { state: None }, "pause", PERMISSION_PLAYER);
+    check(&Command::Stop, "stop", PERMISSION_PLAYER);
+    check(&Command::Next, "next", PERMISSION_PLAYER);
+    check(&Command::Previous, "previous", PERMISSION_PLAYER);
     check(
         &Command::Seek {
             position: 0,
             time: 0.0,
         },
         "seek",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
     check(
         &Command::SeekId { id: 0, time: 0.0 },
         "seekid",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
     check(
         &Command::SeekCur {
@@ -58,7 +55,7 @@ fn playback_control_metadata() {
             relative: false,
         },
         "seekcur",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
 }
 
@@ -85,37 +82,40 @@ fn queue_management_metadata() {
             target: DeleteTarget::Position(0),
         },
         "delete",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
-    check(&Command::DeleteId { id: 0 }, "deleteid", PERMISSION_CONTROL);
-    check(&Command::Clear, "clear", PERMISSION_CONTROL);
+    check(&Command::DeleteId { id: 0 }, "deleteid", PERMISSION_PLAYER);
+    check(&Command::Clear, "clear", PERMISSION_PLAYER);
     check(
         &Command::Move {
             from: MoveFrom::Position(0),
-            to: 0,
+            to: InsertPosition::Absolute(0),
         },
         "move",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
     check(
-        &Command::MoveId { id: 0, to: 0 },
+        &Command::MoveId {
+            id: 0,
+            to: InsertPosition::Absolute(0),
+        },
         "moveid",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
     check(
         &Command::Shuffle { range: None },
         "shuffle",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
     check(
         &Command::Swap { pos1: 0, pos2: 0 },
         "swap",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
     check(
         &Command::SwapId { id1: 0, id2: 0 },
         "swapid",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
 }
 
@@ -124,7 +124,7 @@ fn status_metadata() {
     check(&Command::Status, "status", PERMISSION_READ);
     check(&Command::CurrentSong, "currentsong", PERMISSION_READ);
     check(&Command::Stats, "stats", PERMISSION_READ);
-    check(&Command::ClearError, "clearerror", PERMISSION_CONTROL);
+    check(&Command::ClearError, "clearerror", PERMISSION_PLAYER);
 }
 
 #[test]
@@ -158,16 +158,18 @@ fn queue_inspection_metadata() {
     );
     check(
         &Command::PlaylistFind {
-            tag: s(""),
-            value: s(""),
+            filters: vec![(s(""), s(""))],
+            sort: None,
+            window: None,
         },
         "playlistfind",
         PERMISSION_READ,
     );
     check(
         &Command::PlaylistSearch {
-            tag: s(""),
-            value: s(""),
+            filters: vec![(s(""), s(""))],
+            sort: None,
+            window: None,
         },
         "playlistsearch",
         PERMISSION_READ,
@@ -176,12 +178,8 @@ fn queue_inspection_metadata() {
 
 #[test]
 fn volume_metadata() {
-    check(
-        &Command::SetVol { volume: 50 },
-        "setvol",
-        PERMISSION_CONTROL,
-    );
-    check(&Command::Volume { change: 0 }, "volume", PERMISSION_CONTROL);
+    check(&Command::SetVol { volume: 50 }, "setvol", PERMISSION_PLAYER);
+    check(&Command::Volume { change: 0 }, "volume", PERMISSION_PLAYER);
     check(&Command::GetVol, "getvol", PERMISSION_READ);
 }
 
@@ -190,32 +188,32 @@ fn options_metadata() {
     check(
         &Command::Repeat { enabled: false },
         "repeat",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
     check(
         &Command::Random { enabled: false },
         "random",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
     check(
         &Command::Single { mode: s("0") },
         "single",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
     check(
         &Command::Consume { mode: s("0") },
         "consume",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
     check(
         &Command::Crossfade { seconds: 0 },
         "crossfade",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
     check(
         &Command::ReplayGainMode { mode: s("off") },
         "replay_gain_mode",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
     check(
         &Command::ReplayGainStatus,
@@ -257,7 +255,7 @@ fn reflection_metadata() {
     check(&Command::UrlHandlers, "urlhandlers", PERMISSION_READ);
     check(&Command::Decoders, "decoders", PERMISSION_READ);
     check(
-        &Command::StringNormalization,
+        &Command::StringNormalization { subcommand: None },
         "stringnormalization",
         PERMISSION_NONE,
     );
@@ -296,9 +294,9 @@ fn database_metadata() {
     check(
         &Command::List {
             tag: s(""),
-            filter_tag: None,
-            filter_value: None,
-            group: None,
+            filters: vec![],
+            groups: vec![],
+            window: None,
         },
         "list",
         PERMISSION_READ,
@@ -320,8 +318,7 @@ fn database_metadata() {
     );
     check(
         &Command::SearchCount {
-            tag: s(""),
-            value: s(""),
+            filters: vec![],
             group: None,
         },
         "searchcount",
@@ -412,7 +409,7 @@ fn stored_playlists_metadata() {
     check(
         &Command::PlaylistDelete {
             name: s(""),
-            position: 0,
+            range: (0, 0),
         },
         "playlistdelete",
         PERMISSION_CONTROL,
@@ -420,7 +417,7 @@ fn stored_playlists_metadata() {
     check(
         &Command::PlaylistMove {
             name: s(""),
-            from: 0,
+            from: (0, 0),
             to: 0,
         },
         "playlistmove",
@@ -438,8 +435,8 @@ fn stored_playlists_metadata() {
     check(
         &Command::SearchPlaylist {
             name: s(""),
-            tag: s(""),
-            value: s(""),
+            filters: vec![],
+            window: None,
         },
         "searchplaylist",
         PERMISSION_READ,
@@ -456,7 +453,7 @@ fn idle_metadata() {
     check(
         &Command::Idle { subsystems: vec![] },
         "idle",
-        PERMISSION_NONE,
+        PERMISSION_READ,
     );
     check(&Command::NoIdle, "noidle", PERMISSION_NONE);
 }
@@ -505,8 +502,10 @@ fn command_batching_metadata() {
 fn advanced_database_metadata() {
     check(
         &Command::SearchAdd {
-            tag: s(""),
-            value: s(""),
+            filters: vec![],
+            sort: None,
+            window: None,
+            position: None,
         },
         "searchadd",
         PERMISSION_ADD,
@@ -514,16 +513,20 @@ fn advanced_database_metadata() {
     check(
         &Command::SearchAddPl {
             name: s(""),
-            tag: s(""),
-            value: s(""),
+            filters: vec![],
+            sort: None,
+            window: None,
+            position: None,
         },
         "searchaddpl",
-        PERMISSION_ADD,
+        PERMISSION_CONTROL,
     );
     check(
         &Command::FindAdd {
-            tag: s(""),
-            value: s(""),
+            filters: vec![],
+            sort: None,
+            window: None,
+            position: None,
         },
         "findadd",
         PERMISSION_ADD,
@@ -539,71 +542,78 @@ fn advanced_database_metadata() {
 fn sticker_metadata() {
     check(
         &Command::StickerGet {
+            sticker_type: s("song"),
             uri: s(""),
             name: s(""),
         },
         "sticker",
-        PERMISSION_CONTROL,
+        PERMISSION_ADMIN,
     );
     check(
         &Command::StickerSet {
+            sticker_type: s("song"),
             uri: s(""),
             name: s(""),
             value: s(""),
         },
         "sticker",
-        PERMISSION_CONTROL,
+        PERMISSION_ADMIN,
     );
     check(
         &Command::StickerDelete {
+            sticker_type: s("song"),
             uri: s(""),
             name: None,
         },
         "sticker",
-        PERMISSION_CONTROL,
+        PERMISSION_ADMIN,
     );
     check(
-        &Command::StickerList { uri: s("") },
+        &Command::StickerList {
+            sticker_type: s("song"),
+            uri: s(""),
+        },
         "sticker",
-        PERMISSION_CONTROL,
+        PERMISSION_ADMIN,
     );
     check(
         &Command::StickerFind {
+            sticker_type: s("song"),
             uri: s(""),
             name: s(""),
             value: None,
+            sort: None,
+            window: None,
         },
         "sticker",
-        PERMISSION_CONTROL,
+        PERMISSION_ADMIN,
     );
     check(
         &Command::StickerInc {
+            sticker_type: s("song"),
             uri: s(""),
             name: s(""),
-            delta: None,
+            delta: 1,
         },
         "sticker",
-        PERMISSION_CONTROL,
+        PERMISSION_ADMIN,
     );
     check(
         &Command::StickerDec {
+            sticker_type: s("song"),
             uri: s(""),
             name: s(""),
-            delta: None,
+            delta: 1,
         },
         "sticker",
-        PERMISSION_CONTROL,
+        PERMISSION_ADMIN,
     );
+    check(&Command::StickerNames, "stickernames", PERMISSION_ADMIN);
+    check(&Command::StickerTypes, "stickertypes", PERMISSION_ADMIN);
     check(
-        &Command::StickerNames { uri: None },
-        "stickernames",
-        PERMISSION_READ,
-    );
-    check(&Command::StickerTypes, "stickertypes", PERMISSION_READ);
-    check(
-        &Command::StickerNamesTypes { uri: None },
+        &Command::StickerNamesTypes { sticker_type: None },
         "stickernamestypes",
-        PERMISSION_READ,
+        PERMISSION_ADMIN,
     );
 }
 
@@ -612,7 +622,7 @@ fn partition_metadata() {
     check(
         &Command::Partition { name: s("") },
         "partition",
-        PERMISSION_CONTROL,
+        PERMISSION_READ,
     );
     check(&Command::ListPartitions, "listpartitions", PERMISSION_READ);
     check(
@@ -656,15 +666,15 @@ fn messaging_metadata() {
     check(
         &Command::Subscribe { channel: s("") },
         "subscribe",
-        PERMISSION_CONTROL,
+        PERMISSION_READ,
     );
     check(
         &Command::Unsubscribe { channel: s("") },
         "unsubscribe",
-        PERMISSION_CONTROL,
+        PERMISSION_READ,
     );
     check(&Command::Channels, "channels", PERMISSION_READ);
-    check(&Command::ReadMessages, "readmessages", PERMISSION_CONTROL);
+    check(&Command::ReadMessages, "readmessages", PERMISSION_READ);
     check(
         &Command::SendMessage {
             channel: s(""),
@@ -683,7 +693,7 @@ fn advanced_queue_metadata() {
             ranges: vec![],
         },
         "prio",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
     check(
         &Command::PrioId {
@@ -691,15 +701,12 @@ fn advanced_queue_metadata() {
             ids: vec![],
         },
         "prioid",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
     check(
-        &Command::RangeId {
-            id: 0,
-            range: (0.0, 0.0),
-        },
+        &Command::RangeId { id: 0, range: None },
         "rangeid",
-        PERMISSION_CONTROL,
+        PERMISSION_ADD,
     );
     check(
         &Command::AddTagId {
@@ -708,12 +715,12 @@ fn advanced_queue_metadata() {
             value: s(""),
         },
         "addtagid",
-        PERMISSION_CONTROL,
+        PERMISSION_ADD,
     );
     check(
         &Command::ClearTagId { id: 0, tag: None },
         "cleartagid",
-        PERMISSION_CONTROL,
+        PERMISSION_ADD,
     );
 }
 
@@ -724,12 +731,12 @@ fn miscellaneous_metadata() {
     check(
         &Command::MixRampDb { decibels: 0.0 },
         "mixrampdb",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
     check(
         &Command::MixRampDelay { seconds: 0.0 },
         "mixrampdelay",
-        PERMISSION_CONTROL,
+        PERMISSION_PLAYER,
     );
 }
 

--- a/rmpd-protocol/tests/common/state_helpers.rs
+++ b/rmpd-protocol/tests/common/state_helpers.rs
@@ -1,3 +1,6 @@
+// Shared across multiple test binaries; each uses only a subset of the helpers.
+#![allow(dead_code)]
+
 use rmpd_core::queue::Queue;
 use rmpd_core::state::{
     ConsumeMode, PlayerState, PlayerStatus, QueuePosition, ReplayGainMode, SingleMode,

--- a/rmpd-protocol/tests/conformance/command_batching.rs
+++ b/rmpd-protocol/tests/conformance/command_batching.rs
@@ -50,9 +50,65 @@ async fn command_list_ok_error_stops_batch() {
 async fn command_list_end_without_begin() {
     let (_server, mut client) = setup().await;
     let resp = client.command("command_list_end").await;
+    // `command_list_end` isn't in MPD's `commands[]` table; outside a list
+    // it's looked up like any other name and reported as unknown, exactly as
+    // MPD does (`ACK_ERROR_NOT_LIST` is declared but never actually thrown).
+    assert_eq!(resp, "ACK [5@0] {} unknown command \"command_list_end\"\n");
+}
+
+#[tokio::test]
+async fn idle_inside_command_list_closes_connection() {
+    let (_server, mut client) = setup().await;
+    // MPD: idle/noidle are async commands and can't be used inside a command
+    // list; the connection is closed immediately with no ACK at all
+    // (Client::ProcessLine's IsAsyncCommmand check runs before the list is
+    // ever executed).
+    client
+        .send_raw("command_list_begin\nidle\ncommand_list_end\n")
+        .await;
+    let line = client.read_line().await;
     assert!(
-        resp.starts_with("ACK "),
-        "end without begin should be an error: {resp}"
+        line.is_empty(),
+        "idle inside a command list should close the connection: {line:?}"
+    );
+}
+
+#[tokio::test]
+async fn close_inside_command_list_closes_connection_without_panicking() {
+    let (_server, mut client) = setup().await;
+    // MPD's `close` short-circuits list execution (`CommandResult::FINISH`)
+    // and closes the connection; it must not reach the normal per-command
+    // dispatch (which has no handler for `Close`, since it's always meant
+    // to be intercepted first).
+    let resp = client.command_list(&["status", "close", "ping"]).await;
+    // The first command's output is flushed before `close`, but the list
+    // never completes, so there's no trailing "OK" for it.
+    assert!(
+        !resp.ends_with("OK\n"),
+        "list should not complete: {resp:?}"
+    );
+    let line = client.read_line().await;
+    assert!(
+        line.is_empty(),
+        "close inside a command list should close the connection: {line:?}"
+    );
+}
+
+#[tokio::test]
+async fn nested_command_list_begin_fails_as_unknown_command() {
+    let (_server, mut client) = setup().await;
+    // MPD has no nesting check: `command_list_begin` is only special-cased
+    // at the top level while *not* already in a list. Once inside one, it
+    // is just another line appended to the list, which then fails
+    // `command_lookup` (it isn't in `commands[]` either) when the list
+    // executes.
+    client
+        .send_raw("command_list_begin\ncommand_list_begin\ncommand_list_end\n")
+        .await;
+    let resp = client.read_response().await;
+    assert_eq!(
+        resp,
+        "ACK [5@0] {} unknown command \"command_list_begin\"\n"
     );
 }
 

--- a/rmpd-protocol/tests/conformance/connection_lifecycle.rs
+++ b/rmpd-protocol/tests/conformance/connection_lifecycle.rs
@@ -50,12 +50,17 @@ async fn close_terminates_connection() {
 }
 
 #[tokio::test]
-async fn empty_lines_are_ignored() {
+async fn empty_line_closes_connection() {
     let (_server, mut client) = setup().await;
-    // Send empty lines then a real command
-    client.send_raw("\n\n\nping\n").await;
-    let resp = client.read_response().await;
-    assert_ok(&resp);
+    // MPD closes the connection on any line that doesn't start with a
+    // lowercase ASCII letter (Client::ProcessLine's IsLowerAlphaASCII
+    // check) — including a bare empty line. No ACK is sent.
+    client.send_raw("\n").await;
+    let line = client.read_line().await;
+    assert!(
+        line.is_empty(),
+        "empty line should close the connection: {line:?}"
+    );
 }
 
 #[tokio::test]

--- a/rmpd-protocol/tests/conformance/error_handling.rs
+++ b/rmpd-protocol/tests/conformance/error_handling.rs
@@ -45,7 +45,9 @@ async fn ack_for_non_numeric_argument() {
 #[tokio::test]
 async fn ack_for_delete_empty_queue() {
     let (_server, mut client) = setup().await;
-    let resp = client.command("delete 0").await;
+    // Position 0 on an empty queue clips to an empty (no-op OK) range per
+    // MPD's RangeArg::CheckClip; position 1 is genuinely out of bounds.
+    let resp = client.command("delete 1").await;
     assert!(
         resp.starts_with("ACK "),
         "delete on empty queue should error: {resp}"
@@ -79,5 +81,208 @@ async fn ack_for_deleteid_nonexistent() {
     assert!(
         resp.starts_with("ACK "),
         "deleteid non-existent should error: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn ack_for_unknown_command_has_empty_command_field() {
+    let (_server, mut client) = setup().await;
+    let resp = client.command("not_a_real_command").await;
+    // MPD's `Response::current_command` defaults to "" until a real command
+    // is looked up, so an unknown command's `{}` field must stay empty.
+    assert_eq!(
+        resp,
+        "ACK [5@0] {} unknown command \"not_a_real_command\"\n"
+    );
+}
+
+#[tokio::test]
+async fn ack_for_too_few_arguments_names_the_command() {
+    let (_server, mut client) = setup().await;
+    // "add" needs at least a URI (min=1, max=2 in MPD's commands[] table).
+    let resp = client.command("add").await;
+    assert_eq!(resp, "ACK [2@0] {add} too few arguments for \"add\"\n");
+}
+
+#[tokio::test]
+async fn ack_for_too_many_arguments_on_bounded_variable_arity() {
+    let (_server, mut client) = setup().await;
+    // "add" accepts at most 2 args (URI, position); a 3rd is rejected.
+    let resp = client.command("add song.mp3 1 2").await;
+    assert_eq!(resp, "ACK [2@0] {add} too many arguments for \"add\"\n");
+}
+
+#[tokio::test]
+async fn ack_for_wrong_number_on_fixed_arity() {
+    let (_server, mut client) = setup().await;
+    // "seek" always takes exactly 2 args (position, time); MPD reports any
+    // mismatch as "wrong number", never "too few"/"too many".
+    let resp = client.command("seek 5").await;
+    assert_eq!(
+        resp,
+        "ACK [2@0] {seek} wrong number of arguments for \"seek\"\n"
+    );
+}
+
+#[tokio::test]
+async fn ack_for_setvol_non_numeric_says_integer_expected() {
+    let (_server, mut client) = setup().await;
+    let resp = client.command("setvol abc").await;
+    assert_eq!(resp, "ACK [2@0] {setvol} Integer expected: abc\n");
+}
+
+#[tokio::test]
+async fn close_accepts_and_ignores_extra_arguments() {
+    let (_server, mut client) = setup().await;
+    // MPD's `close` has unchecked arity (min = -1 in commands[]): any
+    // trailing arguments are accepted and ignored, not rejected as a bad
+    // argument count. It just closes the connection with no response.
+    client.send_raw("close extra args\n").await;
+    let line = client.read_line().await;
+    assert!(
+        line.is_empty(),
+        "close should close the connection: {line:?}"
+    );
+}
+
+#[tokio::test]
+async fn ack_for_bad_boolean_argument() {
+    let (_server, mut client) = setup().await;
+    let resp = client.command("pause abc").await;
+    assert_eq!(resp, "ACK [2@0] {pause} Boolean (0/1) expected: abc\n");
+}
+
+#[tokio::test]
+async fn ack_for_bad_float_argument() {
+    let (_server, mut client) = setup().await;
+    let resp = client.command("seek 0 abc").await;
+    assert_eq!(resp, "ACK [2@0] {seek} Float expected: abc\n");
+}
+
+#[tokio::test]
+async fn ack_for_bad_integer_argument() {
+    let (_server, mut client) = setup().await;
+    let resp = client.command("addid song.mp3 abc").await;
+    assert_eq!(resp, "ACK [2@0] {addid} Integer expected: abc\n");
+}
+
+#[tokio::test]
+async fn ack_for_out_of_range_priority() {
+    let (_server, mut client) = setup().await;
+    // `prio`'s priority is bounded to 0-255 (0xff) in MPD's commands[].
+    let resp = client.command("prio 300 0").await;
+    assert_eq!(resp, "ACK [2@0] {prio} Number too large: 300\n");
+}
+
+#[tokio::test]
+async fn ack_for_malformed_inverted_range() {
+    let (_server, mut client) = setup().await;
+    let resp = client.command("move 2:1 0").await;
+    assert_eq!(resp, "ACK [2@0] {move} Malformed range: 2:1\n");
+}
+
+#[tokio::test]
+async fn ack_for_unparseable_range_token() {
+    let (_server, mut client) = setup().await;
+    let resp = client.command("delete abc").await;
+    assert_eq!(resp, "ACK [2@0] {delete} Integer or range expected: abc\n");
+}
+
+#[tokio::test]
+async fn ack_for_filter_odd_argument_count() {
+    let (_server, mut client) = setup().await;
+    // A legacy TAG/VALUE filter list with a dangling TAG and no VALUE is a
+    // filter-syntax error in MPD's song::Filter, not an arity error, even
+    // though `find`'s own min/max (1, unlimited) is satisfied by one token.
+    let resp = client.command("find artist").await;
+    assert_eq!(
+        resp,
+        "ACK [2@0] {find} Incorrect number of filter arguments\n"
+    );
+}
+
+#[tokio::test]
+async fn ack_for_embedded_quote_in_unquoted_token() {
+    let (_server, mut client) = setup().await;
+    // Mirrors `Tokenizer::NextUnquoted`: a literal `'` (or `"`) inside an
+    // otherwise-unquoted token is a raw tokenization failure, not an
+    // arity/value error — it's thrown (and caught) before the command name
+    // is ever looked up, so the `{}` field stays empty.
+    let resp = client.command("subscribe 'bad channel'").await;
+    assert_eq!(resp, "ACK [5@0] {} Invalid unquoted character\n");
+}
+
+#[tokio::test]
+async fn ack_for_unterminated_quoted_string() {
+    let (_server, mut client) = setup().await;
+    let resp = client.command("password \"unterminated").await;
+    assert_eq!(resp, "ACK [5@0] {} Missing closing '\"'\n");
+}
+
+#[tokio::test]
+async fn ack_for_missing_space_after_closing_quote() {
+    let (_server, mut client) = setup().await;
+    let resp = client.command("password \"closed\"extra").await;
+    assert_eq!(resp, "ACK [5@0] {} Space expected after closing '\"'\n");
+}
+
+#[tokio::test]
+async fn arity_mismatch_takes_precedence_over_a_bad_value() {
+    let (_server, mut client) = setup().await;
+    // MPD's `command_check_request` (arity) always runs before the
+    // handler's own value parsing: 3 args for `seek` (which takes exactly
+    // 2) is "wrong number of arguments", not "Float expected: abc", even
+    // though the 2nd token is also not a valid float.
+    let resp = client.command("seek 0 abc extra").await;
+    assert_eq!(
+        resp,
+        "ACK [2@0] {seek} wrong number of arguments for \"seek\"\n"
+    );
+}
+
+#[tokio::test]
+async fn ack_for_bare_trailing_sort_keyword() {
+    let (_server, mut client) = setup().await;
+    // MPD's song::Filter only recognizes a trailing "sort"/"window" once a
+    // value follows it; a dangling "sort" with nothing after it becomes an
+    // unpaired (valueless) filter tag instead.
+    let resp = client.command("find artist val sort").await;
+    assert_eq!(
+        resp,
+        "ACK [2@0] {find} Incorrect number of filter arguments\n"
+    );
+}
+
+#[tokio::test]
+async fn ack_for_bare_trailing_position_keyword() {
+    let (_server, mut client) = setup().await;
+    let resp = client.command("findadd artist val position").await;
+    assert_eq!(
+        resp,
+        "ACK [2@0] {findadd} Incorrect number of filter arguments\n"
+    );
+}
+
+#[tokio::test]
+async fn ack_for_bare_trailing_group_keyword() {
+    let (_server, mut client) = setup().await;
+    // MPD's `handle_count_internal` only recognizes "group" as the
+    // trailing-clause marker when `args[size - 2] == "group"` (i.e. a tag
+    // name follows it); a bare trailing "group" with nothing after it
+    // falls through to filter parsing as an unpaired filter tag.
+    let resp = client.command("searchcount artist val group").await;
+    assert_eq!(
+        resp,
+        "ACK [2@0] {searchcount} Incorrect number of filter arguments\n"
+    );
+}
+
+#[tokio::test]
+async fn ack_for_bare_group_with_no_tag_name() {
+    let (_server, mut client) = setup().await;
+    let resp = client.command("count group").await;
+    assert_eq!(
+        resp,
+        "ACK [2@0] {count} Incorrect number of filter arguments\n"
     );
 }

--- a/rmpd-protocol/tests/conformance/idle_conformance.rs
+++ b/rmpd-protocol/tests/conformance/idle_conformance.rs
@@ -146,3 +146,29 @@ async fn single_connection_idle_sees_buffered_addid() {
     );
     assert_ok(&idle_resp);
 }
+
+#[tokio::test]
+async fn idle_coalesces_simultaneous_subsystem_changes() {
+    // Regression: protocol.rst command_idle says idle "lists all changed
+    // systems in a line" — MPD accumulates idle flags and reports every
+    // pending subsystem in one reply. rmpd used to return only the first
+    // matching event and silently drop the rest until the next idle.
+    //
+    // Both changes are made while the client is NOT idling, so they are
+    // already buffered by the time `idle` is sent — no race between the
+    // triggering commands and the idler's wakeup.
+    let (server, mut trigger, _tmp) = setup_with_db(1).await;
+    let mut idler = MpdTestClient::connect(server.port()).await;
+
+    let r1 = trigger.command("toggleoutput 0").await;
+    assert_ok(&r1);
+    let r2 = trigger.command("addid \"music/song1.flac\"").await;
+    assert!(get_field(&r2, "Id").is_some(), "addid must return Id: {r2}");
+
+    let idle_resp = idler.command("idle").await;
+    assert!(
+        idle_resp.contains("changed: output") && idle_resp.contains("changed: playlist"),
+        "idle must report every buffered subsystem in one reply, got: {idle_resp}"
+    );
+    assert_ok(&idle_resp);
+}

--- a/rmpd-protocol/tests/conformance/output_conformance.rs
+++ b/rmpd-protocol/tests/conformance/output_conformance.rs
@@ -68,3 +68,38 @@ async fn output_nonexistent_id() {
     let resp = client.command("enableoutput 999").await;
     assert!(resp.starts_with("ACK "), "nonexistent output: {resp}");
 }
+
+#[tokio::test]
+async fn outputset_illegal_attribute_name_rejected() {
+    let (_server, mut client) = setup().await;
+    let resp = client.command("outputset 0 \"bad name!\" value").await;
+    assert!(resp.starts_with("ACK [2@0]"), "got: {resp}");
+}
+
+#[tokio::test]
+async fn outputs_no_blank_line_between_entries() {
+    use rmpd_protocol::state::{AppState, OutputInfo};
+
+    let state = AppState::new();
+    {
+        let mut outputs = state.outputs.write().await;
+        outputs.push(OutputInfo {
+            id: 1,
+            name: "Second Output".to_string(),
+            plugin: "cpal".to_string(),
+            enabled: true,
+            partition: Some("default".to_string()),
+            config: None,
+            attributes: Default::default(),
+        });
+    }
+
+    let server = MpdTestServer::start_with_state(state).await;
+    let mut client = MpdTestClient::connect(server.port()).await;
+    let resp = client.command("outputs").await;
+    assert_ok(&resp);
+    assert!(
+        !resp.contains("\n\n"),
+        "outputs response must not have blank lines between entries: {resp:?}"
+    );
+}

--- a/rmpd-protocol/tests/conformance/queue_conformance.rs
+++ b/rmpd-protocol/tests/conformance/queue_conformance.rs
@@ -222,8 +222,12 @@ async fn clear_removes_all_songs() {
 
 #[tokio::test]
 async fn addtagid_and_cleartagid() {
-    let (_server, mut client, _tmp) = setup_with_db(3).await;
-    let r = client.command("addid \"music/song1.flac\"").await;
+    // MPD only allows tag edits on remote songs (a `scheme://` URI); local
+    // database files reject with "Cannot edit tags of local file".
+    let (_server, mut client) = setup().await;
+    let r = client
+        .command("addid \"http://example.com/stream.mp3\"")
+        .await;
     let id = get_field(&r, "Id").unwrap();
 
     let resp = client

--- a/rmpd-protocol/tests/conformance/range_parsing.rs
+++ b/rmpd-protocol/tests/conformance/range_parsing.rs
@@ -92,11 +92,13 @@ async fn playlistinfo_out_of_bounds() {
     let (_server, mut client, _tmp) = setup_with_db(3).await;
     client.command("add \"music/song1.flac\"").await;
 
-    // Single position beyond queue should return empty (apply_range returns &[])
+    // MPD's RangeArg::CheckClip errors when `start > length` (here 999 > 1)
+    // rather than silently returning an empty list.
     let resp = client.command("playlistinfo 999").await;
-    assert_ok(&resp);
-    let file_count = resp.matches("file:").count();
-    assert_eq!(file_count, 0, "out of bounds should return 0 songs");
+    assert!(
+        resp.starts_with("ACK [2@0]") && resp.contains("Bad song index"),
+        "out of bounds should ACK: {resp}"
+    );
 }
 
 #[tokio::test]
@@ -148,7 +150,9 @@ async fn move_range() {
     client.command("add \"music/song2.flac\"").await;
     client.command("add \"music/song3.flac\"").await;
 
-    let resp = client.command("move 0:2 2").await;
+    // Moving the 2-song range [0,2) leaves exactly 1 slot (3 - 2); `to = 1`
+    // is the largest destination that fits.
+    let resp = client.command("move 0:2 1").await;
     assert_ok(&resp);
 
     let status = client.command("status").await;

--- a/rmpd-protocol/tests/conformance/reflection_conformance.rs
+++ b/rmpd-protocol/tests/conformance/reflection_conformance.rs
@@ -1,6 +1,7 @@
 //! Tests for MPD reflection commands over TCP.
 
 use crate::tcp_harness::*;
+use rmpd_protocol::state::AppState;
 
 #[tokio::test]
 async fn commands_lists_available() {
@@ -11,6 +12,93 @@ async fn commands_lists_available() {
     assert!(resp.contains("command: play"), "should list play: {resp}");
     assert!(resp.contains("command: status"), "should list status");
     assert!(resp.contains("command: ping"), "should list ping");
+}
+
+#[tokio::test]
+async fn commands_and_notcommands_partition_by_permission() {
+    // With a password configured, an unauthenticated connection starts with
+    // zero permissions, so PLAYER-gated commands (e.g. "play") must appear
+    // in `notcommands` and not in `commands`, while NONE-gated commands
+    // (e.g. "ping") always appear in `commands`.
+    let mut state = AppState::new();
+    state.password = Some("secret".to_string());
+    let (_server, mut client) = setup_with_state(state).await;
+
+    let commands = client.command("commands").await;
+    assert_ok(&commands);
+    assert!(
+        commands.contains("command: ping"),
+        "ping is PERMISSION_NONE: {commands}"
+    );
+    assert!(
+        !commands.contains("command: play"),
+        "play requires permission: {commands}"
+    );
+
+    let notcommands = client.command("notcommands").await;
+    assert_ok(&notcommands);
+    assert!(
+        notcommands.contains("command: play"),
+        "play should be listed as unavailable: {notcommands}"
+    );
+    assert!(
+        !notcommands.contains("command: ping"),
+        "ping should not be listed as unavailable: {notcommands}"
+    );
+
+    // After authenticating, play becomes available and is no longer in notcommands.
+    let auth = client.command("password secret").await;
+    assert_ok(&auth);
+    let commands = client.command("commands").await;
+    assert!(
+        commands.contains("command: play"),
+        "play should be available after auth: {commands}"
+    );
+    let notcommands = client.command("notcommands").await;
+    assert!(
+        !notcommands.contains("command: play"),
+        "play should no longer be unavailable after auth: {notcommands}"
+    );
+}
+
+#[tokio::test]
+async fn permission_denied_ack_matches_mpd() {
+    // A PLAYER-gated command without permission must return MPD's exact
+    // ACK code (4 = ACK_ERROR_PERMISSION) and message text.
+    let mut state = AppState::new();
+    state.password = Some("secret".to_string());
+    let (_server, mut client) = setup_with_state(state).await;
+
+    let resp = client.command("play").await;
+    assert!(
+        resp.contains("ACK [4@0] {play} you don't have permission for \"play\""),
+        "unexpected ACK: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn idle_requires_read_permission() {
+    // idle bypasses handle_command's generic permission check (it needs
+    // raw reader/event_rx access for long-poll), so it must be gated
+    // separately; verify it still enforces PERMISSION_READ.
+    let mut state = AppState::new();
+    state.password = Some("secret".to_string());
+    let (_server, mut client) = setup_with_state(state).await;
+
+    let resp = client.command("idle").await;
+    assert!(
+        resp.contains("ACK [4@0] {idle} you don't have permission for \"idle\""),
+        "unexpected ACK: {resp}"
+    );
+
+    let auth = client.command("password secret").await;
+    assert_ok(&auth);
+
+    client.send_raw("idle\n").await;
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    client.send_raw("noidle\n").await;
+    let resp = client.read_response().await;
+    assert_ok(&resp);
 }
 
 #[tokio::test]
@@ -100,5 +188,16 @@ async fn protocol_disable_and_enable() {
     assert_ok(&resp);
 
     let resp = client.command("protocol enable binary").await;
+    assert_ok(&resp);
+}
+
+#[tokio::test]
+async fn binarylimit_rejects_too_small() {
+    let (_server, mut client) = setup().await;
+
+    let resp = client.command("binarylimit 32").await;
+    assert!(resp.starts_with("ACK [2@0]"), "got: {resp}");
+
+    let resp = client.command("binarylimit 8192").await;
     assert_ok(&resp);
 }

--- a/rmpd-protocol/tests/conformance/status_and_stats.rs
+++ b/rmpd-protocol/tests/conformance/status_and_stats.rs
@@ -45,13 +45,13 @@ async fn stats_response_format() {
     let resp = client.command("stats").await;
     assert_ok(&resp);
 
+    // MPD always emits these regardless of database state.
     for field in &[
         "artists",
         "albums",
         "songs",
         "uptime",
         "db_playtime",
-        "db_update",
         "playtime",
     ] {
         assert!(
@@ -59,6 +59,30 @@ async fn stats_response_format() {
             "missing required field: {field}"
         );
     }
+}
+
+#[tokio::test]
+async fn stats_omits_db_update_when_never_updated() {
+    // Stats.cxx db_stats_print omits `db_update` entirely when the database
+    // has never been updated (GetUpdateStamp() negative).
+    let (_server, mut client) = setup().await;
+    let resp = client.command("stats").await;
+    assert_ok(&resp);
+    assert!(
+        get_field(&resp, "db_update").is_none(),
+        "db_update should be omitted with no database: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn stats_includes_db_update_once_songs_exist() {
+    let (_server, mut client, _tmp) = setup_with_db(2).await;
+    let resp = client.command("stats").await;
+    assert_ok(&resp);
+    assert!(
+        get_field(&resp, "db_update").is_some(),
+        "db_update should be present once songs exist: {resp}"
+    );
 }
 
 #[tokio::test]

--- a/rmpd-protocol/tests/conformance/stored_playlists_extended.rs
+++ b/rmpd-protocol/tests/conformance/stored_playlists_extended.rs
@@ -4,16 +4,22 @@
 use crate::tcp_harness::*;
 
 #[tokio::test]
-async fn save_default_replaces_existing() {
+async fn save_default_mode_is_create() {
     let (_server, mut client, _tmp) = setup_with_db(3).await;
     client.command("add \"music/song1.flac\"").await;
 
     let resp = client.command("save \"dup\"").await;
     assert_ok(&resp);
 
-    // MPD default: save replaces existing playlist (not create-or-fail)
+    // MPD's handle_save defaults to PlaylistSaveMode::CREATE, and
+    // spl_save_playlist throws LIST_EXISTS -> ACK_ERROR_EXIST(56) with
+    // "Playlist already exists" when the file is already there.
     let resp = client.command("save \"dup\"").await;
-    assert_ok(&resp);
+    assert_eq!(
+        resp.trim_end(),
+        "ACK [56@0] {save} Playlist already exists",
+        "default save mode must be create, not replace"
+    );
 }
 
 #[tokio::test]

--- a/rmpd-protocol/tests/database_commands.rs
+++ b/rmpd-protocol/tests/database_commands.rs
@@ -1,6 +1,8 @@
 //! Integration tests for database commands
 
 mod common;
+#[path = "common/tcp_harness.rs"]
+mod tcp_harness;
 
 use common::TestClient;
 
@@ -132,4 +134,95 @@ fn test_readpicture_command() {
     let response = "size: 54321\ntype: image/jpeg\nbinary: 54321\nOK\n";
     assert!(TestClient::is_ok(response));
     assert_eq!(TestClient::get_field(response, "type"), Some("image/jpeg"));
+}
+
+// ── ACK code audit: "not found" (DatabaseErrorCode::NOT_FOUND ->
+// ACK_ERROR_NO_EXIST=50) vs genuine internal/IO failure (ACK_ERROR_SYS=52),
+// mirroring MPD's CommandError.cxx exception mapping. These run against a
+// real rmpd instance (tcp_harness) rather than canned strings, so they
+// actually exercise the handlers.
+
+#[tokio::test]
+async fn lsinfo_nonexistent_directory_is_no_exist() {
+    let (_server, mut client, _tmp) = tcp_harness::setup_with_db(1).await;
+    let resp = client.command("lsinfo nosuch").await;
+    assert!(resp.starts_with("ACK [50@0]"), "got: {resp}");
+}
+
+#[tokio::test]
+async fn listall_nonexistent_directory_is_no_exist() {
+    let (_server, mut client, _tmp) = tcp_harness::setup_with_db(1).await;
+    let resp = client.command("listall nosuch").await;
+    assert!(resp.starts_with("ACK [50@0]"), "got: {resp}");
+}
+
+#[tokio::test]
+async fn listallinfo_nonexistent_directory_is_no_exist() {
+    let (_server, mut client, _tmp) = tcp_harness::setup_with_db(1).await;
+    let resp = client.command("listallinfo nosuch").await;
+    assert!(resp.starts_with("ACK [50@0]"), "got: {resp}");
+}
+
+#[tokio::test]
+async fn listfiles_nonexistent_directory_stays_sys_error() {
+    // Unlike lsinfo/listall (a pure database-tree lookup), `listfiles` reads
+    // the real filesystem: a missing directory is a genuine `opendir()`
+    // failure, which MPD's own exception mapping treats as a
+    // `std::system_error` -> ACK_ERROR_SYS (52), not NOT_FOUND. This is a
+    // regression test pinning that this one stays 52.
+    let (_server, mut client, _tmp) = tcp_harness::setup_with_db(1).await;
+    let resp = client.command("listfiles nosuch").await;
+    assert!(resp.starts_with("ACK [52@0]"), "got: {resp}");
+}
+
+#[tokio::test]
+async fn update_nonexistent_path_is_no_exist() {
+    let (_server, mut client, _tmp) = tcp_harness::setup_with_db(1).await;
+    let resp = client.command("update nosuch").await;
+    assert!(resp.starts_with("ACK [50@0]"), "got: {resp}");
+}
+
+#[tokio::test]
+async fn update_malformed_path_is_arg_error() {
+    // A path escaping the music directory (`..`) is a different MPD error
+    // than a merely nonexistent one: `uri_safe_local()` rejects it before
+    // any database lookup happens, giving ACK_ERROR_ARG (2), not NOT_FOUND.
+    let (_server, mut client, _tmp) = tcp_harness::setup_with_db(1).await;
+    let resp = client.command("update \"../etc\"").await;
+    assert!(resp.starts_with("ACK [2@0]"), "got: {resp}");
+}
+
+#[tokio::test]
+async fn rescan_nonexistent_path_is_no_exist() {
+    let (_server, mut client, _tmp) = tcp_harness::setup_with_db(1).await;
+    let resp = client.command("rescan nosuch").await;
+    assert!(resp.starts_with("ACK [50@0]"), "got: {resp}");
+}
+
+#[tokio::test]
+async fn rescan_malformed_path_is_arg_error() {
+    let (_server, mut client, _tmp) = tcp_harness::setup_with_db(1).await;
+    let resp = client.command("rescan \"../etc\"").await;
+    assert!(resp.starts_with("ACK [2@0]"), "got: {resp}");
+}
+
+#[tokio::test]
+async fn albumart_missing_uri_is_no_exist() {
+    let (_server, mut client, _tmp) = tcp_harness::setup_with_db(1).await;
+    let resp = client.command("albumart \"nosuch.flac\" 0").await;
+    assert!(resp.starts_with("ACK [50@0]"), "got: {resp}");
+}
+
+#[tokio::test]
+async fn readpicture_missing_uri_is_no_exist() {
+    let (_server, mut client, _tmp) = tcp_harness::setup_with_db(1).await;
+    let resp = client.command("readpicture \"nosuch.flac\" 0").await;
+    assert!(resp.starts_with("ACK [50@0]"), "got: {resp}");
+}
+
+#[tokio::test]
+async fn readcomments_missing_uri_is_no_exist() {
+    let (_server, mut client, _tmp) = tcp_harness::setup_with_db(1).await;
+    let resp = client.command("readcomments \"nosuch.flac\"").await;
+    assert!(resp.starts_with("ACK [50@0]"), "got: {resp}");
 }

--- a/rmpd-protocol/tests/messaging_idle.rs
+++ b/rmpd-protocol/tests/messaging_idle.rs
@@ -1,0 +1,80 @@
+//! Verifies `subscribe`/`unsubscribe` notify idle `subscription` clients and
+//! `sendmessage` notifies idle `message` clients, matching MPD's
+//! `EmitIdle(IDLE_SUBSCRIPTION)` / `IdleAdd(IDLE_MESSAGE)`.
+
+use rmpd_core::event::{Event, Subsystem};
+use rmpd_protocol::commands::messaging;
+use rmpd_protocol::connection::ConnectionState;
+use rmpd_protocol::state::AppState;
+
+#[test]
+fn subscription_and_message_events_map_to_subsystems() {
+    assert!(
+        Event::SubscriptionChanged
+            .subsystems()
+            .contains(&Subsystem::Subscription),
+        "Event::SubscriptionChanged must map to Subsystem::Subscription"
+    );
+    assert!(
+        Event::MessageReceived
+            .subsystems()
+            .contains(&Subsystem::Message),
+        "Event::MessageReceived must map to Subsystem::Message"
+    );
+}
+
+#[tokio::test]
+async fn subscribe_emits_subscription_notification() {
+    let state = AppState::new();
+    let mut conn = ConnectionState::new();
+    let mut rx = state.event_bus.subscribe();
+
+    let resp = messaging::handle_subscribe_command(&state, &mut conn, "testchan").await;
+    assert!(resp.contains("OK"), "got: {resp}");
+
+    assert!(
+        rx.try_recv()
+            .is_ok_and(|ev| matches!(ev, Event::SubscriptionChanged)),
+        "subscribe must emit Event::SubscriptionChanged"
+    );
+}
+
+#[tokio::test]
+async fn unsubscribe_emits_subscription_notification() {
+    let state = AppState::new();
+    let mut conn = ConnectionState::new();
+    messaging::handle_subscribe_command(&state, &mut conn, "testchan").await;
+
+    let mut rx = state.event_bus.subscribe();
+    let resp = messaging::handle_unsubscribe_command(&state, &mut conn, "testchan").await;
+    assert!(resp.contains("OK"), "got: {resp}");
+
+    assert!(
+        rx.try_recv()
+            .is_ok_and(|ev| matches!(ev, Event::SubscriptionChanged)),
+        "unsubscribe must emit Event::SubscriptionChanged"
+    );
+}
+
+#[tokio::test]
+async fn sendmessage_emits_message_notification_only_when_delivered() {
+    let state = AppState::new();
+    let mut conn = ConnectionState::new();
+    messaging::handle_subscribe_command(&state, &mut conn, "testchan").await;
+
+    let mut rx = state.event_bus.subscribe();
+    let resp = messaging::handle_sendmessage_command(&state, "testchan", "hi").await;
+    assert!(resp.contains("OK"), "got: {resp}");
+    assert!(
+        rx.try_recv()
+            .is_ok_and(|ev| matches!(ev, Event::MessageReceived)),
+        "sendmessage to a subscribed channel must emit Event::MessageReceived"
+    );
+
+    let resp = messaging::handle_sendmessage_command(&state, "nobody-here", "hi").await;
+    assert!(resp.starts_with("ACK"), "got: {resp}");
+    assert!(
+        rx.try_recv().is_err(),
+        "sendmessage with no subscribers must not emit a notification"
+    );
+}

--- a/rmpd-protocol/tests/partition_commands.rs
+++ b/rmpd-protocol/tests/partition_commands.rs
@@ -3,6 +3,10 @@
 //! Tests for multi-partition support including partition management,
 //! client context switching, and output assignment.
 
+mod common;
+#[path = "common/tcp_harness.rs"]
+mod tcp_harness;
+
 use rmpd_protocol::commands::partition;
 use rmpd_protocol::{AppState, ConnectionState};
 
@@ -52,12 +56,12 @@ async fn test_newpartition_invalid_name() {
     // Test empty name
     let response1 = partition::handle_newpartition_command(&state, "").await;
     assert!(response1.contains("ACK"));
-    assert!(response1.contains("Invalid partition name"));
+    assert!(response1.contains("bad name"));
 
     // Test invalid characters
     let response2 = partition::handle_newpartition_command(&state, "foo/bar").await;
     assert!(response2.contains("ACK"));
-    assert!(response2.contains("Invalid partition name"));
+    assert!(response2.contains("bad name"));
 }
 
 #[tokio::test]
@@ -102,7 +106,7 @@ async fn test_partition_switch_nonexistent() {
         partition::handle_partition_command(&state, &mut conn_state, "nonexistent").await;
 
     assert!(response.contains("ACK"));
-    assert!(response.contains("No such partition"));
+    assert!(response.contains("partition does not exist"));
     // Should not change current partition
     assert_eq!(conn_state.current_partition, "default");
 }
@@ -130,7 +134,7 @@ async fn test_delpartition_default() {
     let response = partition::handle_delpartition_command(&state, "default").await;
 
     assert!(response.contains("ACK"));
-    assert!(response.contains("Cannot delete default partition"));
+    assert!(response.contains("cannot delete the default partition"));
 }
 
 #[tokio::test]
@@ -140,8 +144,7 @@ async fn test_delpartition_nonexistent() {
     let response = partition::handle_delpartition_command(&state, "nonexistent").await;
 
     assert!(response.contains("ACK"));
-    // The error message may vary, just check it's an error
-    assert!(response.contains("not found") || response.contains("No such partition"));
+    assert!(response.contains("no such partition"));
 }
 
 #[tokio::test]
@@ -242,4 +245,129 @@ async fn test_output_partition_tracking() {
     let outputs = state.outputs.read().await;
     let moved_output = outputs.iter().find(|o| o.id == 0).unwrap();
     assert_eq!(moved_output.partition.as_deref(), Some("bedroom"));
+}
+
+#[tokio::test]
+async fn test_delpartition_refuses_with_assigned_outputs() {
+    let state = AppState::new();
+    let mut conn_state = ConnectionState::new();
+
+    partition::handle_newpartition_command(&state, "bedroom").await;
+    partition::handle_partition_command(&state, &mut conn_state, "bedroom").await;
+    partition::handle_moveoutput_command(&state, &conn_state, "Default Output").await;
+
+    let response = partition::handle_delpartition_command(&state, "bedroom").await;
+    assert!(response.contains("ACK"));
+    assert!(response.contains("still has outputs"));
+
+    // Partition must still exist
+    let manager = state.partition_manager.as_ref().unwrap();
+    assert!(manager.get_partition("bedroom").await.is_some());
+}
+
+#[tokio::test]
+async fn test_listpartitions_creation_order() {
+    let state = AppState::new();
+
+    // MPD lists partitions in creation order, not alphabetically.
+    partition::handle_newpartition_command(&state, "zzz").await;
+    partition::handle_newpartition_command(&state, "aaa").await;
+
+    let response = partition::handle_listpartitions_command(&state).await;
+    let default_pos = response.find("partition: default").unwrap();
+    let zzz_pos = response.find("partition: zzz").unwrap();
+    let aaa_pos = response.find("partition: aaa").unwrap();
+    assert!(default_pos < zzz_pos);
+    assert!(zzz_pos < aaa_pos);
+}
+
+#[tokio::test]
+async fn test_newpartition_delpartition_emit_partition_idle() {
+    use rmpd_core::event::Event;
+
+    let state = AppState::new();
+    let mut rx = state.event_bus.subscribe();
+
+    partition::handle_newpartition_command(&state, "bedroom").await;
+    let mut got = false;
+    while let Ok(ev) = rx.try_recv() {
+        got |= matches!(ev, Event::PartitionsChanged);
+    }
+    assert!(got, "newpartition must emit Event::PartitionsChanged");
+
+    partition::handle_delpartition_command(&state, "bedroom").await;
+    let mut got = false;
+    while let Ok(ev) = rx.try_recv() {
+        got |= matches!(ev, Event::PartitionsChanged);
+    }
+    assert!(got, "delpartition must emit Event::PartitionsChanged");
+}
+
+#[tokio::test]
+async fn test_moveoutput_emits_output_idle() {
+    use rmpd_core::event::Event;
+
+    let state = AppState::new();
+    let mut conn_state = ConnectionState::new();
+    partition::handle_newpartition_command(&state, "bedroom").await;
+    partition::handle_partition_command(&state, &mut conn_state, "bedroom").await;
+
+    let mut rx = state.event_bus.subscribe();
+    let response =
+        partition::handle_moveoutput_command(&state, &conn_state, "Default Output").await;
+    assert_eq!(response, "OK\n");
+
+    let mut got = false;
+    while let Ok(ev) = rx.try_recv() {
+        got |= matches!(ev, Event::OutputsChanged);
+    }
+    assert!(got, "moveoutput must emit Event::OutputsChanged");
+}
+
+#[tokio::test]
+async fn status_reflects_current_partition() {
+    let (_server, mut client) = tcp_harness::setup().await;
+
+    client.command("newpartition bedroom").await;
+    client.command("partition bedroom").await;
+
+    let status = client.command("status").await;
+    assert_eq!(
+        tcp_harness::get_field(&status, "partition"),
+        Some("bedroom"),
+        "status must report the client's current partition, not a hardcoded default: {status}"
+    );
+}
+
+#[tokio::test]
+async fn outputs_scoped_to_current_partition() {
+    let (_server, mut client) = tcp_harness::setup().await;
+
+    client.command("newpartition bedroom").await;
+    client.command("partition bedroom").await;
+
+    // The default output still belongs to "default"; a fresh partition owns
+    // no outputs, so `outputs` must be a bare OK (matches MPD's
+    // per-partition output listing).
+    let resp = client.command("outputs").await;
+    assert_eq!(
+        resp, "OK\n",
+        "outputs must be scoped to the current partition: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn enableoutput_scoped_to_current_partition() {
+    let (_server, mut client) = tcp_harness::setup().await;
+
+    client.command("newpartition bedroom").await;
+    client.command("partition bedroom").await;
+
+    // Output id 0 exists but belongs to "default", not "bedroom" — must be
+    // invisible to id-based lookups from this partition.
+    let resp = client.command("enableoutput 0").await;
+    assert!(
+        resp.starts_with("ACK ") && resp.contains("No such audio output"),
+        "enableoutput must not resolve ids outside the current partition: {resp}"
+    );
 }

--- a/rmpd-protocol/tests/playlist_commands.rs
+++ b/rmpd-protocol/tests/playlist_commands.rs
@@ -207,3 +207,265 @@ async fn test_playlist_name_normal_round_trips() {
     let resp = playlists::handle_rm_command(&state, "My Playlist").await;
     assert!(TestClient::is_ok(&resp), "rm should succeed, got: {resp}");
 }
+
+fn add_songs_to_db(state: &AppState, paths: &[&str]) {
+    let db = rmpd_library::Database::open(state.db_path.as_ref().unwrap()).unwrap();
+    for (i, path) in paths.iter().enumerate() {
+        let song = rmpd_core::test_utils::make_test_song(path, i as u32 + 1);
+        db.add_song(&song).unwrap();
+    }
+}
+
+fn write_playlist(state: &AppState, name: &str, paths: &[&str]) {
+    let dir = state.playlist_dir.as_ref().unwrap();
+    let content: String = paths.iter().map(|p| format!("{p}\n")).collect();
+    std::fs::write(
+        std::path::Path::new(dir).join(format!("{name}.m3u")),
+        content,
+    )
+    .unwrap();
+}
+
+#[tokio::test]
+async fn test_save_default_mode_is_create() {
+    // MPD's `save` defaults to CREATE, not REPLACE: a second save of the
+    // same name without a mode must fail EXIST, not silently overwrite.
+    let (_tmp, state) = new_test_state();
+
+    let resp = playlists::handle_save_command(&state, "list1", None).await;
+    assert!(
+        TestClient::is_ok(&resp),
+        "first save should succeed, got: {resp}"
+    );
+
+    let resp = playlists::handle_save_command(&state, "list1", None).await;
+    assert!(
+        resp.contains("[56@0]") && resp.contains("Playlist already exists"),
+        "default save mode must be 'create', got: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_save_replace_requires_existing_playlist() {
+    // Despite the name, "replace" fails on a playlist that doesn't exist yet
+    // (PlaylistSave.cxx: only CREATE tolerates a missing file).
+    let (_tmp, state) = new_test_state();
+
+    let resp = playlists::handle_save_command(&state, "missing", Some("replace".to_string())).await;
+    assert!(
+        resp.contains("[50@0]") && resp.contains("No such playlist"),
+        "replace on a missing playlist must ACK No such playlist, got: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_save_unrecognized_mode_message() {
+    let (_tmp, state) = new_test_state();
+
+    let resp = playlists::handle_save_command(&state, "list1", Some("bogus".to_string())).await;
+    assert!(
+        resp.contains("[2@0]") && resp.contains("Unrecognized save mode"),
+        "bad mode must ACK MPD's exact message, got: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_playlist_name_with_dots_is_valid() {
+    // MPD's spl_valid_name() only forbids '/'; unlike a real filesystem, "."
+    // and ".." are ordinary (if odd) playlist names once ".m3u" is appended.
+    let (_tmp, state) = new_test_state();
+
+    let resp = playlists::handle_save_command(&state, "..", None).await;
+    assert!(
+        TestClient::is_ok(&resp),
+        "'..' has no '/' and must be accepted, got: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_load_absolute_position_out_of_range() {
+    let (_tmp, state) = new_test_state();
+    write_playlist(&state, "list1", &["song1.mp3"]);
+
+    // The queue is empty (length 0); position 1 is one past the only valid
+    // insertion point (0).
+    let resp = playlists::handle_load_command(
+        &state,
+        "list1",
+        None,
+        Some(rmpd_protocol::parser::InsertPosition::Absolute(1)),
+    )
+    .await;
+    assert!(
+        resp.contains("[2@0]") && resp.contains("Bad song index"),
+        "out-of-range absolute position must ACK_ERROR_ARG, got: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_load_relative_position_without_current_song() {
+    let (_tmp, state) = new_test_state();
+    write_playlist(&state, "list1", &["song1.mp3"]);
+
+    let resp = playlists::handle_load_command(
+        &state,
+        "list1",
+        None,
+        Some(rmpd_protocol::parser::InsertPosition::After(0)),
+    )
+    .await;
+    assert!(
+        resp.contains("[55@0]") && resp.contains("No current song"),
+        "relative position with nothing playing must ACK_ERROR_PLAYER_SYNC, got: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_playlistadd_bad_position() {
+    let (_tmp, state) = new_test_state();
+    add_songs_to_db(&state, &["song1.mp3"]);
+
+    let resp = playlists::handle_playlistadd_command(&state, "list1", "song1.mp3", Some(5)).await;
+    assert!(
+        resp.contains("[2@0]") && resp.contains("Bad position"),
+        "position beyond the playlist's size must ACK_ERROR_ARG, got: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_playlistdelete_range_removes_multiple_songs() {
+    let (_tmp, state) = new_test_state();
+    write_playlist(&state, "list1", &["a.mp3", "b.mp3", "c.mp3", "d.mp3"]);
+
+    let resp = playlists::handle_playlistdelete_command(&state, "list1", (1, 3)).await;
+    assert!(TestClient::is_ok(&resp), "got: {resp}");
+
+    let resp = playlists::handle_listplaylist_command(&state, "list1", None).await;
+    assert_eq!(resp, "file: a.mp3\nfile: d.mp3\nOK\n");
+}
+
+#[tokio::test]
+async fn test_playlistdelete_one_past_end_is_noop() {
+    // MPD's RangeArg::CheckClip accepts `start == len` (clipping the range
+    // to empty) but rejects `start > len`.
+    let (_tmp, state) = new_test_state();
+    write_playlist(&state, "list1", &["a.mp3", "b.mp3"]);
+
+    let resp = playlists::handle_playlistdelete_command(&state, "list1", (2, 3)).await;
+    assert!(
+        TestClient::is_ok(&resp),
+        "index one past the end must succeed as a no-op, got: {resp}"
+    );
+
+    let resp = playlists::handle_playlistdelete_command(&state, "list1", (3, 4)).await;
+    assert!(
+        resp.contains("[2@0]") && resp.contains("Bad song index"),
+        "index two past the end must ACK_ERROR_ARG, got: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_playlistmove_range_relocates_a_song_block() {
+    let (_tmp, state) = new_test_state();
+    write_playlist(
+        &state,
+        "list1",
+        &["a.mp3", "b.mp3", "c.mp3", "d.mp3", "e.mp3"],
+    );
+
+    // Move the two-song block [b, c] to sit right after d.
+    let resp = playlists::handle_playlistmove_command(&state, "list1", (1, 3), 2).await;
+    assert!(TestClient::is_ok(&resp), "got: {resp}");
+
+    let resp = playlists::handle_listplaylist_command(&state, "list1", None).await;
+    assert_eq!(
+        resp,
+        "file: a.mp3\nfile: d.mp3\nfile: b.mp3\nfile: c.mp3\nfile: e.mp3\nOK\n"
+    );
+}
+
+#[tokio::test]
+async fn test_playlistmove_open_ended_range_rejected() {
+    let (_tmp, state) = new_test_state();
+
+    let resp = playlists::handle_playlistmove_command(&state, "list1", (1, u32::MAX), 0).await;
+    assert!(
+        resp.contains("[2@0]") && resp.contains("Open-ended range not supported"),
+        "got: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_playlistmove_noop_skips_existence_check() {
+    // MPD's early-out for an empty range never touches the playlist file, so
+    // it succeeds even for a playlist that doesn't exist.
+    let (_tmp, state) = new_test_state();
+
+    let resp = playlists::handle_playlistmove_command(&state, "does-not-exist", (3, 3), 5).await;
+    assert!(TestClient::is_ok(&resp), "got: {resp}");
+}
+
+#[tokio::test]
+async fn test_searchplaylist_filter_and_window() {
+    let (_tmp, state) = new_test_state();
+    add_songs_to_db(&state, &["a.mp3", "b.mp3", "c.mp3"]);
+    write_playlist(&state, "list1", &["a.mp3", "b.mp3", "c.mp3"]);
+
+    let filters = vec![("artist".to_string(), "Test Artist".to_string())];
+    let resp =
+        playlists::handle_searchplaylist_command(&state, "list1", &filters, Some((1, 2))).await;
+    assert!(TestClient::is_ok(&resp), "got: {resp}");
+    assert!(
+        resp.contains("file: b.mp3")
+            && !resp.contains("file: a.mp3")
+            && !resp.contains("file: c.mp3"),
+        "window(1,2) must return only the second matching playlist entry, got: {resp}"
+    );
+    assert!(
+        resp.contains("Pos: 1"),
+        "Pos must reflect the entry's index within the playlist, got: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_load_tracks_last_loaded_playlist_across_second_load_and_clear() {
+    // Mirrors MPD's queue::last_loaded_playlist (Queue.hxx/PlaylistQueue.cxx):
+    // set unconditionally on a successful `load`, overwritten by a second
+    // `load`, untouched by a failed `load`, and reset by `clear`.
+    let (_tmp, state) = new_test_state();
+    add_songs_to_db(&state, &["a.mp3"]);
+    write_playlist(&state, "pz", &["a.mp3"]);
+    write_playlist(&state, "pz2", &["a.mp3"]);
+
+    assert_eq!(state.queue.read().await.last_loaded_playlist(), "");
+
+    let resp = playlists::handle_load_command(&state, "pz", None, None).await;
+    assert!(TestClient::is_ok(&resp), "got: {resp}");
+    assert_eq!(state.queue.read().await.last_loaded_playlist(), "pz");
+
+    let resp = playlists::handle_load_command(&state, "pz2", None, None).await;
+    assert!(TestClient::is_ok(&resp), "got: {resp}");
+    assert_eq!(
+        state.queue.read().await.last_loaded_playlist(),
+        "pz2",
+        "a second load must overwrite the previous name"
+    );
+
+    let resp = playlists::handle_load_command(&state, "does-not-exist", None, None).await;
+    assert!(
+        !TestClient::is_ok(&resp),
+        "expected a failed load, got: {resp}"
+    );
+    assert_eq!(
+        state.queue.read().await.last_loaded_playlist(),
+        "pz2",
+        "a failed load must leave the previous name untouched"
+    );
+
+    rmpd_protocol::commands::queue::handle_clear_command(&state).await;
+    assert_eq!(
+        state.queue.read().await.last_loaded_playlist(),
+        "",
+        "clear must reset the last-loaded-playlist name"
+    );
+}

--- a/rmpd-protocol/tests/queue_operations.rs
+++ b/rmpd-protocol/tests/queue_operations.rs
@@ -1,8 +1,48 @@
 //! Integration tests for queue operations
 
 mod common;
+#[path = "common/state_helpers.rs"]
+mod state_helpers;
+#[path = "common/tcp_harness.rs"]
+mod tcp_harness;
 
 use common::TestClient;
+use rmpd_protocol::state::AppState;
+use state_helpers::{StatusBuilder, create_test_queue};
+use std::sync::Arc;
+use tcp_harness::*;
+use tokio::sync::RwLock;
+
+/// Like `tcp_harness::setup_with_db`, but with an explicit list of song
+/// paths (so tests can seed a directory tree) instead of a flat
+/// `music/song{i}.flac` run.
+async fn setup_with_songs(paths: &[&str]) -> (MpdTestServer, MpdTestClient, tempfile::TempDir) {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let db_path_str = db_path.to_str().unwrap().to_string();
+    let music_dir = tmp.path().join("music");
+    std::fs::create_dir_all(&music_dir).unwrap();
+    let playlist_dir = tmp.path().join("playlists");
+    std::fs::create_dir_all(&playlist_dir).unwrap();
+
+    {
+        let db = rmpd_library::Database::open(&db_path_str).unwrap();
+        for (i, path) in paths.iter().enumerate() {
+            let song = state_helpers::make_test_song(path, i as u32 + 1);
+            db.add_song(&song).unwrap();
+        }
+    }
+
+    let mut state = AppState::with_all_paths(
+        db_path_str,
+        music_dir.to_str().unwrap().to_string(),
+        playlist_dir.to_str().unwrap().to_string(),
+    );
+    state.disable_actual_mount = true;
+    let server = MpdTestServer::start_with_state(state).await;
+    let client = MpdTestClient::connect(server.port()).await;
+    (server, client, tmp)
+}
 
 #[test]
 fn test_add_and_playlistinfo() {
@@ -170,4 +210,532 @@ fn test_inverted_range_is_error() {
     // inverted range (start > end) must ACK, not silently reach the queue.
     let response = "ACK [2@0] {delete} Bad song index\n";
     assert!(TestClient::is_error(response));
+}
+
+// ── Relative position/destination grammar (`+N`/`-N`), real server ────
+
+#[tokio::test]
+async fn add_relative_position_with_no_current_song_is_error() {
+    let (_server, mut client, _tmp) = setup_with_db(3).await;
+    client.command("add \"music/song1.flac\"").await;
+
+    // Nothing is playing, so "+0" (relative to the current song) has no
+    // current song to be relative to.
+    let resp = client.command("add \"music/song2.flac\" +0").await;
+    assert!(
+        resp.starts_with("ACK [55@0]") && resp.contains("No current song"),
+        "unexpected response: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn addid_relative_position_after_current_song() {
+    // Pre-populate the queue/status directly (bypassing the real playback
+    // engine, whose success depends on an actual audio backend) so the
+    // "current song" is deterministic: 2 songs, song at position 0 current.
+    let mut state = AppState::new();
+    state.queue = Arc::new(RwLock::new(create_test_queue(2)));
+    state.status = Arc::new(RwLock::new(
+        StatusBuilder::new().current_position(0, 0).build(2),
+    ));
+    let (_server, mut client) = setup_with_state(state).await;
+
+    // "+0" inserts right after the current song (position 0), i.e. at 1.
+    // Use a stream URI so no database lookup is needed.
+    let resp = client
+        .command("addid \"http://example.com/song3.mp3\" +0")
+        .await;
+    assert_ok(&resp);
+
+    let info = client.command("playlistinfo 1").await;
+    assert!(
+        info.contains("song3.mp3"),
+        "song3 should land right after the current song: {info}"
+    );
+}
+
+#[tokio::test]
+async fn moveid_relative_destination_before_current_song() {
+    // 3 pre-existing songs; Queue ids start at 1, so song0/1/2.mp3 have ids
+    // 1/2/3 at positions 0/1/2 respectively. Song at position 0 (id 1) is
+    // current.
+    let mut state = AppState::new();
+    state.queue = Arc::new(RwLock::new(create_test_queue(3)));
+    state.status = Arc::new(RwLock::new(
+        StatusBuilder::new().current_position(0, 1).build(3),
+    ));
+    let (_server, mut client) = setup_with_state(state).await;
+
+    // "-0" moves song id 3 (song2.mp3, currently at position 2) to right
+    // before the current song (position 0).
+    let resp = client.command("moveid 3 -0").await;
+    assert_ok(&resp);
+
+    let info = client.command("playlistinfo 0").await;
+    assert!(
+        info.contains("song2.mp3"),
+        "song id 3 should land right before the current song: {info}"
+    );
+}
+
+#[tokio::test]
+async fn move_relative_destination_onto_own_range_is_error() {
+    let mut state = AppState::new();
+    state.queue = Arc::new(RwLock::new(create_test_queue(2)));
+    state.status = Arc::new(RwLock::new(
+        StatusBuilder::new().current_position(0, 0).build(2),
+    ));
+    let (_server, mut client) = setup_with_state(state).await;
+
+    // Moving the range containing the current song relative to itself.
+    let resp = client.command("move 0:1 +0").await;
+    assert!(
+        resp.starts_with("ACK [2@0]") && resp.contains("relative to itself"),
+        "unexpected response: {resp}"
+    );
+}
+
+// ── Open-ended range grammar (`START:`) ────────────────────────────────
+
+#[tokio::test]
+async fn delete_open_ended_range() {
+    let (_server, mut client, _tmp) = setup_with_db(3).await;
+    client.command("add \"music/song1.flac\"").await;
+    client.command("add \"music/song2.flac\"").await;
+    client.command("add \"music/song3.flac\"").await;
+
+    // "1:" deletes from position 1 to the end of the queue.
+    let resp = client.command("delete 1:").await;
+    assert_ok(&resp);
+
+    let status = client.command("status").await;
+    assert_eq!(get_field(&status, "playlistlength"), Some("1"));
+}
+
+#[tokio::test]
+async fn move_open_ended_range_is_error() {
+    let (_server, mut client, _tmp) = setup_with_db(3).await;
+    client.command("add \"music/song1.flac\"").await;
+    client.command("add \"music/song2.flac\"").await;
+
+    let resp = client.command("move 0: 1").await;
+    assert!(
+        resp.starts_with("ACK [2@0]") && resp.contains("Open-ended range not supported"),
+        "unexpected response: {resp}"
+    );
+}
+
+// ── ACK cases fixed by this pass ───────────────────────────────────────
+
+#[tokio::test]
+async fn delete_at_exact_queue_length_is_noop_not_error() {
+    let (_server, mut client, _tmp) = setup_with_db(3).await;
+    client.command("add \"music/song1.flac\"").await;
+    client.command("add \"music/song2.flac\"").await;
+
+    // MPD's RangeArg::CheckClip only errors on `start > length`; `start ==
+    // length` clips to an empty range and is a silent no-op OK.
+    let resp = client.command("delete 2").await;
+    assert_ok(&resp);
+    let status = client.command("status").await;
+    assert_eq!(get_field(&status, "playlistlength"), Some("2"));
+}
+
+#[tokio::test]
+async fn playlistinfo_start_beyond_length_is_error() {
+    let (_server, mut client, _tmp) = setup_with_db(3).await;
+    client.command("add \"music/song1.flac\"").await;
+
+    // `start > length` (1 song, position 5) must ACK, not silently return
+    // an empty list.
+    let resp = client.command("playlistinfo 5").await;
+    assert!(
+        resp.starts_with("ACK [2@0]") && resp.contains("Bad song index"),
+        "unexpected response: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn move_multi_item_range_up_preserves_order() {
+    let (_server, mut client, _tmp) = setup_with_db(4).await;
+    client.command("add \"music/song1.flac\"").await;
+    client.command("add \"music/song2.flac\"").await;
+    client.command("add \"music/song3.flac\"").await;
+    client.command("add \"music/song4.flac\"").await;
+
+    // Moving a 2-song range up must preserve the moved songs' relative
+    // order (a fixed source index across iterations would corrupt this).
+    let resp = client.command("move 2:4 0").await;
+    assert_ok(&resp);
+
+    let info = client.command("playlistinfo").await;
+    let files: Vec<&str> = info
+        .lines()
+        .filter_map(|l| l.strip_prefix("file: "))
+        .collect();
+    assert_eq!(
+        files,
+        vec![
+            "music/song3.flac",
+            "music/song4.flac",
+            "music/song1.flac",
+            "music/song2.flac",
+        ],
+        "moving [2:4) to 0 should preserve song3,song4 order: {info}"
+    );
+}
+
+#[tokio::test]
+async fn move_single_item_forward_lands_at_final_position() {
+    let (_server, mut client, _tmp) = setup_with_db(4).await;
+    client.command("add \"music/song1.flac\"").await;
+    client.command("add \"music/song2.flac\"").await;
+    client.command("add \"music/song3.flac\"").await;
+    client.command("add \"music/song4.flac\"").await;
+
+    // `to` is the item's final absolute position in the resulting queue,
+    // not an index into the post-removal array — moving position 0 to 1
+    // must swap it past exactly one song, not land back at its own spot.
+    let resp = client.command("move 0 1").await;
+    assert_ok(&resp);
+
+    let info = client.command("playlistinfo").await;
+    let files: Vec<&str> = info
+        .lines()
+        .filter_map(|l| l.strip_prefix("file: "))
+        .collect();
+    assert_eq!(
+        files,
+        vec![
+            "music/song2.flac",
+            "music/song1.flac",
+            "music/song3.flac",
+            "music/song4.flac",
+        ],
+        "move 0 1 should land song1 at position 1: {info}"
+    );
+
+    // move 1 2 on the now-current order ([song2, song1, song3, song4]):
+    // moves song1 (position 1) to land at position 2.
+    let resp = client.command("move 1 2").await;
+    assert_ok(&resp);
+    let info = client.command("playlistinfo").await;
+    let files: Vec<&str> = info
+        .lines()
+        .filter_map(|l| l.strip_prefix("file: "))
+        .collect();
+    assert_eq!(
+        files,
+        vec![
+            "music/song2.flac",
+            "music/song3.flac",
+            "music/song1.flac",
+            "music/song4.flac",
+        ],
+        "move 1 2 should land song1 at position 2: {info}"
+    );
+}
+
+#[tokio::test]
+async fn move_multi_item_range_forward_lands_at_final_position() {
+    let (_server, mut client, _tmp) = setup_with_db(4).await;
+    client.command("add \"music/song1.flac\"").await;
+    client.command("add \"music/song2.flac\"").await;
+    client.command("add \"music/song3.flac\"").await;
+    client.command("add \"music/song4.flac\"").await;
+
+    // Moving the 2-song range [0,2) forward to final position 2: song3,
+    // song4 (currently at [2,4)) shift back to fill [0,2), and song1,
+    // song2 land at [2,4) in order.
+    let resp = client.command("move 0:2 2").await;
+    assert_ok(&resp);
+
+    let info = client.command("playlistinfo").await;
+    let files: Vec<&str> = info
+        .lines()
+        .filter_map(|l| l.strip_prefix("file: "))
+        .collect();
+    assert_eq!(
+        files,
+        vec![
+            "music/song3.flac",
+            "music/song4.flac",
+            "music/song1.flac",
+            "music/song2.flac",
+        ],
+        "move 0:2 2 should land the [song1,song2] block at [2,4): {info}"
+    );
+}
+
+#[tokio::test]
+async fn move_range_destination_out_of_bounds_is_error() {
+    let (_server, mut client, _tmp) = setup_with_db(3).await;
+    client.command("add \"music/song1.flac\"").await;
+    client.command("add \"music/song2.flac\"").await;
+    client.command("add \"music/song3.flac\"").await;
+
+    // Moving the 2-song range [0,2) leaves only 1 slot (3 - 2); `to = 2`
+    // doesn't fit and must ACK "Number too large", not silently succeed.
+    let resp = client.command("move 0:2 2").await;
+    assert!(
+        resp.starts_with("ACK [2@0]") && resp.contains("Number too large"),
+        "unexpected response: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn swap_accepts_quoted_arguments() {
+    let (_server, mut client, _tmp) = setup_with_db(3).await;
+    client.command("add \"music/song1.flac\"").await;
+    client.command("add \"music/song2.flac\"").await;
+
+    // libmpdclient-style clients quote every argument, including bare
+    // integers; `swap`/`swapid` must accept that, not just bare digits.
+    let resp = client.command("swap \"0\" \"1\"").await;
+    assert_ok(&resp);
+}
+
+#[tokio::test]
+async fn rangeid_empty_clears_the_range() {
+    let (_server, mut client, _tmp) = setup_with_db(3).await;
+    let resp = client.command("addid \"music/song1.flac\"").await;
+    let id = get_field(&resp, "Id").unwrap().to_string();
+
+    let resp = client.command(&format!("rangeid {id} 1.5:3.0")).await;
+    assert_ok(&resp);
+    let info = client.command("playlistid").await;
+    assert!(
+        get_field(&info, "Range").is_some(),
+        "range should be set: {info}"
+    );
+
+    // A bare ":" clears the range entirely ("play everything").
+    let resp = client.command(&format!("rangeid {id} :")).await;
+    assert_ok(&resp);
+    let info = client.command("playlistid").await;
+    assert!(
+        get_field(&info, "Range").is_none(),
+        "range should be cleared: {info}"
+    );
+}
+
+#[tokio::test]
+async fn addtagid_rejects_local_database_song() {
+    let (_server, mut client, _tmp) = setup_with_db(3).await;
+    let resp = client.command("addid \"music/song1.flac\"").await;
+    let id = get_field(&resp, "Id").unwrap();
+
+    // MPD only allows tag edits on remote songs; local/database files ACK.
+    let resp = client
+        .command(&format!("addtagid {id} Artist \"New Artist\""))
+        .await;
+    assert!(
+        resp.starts_with("ACK [4@0]") && resp.contains("Cannot edit tags of local file"),
+        "unexpected response: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn addtagid_and_cleartagid_on_remote_song() {
+    let (_server, mut client) = setup().await;
+    let resp = client
+        .command("addid \"http://example.com/stream.mp3\"")
+        .await;
+    let id = get_field(&resp, "Id").unwrap();
+
+    let resp = client
+        .command(&format!("addtagid {id} Artist \"New Artist\""))
+        .await;
+    assert_ok(&resp);
+
+    let resp = client.command(&format!("cleartagid {id} Artist")).await;
+    assert_ok(&resp);
+}
+
+// ── `add` directory/root selection (recursive, path-sorted) ────────────
+
+#[tokio::test]
+async fn add_root_queues_entire_database_in_path_order() {
+    let (_server, mut client, _tmp) = setup_with_songs(&[
+        "music/album1/song1.flac",
+        "music/album1/song2.flac",
+        "music/album2/song3.flac",
+    ])
+    .await;
+
+    // `mpc add /` strips the trailing slash and sends `add ""`; both forms
+    // must add the whole database, path-sorted.
+    let resp = client.command("add \"\"").await;
+    assert_ok(&resp);
+
+    let info = client.command("playlistinfo").await;
+    assert_ok(&info);
+    let files: Vec<&str> = info
+        .lines()
+        .filter_map(|l| l.strip_prefix("file: "))
+        .collect();
+    assert_eq!(
+        files,
+        vec![
+            "music/album1/song1.flac",
+            "music/album1/song2.flac",
+            "music/album2/song3.flac",
+        ],
+        "add \"\" should queue every song in path order: {info}"
+    );
+
+    let resp = client.command("add \"/\"").await;
+    assert_ok(&resp);
+    let status = client.command("status").await;
+    assert_eq!(
+        get_field(&status, "playlistlength"),
+        Some("6"),
+        "add \"/\" should also queue the whole database again"
+    );
+}
+
+#[tokio::test]
+async fn add_directory_queues_only_that_subtree() {
+    let (_server, mut client, _tmp) = setup_with_songs(&[
+        "music/album1/song1.flac",
+        "music/album1/song2.flac",
+        "music/album2/song3.flac",
+    ])
+    .await;
+
+    let resp = client.command("add \"music/album1\"").await;
+    assert_ok(&resp);
+
+    let info = client.command("playlistinfo").await;
+    let files: Vec<&str> = info
+        .lines()
+        .filter_map(|l| l.strip_prefix("file: "))
+        .collect();
+    assert_eq!(
+        files,
+        vec!["music/album1/song1.flac", "music/album1/song2.flac"],
+        "add on a directory should only queue that subtree: {info}"
+    );
+}
+
+#[tokio::test]
+async fn add_directory_with_position_inserts_the_block() {
+    let (_server, mut client, _tmp) = setup_with_songs(&[
+        "music/album1/song1.flac",
+        "music/album1/song2.flac",
+        "music/other/sentinel.flac",
+    ])
+    .await;
+
+    client.command("add \"music/other/sentinel.flac\"").await;
+    let resp = client.command("add \"music/album1\" 0").await;
+    assert_ok(&resp);
+
+    let info = client.command("playlistinfo").await;
+    let files: Vec<&str> = info
+        .lines()
+        .filter_map(|l| l.strip_prefix("file: "))
+        .collect();
+    assert_eq!(
+        files,
+        vec![
+            "music/album1/song1.flac",
+            "music/album1/song2.flac",
+            "music/other/sentinel.flac",
+        ],
+        "the added directory block should be inserted at position 0: {info}"
+    );
+}
+
+#[tokio::test]
+async fn add_unknown_uri_still_acks() {
+    let (_server, mut client, _tmp) = setup_with_songs(&["music/album1/song1.flac"]).await;
+
+    let resp = client.command("add \"no/such/directory\"").await;
+    assert!(
+        resp.starts_with("ACK [50@0]") && resp.contains("No such directory"),
+        "unexpected response: {resp}"
+    );
+}
+
+// ── playlistfind/playlistsearch filter-expression grammar ──────────────
+
+#[tokio::test]
+async fn playlistfind_expression_form() {
+    let (_server, mut client, _tmp) = setup_with_db(3).await;
+    client.command("add \"music/song1.flac\"").await;
+    client.command("add \"music/song2.flac\"").await;
+    client.command("add \"music/song3.flac\"").await;
+
+    let resp = client
+        .command("playlistfind \"(artist == 'Test Artist')\"")
+        .await;
+    assert_ok(&resp);
+    let count = resp.matches("file:").count();
+    assert_eq!(count, 3, "expression form should match all 3 songs: {resp}");
+}
+
+#[tokio::test]
+async fn playlistsearch_expression_form_with_sort_and_window() {
+    let (_server, mut client, _tmp) = setup_with_db(3).await;
+    client.command("add \"music/song1.flac\"").await;
+    client.command("add \"music/song2.flac\"").await;
+    client.command("add \"music/song3.flac\"").await;
+
+    let resp = client
+        .command("playlistsearch \"(artist contains 'test')\" sort Title window 0:1")
+        .await;
+    assert_ok(&resp);
+    let titles: Vec<&str> = resp
+        .lines()
+        .filter_map(|l| l.strip_prefix("Title: "))
+        .collect();
+    assert_eq!(
+        titles,
+        vec!["Track 1"],
+        "sort Title + window 0:1 should return only the first title: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn playlistfind_legacy_pair_form_still_works() {
+    let (_server, mut client, _tmp) = setup_with_db(3).await;
+    client.command("add \"music/song1.flac\"").await;
+    client.command("add \"music/song2.flac\"").await;
+
+    let resp = client.command("playlistfind Artist \"Test Artist\"").await;
+    assert_ok(&resp);
+    let count = resp.matches("file:").count();
+    assert_eq!(count, 2, "legacy TAG VALUE form should still match: {resp}");
+}
+
+#[tokio::test]
+async fn playlistfind_unknown_filter_tag_is_error() {
+    let (_server, mut client, _tmp) = setup_with_db(1).await;
+    client.command("add \"music/song1.flac\"").await;
+
+    let resp = client.command("playlistfind \"(bogus == 'x')\"").await;
+    assert!(
+        resp.starts_with("ACK [2@0]") && resp.contains("Unknown filter type: bogus"),
+        "unexpected response: {resp}"
+    );
+}
+
+// ── plchanges field parity with playlistinfo/playlistid ────────────────
+
+#[tokio::test]
+async fn plchanges_includes_prio() {
+    let (_server, mut client, _tmp) = setup_with_db(2).await;
+    client.command("add \"music/song1.flac\"").await;
+    client.command("add \"music/song2.flac\"").await;
+
+    let resp = client.command("prio 200 0").await;
+    assert_ok(&resp);
+
+    let resp = client.command("plchanges 0").await;
+    assert_ok(&resp);
+    assert!(
+        resp.contains("Prio: 200"),
+        "plchanges should include Prio like playlistinfo/playlistid: {resp}"
+    );
 }

--- a/rmpd-protocol/tests/reflection_commands.rs
+++ b/rmpd-protocol/tests/reflection_commands.rs
@@ -105,3 +105,138 @@ fn test_kill_command() {
     let response = "OK\n";
     assert!(TestClient::is_ok(response));
 }
+
+// ── Real behavioral tests for fixed protocol-compliance gaps ──────────
+// (the tests above are pre-existing placeholders that assert on literal
+// strings, not handler output; these call the actual handlers.)
+
+use rmpd_protocol::commands::connection;
+use rmpd_protocol::commands::reflection;
+use rmpd_protocol::parser::{StringNormalizationSubcommand, TagTypesSubcommand};
+use rmpd_protocol::{AppState, ConnectionState};
+
+#[tokio::test]
+async fn tagtypes_available_lists_all_tags_even_when_disabled() {
+    let mut conn_state = ConnectionState::new();
+    conn_state.disable_all_tags();
+
+    let bare = reflection::handle_tagtypes_command(&mut conn_state, None).await;
+    assert!(
+        !bare.contains("tagtype: Artist"),
+        "bare tagtypes must respect the disabled set: {bare}"
+    );
+
+    let available =
+        reflection::handle_tagtypes_command(&mut conn_state, Some(TagTypesSubcommand::Available))
+            .await;
+    assert!(
+        available.contains("tagtype: Artist") && available.contains("tagtype: DiscSubtitle"),
+        "available must list every globally-advertised tag regardless of enabled state: {available}"
+    );
+}
+
+#[tokio::test]
+async fn tagtypes_never_advertises_comment() {
+    // MPD's global_tag_mask excludes Comment by default (tag/Settings.cxx);
+    // it never appears in `tagtypes` or `tagtypes available`, even after
+    // `tagtypes enable Comment` or `tagtypes all`.
+    let mut conn_state = ConnectionState::new();
+
+    let available =
+        reflection::handle_tagtypes_command(&mut conn_state, Some(TagTypesSubcommand::Available))
+            .await;
+    assert!(
+        !available.contains("tagtype: Comment"),
+        "available must not advertise Comment: {available}"
+    );
+
+    reflection::handle_tagtypes_command(
+        &mut conn_state,
+        Some(TagTypesSubcommand::Enable {
+            tags: vec!["Comment".to_string()],
+        }),
+    )
+    .await;
+    reflection::handle_tagtypes_command(&mut conn_state, Some(TagTypesSubcommand::All)).await;
+
+    let bare = reflection::handle_tagtypes_command(&mut conn_state, None).await;
+    assert!(
+        !bare.contains("tagtype: Comment"),
+        "bare tagtypes must not surface Comment even after enable/all: {bare}"
+    );
+}
+
+#[tokio::test]
+async fn stringnormalization_enable_disable_and_available() {
+    let mut conn_state = ConnectionState::new();
+
+    let bare = reflection::handle_stringnormalization_command(&mut conn_state, None).await;
+    assert_eq!(bare, "OK\n", "no normalization enabled by default: {bare}");
+
+    let available = reflection::handle_stringnormalization_command(
+        &mut conn_state,
+        Some(StringNormalizationSubcommand::Available),
+    )
+    .await;
+    assert!(available.contains("stringnormalization: strip_diacritics"));
+
+    let enabled = reflection::handle_stringnormalization_command(
+        &mut conn_state,
+        Some(StringNormalizationSubcommand::Enable {
+            options: vec!["strip_diacritics".to_string()],
+        }),
+    )
+    .await;
+    assert_eq!(enabled, "OK\n");
+
+    let bare = reflection::handle_stringnormalization_command(&mut conn_state, None).await;
+    assert!(bare.contains("stringnormalization: strip_diacritics"));
+
+    let unknown = reflection::handle_stringnormalization_command(
+        &mut conn_state,
+        Some(StringNormalizationSubcommand::Enable {
+            options: vec!["bogus".to_string()],
+        }),
+    )
+    .await;
+    assert!(unknown.contains("ACK"));
+}
+
+#[tokio::test]
+async fn config_rejects_remote_clients() {
+    let state = AppState::new();
+    let mut conn_state = ConnectionState::new();
+    conn_state.is_local = false;
+
+    let resp = connection::handle_config_command(&state, &conn_state).await;
+    assert!(resp.contains("ACK"));
+    assert!(resp.contains("Command only permitted to local clients"));
+}
+
+#[tokio::test]
+async fn config_allows_local_clients() {
+    let state = AppState::with_paths(
+        "/tmp/rmpd_test_db".to_string(),
+        "/tmp/rmpd_test_music".to_string(),
+    );
+    let mut conn_state = ConnectionState::new();
+    conn_state.is_local = true;
+
+    let resp = connection::handle_config_command(&state, &conn_state).await;
+    assert!(resp.ends_with("OK\n"), "got: {resp}");
+    assert!(resp.contains("music_directory: /tmp/rmpd_test_music"));
+}
+
+#[tokio::test]
+async fn urlhandlers_hides_file_scheme_from_remote_clients() {
+    let mut conn_state = ConnectionState::new();
+    conn_state.is_local = false;
+    let remote = reflection::handle_urlhandlers_command(&conn_state).await;
+    assert!(!remote.contains("file://"), "got: {remote}");
+    assert!(remote.contains("handler: http://"));
+    assert!(remote.contains("handler: https://"));
+
+    conn_state.is_local = true;
+    let local = reflection::handle_urlhandlers_command(&conn_state).await;
+    assert!(local.contains("handler: file://"), "got: {local}");
+}

--- a/rmpd-protocol/tests/sticker_idle.rs
+++ b/rmpd-protocol/tests/sticker_idle.rs
@@ -1,0 +1,63 @@
+//! Verifies `sticker set`/`delete`/`inc`/`dec` notify idle `sticker` clients,
+//! matching MPD's `idle_add(IDLE_STICKER)` in `sticker/Database.cxx`.
+
+use rmpd_core::event::{Event, Subsystem};
+use rmpd_library::Database;
+use rmpd_protocol::commands::stickers;
+use rmpd_protocol::state::AppState;
+
+#[test]
+fn sticker_changed_event_maps_to_subsystem() {
+    assert!(
+        Event::StickerChanged
+            .subsystems()
+            .contains(&Subsystem::Sticker),
+        "Event::StickerChanged must map to Subsystem::Sticker"
+    );
+}
+
+async fn state_with_song() -> (AppState, tempfile::TempDir) {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    {
+        let db = Database::open(db_path.to_str().unwrap()).unwrap();
+        db.add_song(&rmpd_core::test_utils::make_test_song("song1.flac", 1))
+            .unwrap();
+    }
+    let state = AppState::with_all_paths(
+        db_path.to_str().unwrap().to_string(),
+        tmp.path().join("music").to_str().unwrap().to_string(),
+        tmp.path().join("playlists").to_str().unwrap().to_string(),
+    );
+    (state, tmp)
+}
+
+#[tokio::test]
+async fn sticker_set_emits_notification() {
+    let (state, _tmp) = state_with_song().await;
+    let mut rx = state.event_bus.subscribe();
+
+    let resp =
+        stickers::handle_sticker_set_command(&state, "song", "song1.flac", "rating", "5").await;
+    assert!(resp.contains("OK"), "got: {resp}");
+
+    assert!(
+        rx.try_recv()
+            .is_ok_and(|ev| matches!(ev, Event::StickerChanged)),
+        "sticker set must emit Event::StickerChanged"
+    );
+}
+
+#[tokio::test]
+async fn sticker_get_does_not_emit_notification() {
+    let (state, _tmp) = state_with_song().await;
+    stickers::handle_sticker_set_command(&state, "song", "song1.flac", "rating", "5").await;
+
+    let mut rx = state.event_bus.subscribe();
+    let resp = stickers::handle_sticker_get_command(&state, "song", "song1.flac", "rating").await;
+    assert!(resp.contains("OK"), "got: {resp}");
+    assert!(
+        rx.try_recv().is_err(),
+        "read-only sticker get must not emit an idle notification"
+    );
+}

--- a/rmpd-protocol/tests/stickers_commands.rs
+++ b/rmpd-protocol/tests/stickers_commands.rs
@@ -1,82 +1,252 @@
 //! Integration tests for sticker commands
 
-mod common;
+#[path = "common/tcp_harness.rs"]
+mod tcp_harness;
+use tcp_harness::*;
 
-use common::TestClient;
+#[tokio::test]
+async fn test_sticker_get_set_list_delete_roundtrip() {
+    let (_server, mut client, _tmp) = setup_with_db(1).await;
+    let uri = "music/song1.flac";
 
-#[test]
-fn test_sticker_get_command() {
-    // sticker get should return sticker value
-    let response = "sticker: rating=5\nOK\n";
-    assert!(TestClient::is_ok(response));
+    assert_ok(
+        &client
+            .command(&format!("sticker set song \"{uri}\" rating 5"))
+            .await,
+    );
+
+    let get = client
+        .command(&format!("sticker get song \"{uri}\" rating"))
+        .await;
+    assert_eq!(get, "sticker: rating=5\nOK\n");
+
+    let list = client
+        .command(&format!("sticker list song \"{uri}\""))
+        .await;
+    assert!(list.contains("sticker: rating=5"), "got: {list}");
+
+    assert_ok(
+        &client
+            .command(&format!("sticker delete song \"{uri}\" rating"))
+            .await,
+    );
+    let after = client
+        .command(&format!("sticker get song \"{uri}\" rating"))
+        .await;
+    assert!(after.starts_with("ACK"), "got: {after}");
 }
 
-#[test]
-fn test_sticker_get_not_found() {
-    // sticker get for non-existent sticker
-    let response = "ACK [50@0] {sticker} no such sticker\n";
-    assert!(TestClient::is_error(response));
+#[tokio::test]
+async fn test_sticker_get_not_found() {
+    let (_server, mut client, _tmp) = setup_with_db(1).await;
+    let response = client
+        .command("sticker get song \"music/song1.flac\" nosuch")
+        .await;
+    assert!(response.starts_with("ACK [50@0]"), "got: {response}");
 }
 
-#[test]
-fn test_sticker_set_command() {
-    // sticker set should set sticker value
-    let response = "OK\n";
-    assert!(TestClient::is_ok(response));
+#[tokio::test]
+async fn test_sticker_set_empty_name_rejected() {
+    let (_server, mut client, _tmp) = setup_with_db(1).await;
+    let response = client
+        .command("sticker set song \"music/song1.flac\" \"\" \"x\"")
+        .await;
+    assert!(response.starts_with("ACK"), "got: {response}");
+    assert!(response.contains("empty sticker name"), "got: {response}");
 }
 
-#[test]
-fn test_sticker_delete_command() {
-    // sticker delete should remove sticker
-    let response = "OK\n";
-    assert!(TestClient::is_ok(response));
+#[tokio::test]
+async fn test_sticker_inc_dec_command() {
+    // MPD's Inc/Dec never print the new value: just OK.
+    let (_server, mut client, _tmp) = setup_with_db(1).await;
+    let uri = "music/song1.flac";
+    let inc = client
+        .command(&format!("sticker inc song \"{uri}\" plays 3"))
+        .await;
+    assert_eq!(inc, "OK\n");
+    let dec = client
+        .command(&format!("sticker dec song \"{uri}\" plays 1"))
+        .await;
+    assert_eq!(dec, "OK\n");
+
+    let get = client
+        .command(&format!("sticker get song \"{uri}\" plays"))
+        .await;
+    assert_eq!(get, "sticker: plays=2\nOK\n");
 }
 
-#[test]
-fn test_sticker_list_command() {
-    // sticker list should list all stickers for URI
-    let response = "sticker: rating=5\nsticker: playcount=10\nOK\n";
-    assert!(TestClient::is_ok(response));
+#[tokio::test]
+async fn test_sticker_inc_missing_delta_is_bad_request() {
+    // The delta argument is mandatory in MPD; omitting it isn't "increment
+    // by 1" (rmpd used to default it) — it's the same "bad request" a valid
+    // domain with an unrecognized subcommand gets.
+    let (_server, mut client, _tmp) = setup_with_db(1).await;
+    let response = client
+        .command("sticker inc song \"music/song1.flac\" plays")
+        .await;
+    assert_eq!(response, "ACK [2@0] {sticker} bad request\n");
 }
 
-#[test]
-fn test_sticker_find_command() {
-    // sticker find should find URIs with matching sticker
-    let response = "file: song1.mp3\nsticker: rating=5\nfile: song2.mp3\nsticker: rating=5\nOK\n";
-    assert!(TestClient::is_ok(response));
+#[tokio::test]
+async fn test_sticker_delete_all_with_nothing_to_delete_is_ok() {
+    // Real MPD crashes here (StickerCommands.cxx formats a nullptr with
+    // FmtError when the unnamed delete removes zero rows) — a genuine
+    // upstream bug, not a spec to match. rmpd returns OK instead.
+    let (_server, mut client, _tmp) = setup_with_db(1).await;
+    let response = client
+        .command("sticker delete song \"music/song1.flac\"")
+        .await;
+    assert_ok(&response);
 }
 
-#[test]
-fn test_sticker_inc_command() {
-    // sticker inc should increment integer sticker
-    let response = "OK\n";
-    assert!(TestClient::is_ok(response));
+#[tokio::test]
+async fn test_sticker_unrecognized_subcommand_validates_domain_first() {
+    // MPD's handle_sticker resolves the domain (2nd token) before it ever
+    // looks at the subcommand (1st token), so an invalid domain still wins
+    // over an unrecognized subcommand.
+    let (_server, mut client, _tmp) = setup_with_db(1).await;
+
+    let response = client.command("sticker bogusop bogusdomain uri").await;
+    assert_eq!(
+        response,
+        "ACK [2@0] {sticker} unknown sticker domain \"bogusdomain\"\n"
+    );
+
+    let response = client
+        .command("sticker bogusop song \"music/song1.flac\"")
+        .await;
+    assert_eq!(response, "ACK [2@0] {sticker} bad request\n");
 }
 
-#[test]
-fn test_sticker_dec_command() {
-    // sticker dec should decrement integer sticker
-    let response = "OK\n";
-    assert!(TestClient::is_ok(response));
+#[tokio::test]
+async fn test_sticker_unsupported_domain_rejected() {
+    // rmpd's sticker table only backs the `song` domain; other MPD 0.24
+    // domains must fail loudly instead of misreading the domain as a URI.
+    let (_server, mut client, _tmp) = setup_with_db(1).await;
+    let response = client
+        .command("sticker get playlist \"myplaylist\" rating")
+        .await;
+    assert!(response.starts_with("ACK [2@0]"), "got: {response}");
+
+    let response = client.command("sticker get bogus \"x\" rating").await;
+    assert!(response.starts_with("ACK [2@0]"), "got: {response}");
+    assert!(
+        response.contains("unknown sticker domain"),
+        "got: {response}"
+    );
 }
 
-#[test]
-fn test_sticker_names_command() {
-    // sticker names should list all sticker names
-    let response = "name: rating\nname: playcount\nOK\n";
-    assert!(TestClient::is_ok(response));
+#[tokio::test]
+async fn test_sticker_find_with_equals_operator() {
+    let (_server, mut client, _tmp) = setup_with_db(2).await;
+    assert_ok(
+        &client
+            .command("sticker set song \"music/song1.flac\" rating 5")
+            .await,
+    );
+    assert_ok(
+        &client
+            .command("sticker set song \"music/song2.flac\" rating 9")
+            .await,
+    );
+
+    let response = client.command("sticker find song \"\" rating = 5").await;
+    assert!(response.contains("music/song1.flac"), "got: {response}");
+    assert!(!response.contains("music/song2.flac"), "got: {response}");
 }
 
-#[test]
-fn test_sticker_types_command() {
-    // sticker types should list supported types
-    let response = "type: string\ntype: int\nOK\n";
-    assert!(TestClient::is_ok(response));
+#[tokio::test]
+async fn test_sticker_find_sort_and_window() {
+    let (_server, mut client, _tmp) = setup_with_db(3).await;
+    assert_ok(
+        &client
+            .command("sticker set song \"music/song1.flac\" rating 5")
+            .await,
+    );
+    assert_ok(
+        &client
+            .command("sticker set song \"music/song2.flac\" rating 1")
+            .await,
+    );
+    assert_ok(
+        &client
+            .command("sticker set song \"music/song3.flac\" rating 9")
+            .await,
+    );
+
+    // Sort ascending by numeric value, take just the middle one via window.
+    let response = client
+        .command("sticker find song \"\" rating sort value_int window \"1:2\"")
+        .await;
+    assert_ok(&response);
+    assert!(response.contains("music/song1.flac"), "got: {response}");
+    assert!(!response.contains("music/song2.flac"), "got: {response}");
+    assert!(!response.contains("music/song3.flac"), "got: {response}");
 }
 
-#[test]
-fn test_sticker_namestypes_command() {
-    // sticker namestypes should list names with their types
-    let response = "name: rating\ntype: int\nname: comment\ntype: string\nOK\n";
-    assert!(TestClient::is_ok(response));
+#[tokio::test]
+async fn test_sticker_find_unknown_sort_tag_rejected() {
+    let (_server, mut client, _tmp) = setup_with_db(1).await;
+    let response = client
+        .command("sticker find song \"\" rating sort bogus")
+        .await;
+    assert!(response.starts_with("ACK [2@0]"), "got: {response}");
+}
+
+#[tokio::test]
+async fn test_stickernames_is_global_not_uri_scoped() {
+    // `stickernames` takes no arguments and lists every distinct sticker
+    // name across all songs (MPD's `SELECT DISTINCT name FROM sticker`).
+    let (_server, mut client, _tmp) = setup_with_db(2).await;
+    assert_ok(
+        &client
+            .command("sticker set song \"music/song1.flac\" rating 5")
+            .await,
+    );
+    assert_ok(
+        &client
+            .command("sticker set song \"music/song2.flac\" playcount 10")
+            .await,
+    );
+
+    let response = client.command("stickernames").await;
+    assert!(response.contains("name: playcount"), "got: {response}");
+    assert!(response.contains("name: rating"), "got: {response}");
+    assert!(!response.contains("sticker:"), "got: {response}");
+}
+
+#[tokio::test]
+async fn test_stickernamestypes_lists_name_and_type_pairs() {
+    let (_server, mut client, _tmp) = setup_with_db(1).await;
+    assert_ok(
+        &client
+            .command("sticker set song \"music/song1.flac\" rating 5")
+            .await,
+    );
+
+    let response = client.command("stickernamestypes").await;
+    assert!(
+        response.contains("name: rating\ntype: song"),
+        "got: {response}"
+    );
+
+    // A domain with no stored stickers legitimately yields an empty OK.
+    let response = client.command("stickernamestypes playlist").await;
+    assert_eq!(response, "OK\n");
+}
+
+#[tokio::test]
+async fn test_sticker_types_command() {
+    let (_server, mut client) = setup().await;
+    let response = client.command("stickertypes").await;
+    assert!(
+        response.starts_with("stickertype: filter\n"),
+        "got: {response}"
+    );
+    assert!(
+        response.contains("stickertype: playlist\n"),
+        "got: {response}"
+    );
+    assert!(response.contains("stickertype: song\n"), "got: {response}");
+    assert_ok(&response);
 }

--- a/rmpd-protocol/tests/storage_commands.rs
+++ b/rmpd-protocol/tests/storage_commands.rs
@@ -86,8 +86,7 @@ async fn test_unmount_nonexistent() {
 
     let response = storage::handle_unmount_command(&state, "nonexistent").await;
     assert!(response.contains("ACK"));
-    // In Tier 1 mode, unmounting unregistered mount returns error
-    assert!(response.contains("not found") || response.contains("failed"));
+    assert!(response.contains("Not a mount point"));
 }
 
 #[tokio::test]
@@ -133,4 +132,44 @@ async fn test_protocol_extraction() {
             _ => panic!("Unexpected mount path"),
         }
     }
+}
+
+#[tokio::test]
+async fn test_mount_empty_path_rejected() {
+    let state = test_state();
+
+    let response = storage::handle_mount_command(&state, "", "nfs://server/share").await;
+    assert!(response.contains("ACK"));
+    assert!(response.contains("Bad mount point"));
+}
+
+#[tokio::test]
+async fn test_unmount_empty_path_rejected() {
+    let state = test_state();
+
+    let response = storage::handle_unmount_command(&state, "").await;
+    assert!(response.contains("ACK"));
+    assert!(response.contains("Bad mount point"));
+}
+
+#[tokio::test]
+async fn test_mount_and_unmount_emit_mount_idle() {
+    use rmpd_core::event::Event;
+
+    let state = test_state();
+    let mut rx = state.event_bus.subscribe();
+
+    storage::handle_mount_command(&state, "remote/nas", "nfs://192.168.1.100/music").await;
+    let mut got = false;
+    while let Ok(ev) = rx.try_recv() {
+        got |= matches!(ev, Event::MountsChanged);
+    }
+    assert!(got, "mount must emit Event::MountsChanged");
+
+    storage::handle_unmount_command(&state, "remote/nas").await;
+    let mut got = false;
+    while let Ok(ev) = rx.try_recv() {
+        got |= matches!(ev, Event::MountsChanged);
+    }
+    assert!(got, "unmount must emit Event::MountsChanged");
 }

--- a/rmpd/src/app.rs
+++ b/rmpd/src/app.rs
@@ -136,7 +136,7 @@ pub async fn run(bind_address: String, config: Config) -> Result<()> {
     // Trigger an initial library scan on startup when auto-update is enabled.
     if config.database.auto_update {
         info!("auto-update enabled: scanning music directory");
-        state.spawn_library_update();
+        state.spawn_library_update(false).await;
     }
 
     // Sync enabled music sources (ping first; unreachable sources are skipped).
@@ -276,6 +276,17 @@ async fn restore_state(
         if !enabled.is_empty() {
             state.engine.write().await.set_outputs(enabled);
         }
+    }
+
+    // Restore the last-loaded-playlist name unconditionally (mirrors MPD's
+    // PlaylistState.cxx, which sets it directly from the state file and
+    // doesn't depend on whether any songs are also being restored).
+    if !saved_state.last_loaded_playlist.is_empty() {
+        state
+            .queue
+            .write()
+            .await
+            .set_last_loaded_playlist(saved_state.last_loaded_playlist.clone());
     }
 
     // Restore playlist


### PR DESCRIPTION
Audited rmpd against upstream MPD master (`~/M0Rf30/MPD`, `793eb1219`) and the official `mpc` client, then verified by **running real MPD 0.24.0 on `:6611` beside rmpd on `:6610` over the same library and byte-comparing every response**. That differential harness found bugs no source review did — including several that made rmpd unusable with `mpc`.

## Result

- **116/116 byte-identical replies** on the final id-aligned differential sweep
- All 11 `move` state cases identical; id-addressed commands identical once ids are resolved per server; `idle` delivery identical
- Full `mpc` session works end to end: add / play / seek / pause / next / volume / options / search / list / playlists / stickers / outputs / stats / idle
- **1040 tests pass, 0 failures** (from 987; +53 regression tests), `clippy --all-targets --all-features -D warnings` clean, `fmt --check` clean

## Highest-impact fixes

| Bug | Before → After |
|---|---|
| **Forward `move` was a no-op / off-by-one** | `move 0 1` on `1234` → `1234`; now `2134`. `TO` is the index in the *resulting* queue (`Queue::MoveRange`) |
| **Queue ids started at 0** | `songid: 0` makes libmpdclient/mpc read "no song", so `mpc status` showed **nothing** while rmpd was playing. Now 1-based (`IdTable::next = 1`) |
| **Quoted arguments broke 9 commands** | `mpc update` failed with *"No such directory"* — `update`/`rescan`/`password`/`idle`/`addtagid`/`playlistfind`… used a quote-unaware tokenizer, while libmpdclient quotes everything |
| **`add /` and `add DIR` unsupported** | `mpc add /` failed; now adds the whole database / subtree recursively |
| **Query results in the wrong order** | Path-string sort; now MPD's `Directory::Walk` order (a directory's songs precede its subdirectories) |
| **`playlistfind`/`playlistsearch` returned nothing** | Stuck on the pre-0.21 `TAG VALUE` form; now full filter expressions plus `sort`/`window` |
| **`null` output never paced** | A 2-minute track finished in ~30 ms, so the queue raced to the end on `play`. Now real-time, like MPD's `Timer` (`sync`, default on) |
| **`any` filter matched nothing** | Treated as a literal tag name — `find any "x"` silently returned zero rows |
| **`stickernames` broken** | Demanded a URI, returned empty without one, emitted `sticker:` instead of `name:` |
| **`sticker` discarded its TYPE argument** | `sticker get playlist X rating` misread `X` as a song URI |
| **`sticker`/`subscription`/`message` idle events were dead** | No emitter existed; they could never fire |
| **`PERMISSION_PLAYER` (16) didn't exist** | ~30 commands mis-gated; `idle` had **no** permission check at all (long-poll path bypassed it) |
| **`close` in a command list panicked the connection** | Hit `unreachable!()` |

Plus: typed argument errors (`Boolean (0/1) expected: X`, `Float expected: X`, `Malformed range: 2:1`, `Number too large: 300`, `Invalid unquoted character`) now byte-exact instead of a blanket `wrong number of arguments`; filter grammar accepted `OR`/`<`/`>` that MPD has no operators for and lacked `base`/`modified-since`/`added-since`/`AudioFormat`/`prio` and the `_cs`/`_ci` operators; `find albumartist` skipped the tag fallback chain; `save` defaulted to replace instead of create; `nextsong` was emitted while stopped; `lastloadedplaylist` was never set; `Prio:` was missing from `plchanges`; `tagtypes` advertised `Comment`, which MPD masks; `config` answered remote clients; `lsinfo` used ACK 52 where MPD uses 50; `status`/`outputs` ignored the client's partition; `binarylimit` was a complete no-op; `albumart` read embedded art instead of cover files.

## Upstream MPD bug found

`sticker delete <type> <uri>` (no NAME) on a sticker-less URI **kills the daemon** — `DomainHandler::Delete` formats a `nullptr` with fmt when the delete modifies no rows (`src/command/StickerCommands.cxx:81-91`). Present in 0.24.0 and at master `793eb1219`; reproduced 3×. rmpd deliberately does **not** mimic it — there is no correct byte-target for a crash — and the code carries a comment so nobody "fixes" it by reading the C++ literally. A patch for upstream is prepared separately.

## Deliberately not implemented (reported, not stubbed)

- Per-partition queues and playback state — a client on another partition still sees the default queue. Subsystem, not a protocol detail.
- Multi-domain sticker storage (`playlist`/`filter`/tag domains).
- Per-password permission masks / `default_permissions`.
- MPD's *intra*-directory ordering: proven to be **reverse-`readdir`** (`readdir` gives `commented,rock,song3,song2,song1`; MPD emits `song1,song2,song3,commented`, exactly reversed, because `Directory::AddSong` prepends). A filesystem-dependent artifact, not a contract — rmpd keeps deterministic alphabetical order within a directory.

## Commits

Grouped by domain (10 commits). Shared files (`parser.rs`, `server.rs`) were touched by several domains, so grouping is file-level: individual commits are not independently green, only the branch tip is.
