### PR TITLE
fix(library): prune songs whose files are gone (update + watcher)

### DIFF
--- a/rmpd-library/src/database.rs
+++ b/rmpd-library/src/database.rs
@@ -1110,6 +1110,23 @@ impl Database {
         Ok(())
     }
 
+    /// List the paths of every local song, ordered by path.
+    ///
+    /// `source IS NULL` is the same predicate `delete_song_by_path` guards its
+    /// `DELETE` with, so this only ever returns local filesystem rows — never
+    /// remote catalog rows inserted by `add_source_song`. Used by the scanner to
+    /// find local rows whose file has disappeared from disk. Deliberately not
+    /// `list_all_songs`: that loads tags for every song and includes remote rows.
+    pub fn list_local_song_paths(&self) -> Result<Vec<String>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT path FROM songs WHERE source IS NULL ORDER BY path")?;
+        let paths = stmt
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(paths)
+    }
+
     /// Ensure the root directory (path="", parent_id=NULL) exists and return its id.
     /// Local scans create this automatically via `get_or_create_directory`; this
     /// method creates it on first use in a remote-only deployment.

--- a/rmpd-library/src/scanner.rs
+++ b/rmpd-library/src/scanner.rs
@@ -85,14 +85,70 @@ impl Scanner {
 
         scanner_with_dir.scan_recursive(db, root_path, &mut stats)?;
 
+        self.prune_missing(db, root_path, &mut stats);
+
         info!(
-            "scan complete: {} files scanned, {} added, {} updated, {} errors",
-            stats.scanned, stats.added, stats.updated, stats.errors
+            "scan complete: {} files scanned, {} added, {} updated, {} removed, {} errors",
+            stats.scanned, stats.added, stats.updated, stats.removed, stats.errors
         );
 
         self.event_bus.emit(Event::DatabaseUpdateFinished);
 
         Ok(stats)
+    }
+
+    /// Delete local song rows whose file is no longer present on disk.
+    ///
+    /// Iterates `Database::list_local_song_paths` (already scoped to
+    /// `source IS NULL`, so remote catalog rows from `add_source_song` are never
+    /// considered) and removes any row whose file `root_path.join(path)` does not
+    /// resolve to an existing regular file. A symlink counts as present only when
+    /// the scanner follows symlinks, mirroring the walk in `collect_audio_files`
+    /// (a row for a symlinked file is pruned by a scan configured not to follow
+    /// them, as MPD does).
+    ///
+    /// Assumes `root_path` is the music directory itself (the only way
+    /// `scan_directory` is called today). A scoped update of a subdirectory
+    /// would have to restrict the candidates to rows under that subtree first,
+    /// otherwise every row outside it would look missing.
+    fn prune_missing(&self, db: &Database, root_path: &Path, stats: &mut ScanStats) {
+        let paths = match db.list_local_song_paths() {
+            Ok(paths) => paths,
+            Err(e) => {
+                warn!("failed to list local songs for prune: {}", e);
+                stats.errors += 1;
+                return;
+            }
+        };
+
+        for path in paths {
+            if self.file_is_present(&root_path.join(&path)) {
+                continue;
+            }
+
+            match db.delete_song_by_path(&path) {
+                Ok(()) => {
+                    stats.removed += 1;
+                    debug!("pruned missing song: {}", path);
+                    self.event_bus.emit(Event::SongDeleted { path });
+                }
+                Err(e) => {
+                    warn!("failed to prune missing song {}: {}", path, e);
+                    stats.errors += 1;
+                }
+            }
+        }
+    }
+
+    /// Whether `path` is a regular file the scan would have visited: symlinks
+    /// only count when `follow_symlinks` is set, like `collect_audio_files`.
+    fn file_is_present(&self, path: &Path) -> bool {
+        if !self.follow_symlinks
+            && fs::symlink_metadata(path).is_ok_and(|m| m.file_type().is_symlink())
+        {
+            return false;
+        }
+        path.is_file()
     }
 
     /// Convert absolute path to relative path (relative to music_directory)
@@ -374,5 +430,6 @@ pub struct ScanStats {
     pub scanned: u32,
     pub added: u32,
     pub updated: u32,
+    pub removed: u32,
     pub errors: u32,
 }

--- a/rmpd-library/src/watcher.rs
+++ b/rmpd-library/src/watcher.rs
@@ -149,6 +149,7 @@ async fn handle_fs_event(
         EventKind::Create(_) | EventKind::Modify(_) => {
             for path in &event.paths {
                 if !is_audio_file(path) {
+                    prune_if_vanished_directory(path, music_dir, db, event_bus).await?;
                     continue;
                 }
 
@@ -230,6 +231,7 @@ async fn handle_fs_event(
         EventKind::Remove(_) => {
             for path in &event.paths {
                 if !is_audio_file(path) {
+                    prune_if_vanished_directory(path, music_dir, db, event_bus).await?;
                     continue;
                 }
 
@@ -273,10 +275,62 @@ async fn remove_song_row(
     Ok(())
 }
 
+/// If `path` is not an audio file (the caller already checked that) and no
+/// longer exists on disk, it denotes a directory (or some other non-audio
+/// path) that was removed or moved away out from under the watcher: `notify`
+/// reports the event on the directory path itself, not on each audio file
+/// inside it, so none of those files' own `Remove`/`Modify` events ever fire
+/// and `is_audio_file` never sees them. Prune every local row under it.
+/// A path that still exists (e.g. a directory that is untouched, or some
+/// other non-audio file) is left alone — the caller already skips it.
+async fn prune_if_vanished_directory(
+    path: &Path,
+    music_dir: &Path,
+    db: &Arc<Mutex<Database>>,
+    event_bus: &EventBus,
+) -> Result<()> {
+    if path.exists() {
+        return Ok(());
+    }
+
+    let relative_path = match path.strip_prefix(music_dir) {
+        Ok(p) => p,
+        Err(_) => return Ok(()),
+    };
+    let rel_str = relative_path.to_string_lossy().to_string();
+
+    debug!("directory vanished, pruning rows under: {}", rel_str);
+    remove_rows_under(db, event_bus, &rel_str).await
+}
+
+/// Delete every local row whose path is `rel` itself or starts with `rel/`,
+/// emitting `SongDeleted` for each — used when `rel` denotes a directory that
+/// vanished from disk. Reuses `remove_song_row` per matching row so each
+/// deletion still respects `delete_song_by_path`'s `source IS NULL` guard
+/// (remote catalog rows are never evicted) and still emits the same event a
+/// single vanished file would. A `rel` under which nothing matches (e.g. a
+/// non-audio file that vanished) is a no-op.
+async fn remove_rows_under(
+    db: &Arc<Mutex<Database>>,
+    event_bus: &EventBus,
+    rel: &str,
+) -> Result<()> {
+    let rows = {
+        let db_guard = db.lock().await;
+        db_guard.find_songs_by_prefix(rel)?
+    };
+
+    for song in rows {
+        remove_song_row(db, event_bus, song.path.as_str()).await?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use notify::event::{ModifyKind, RenameMode};
+    use notify::event::{ModifyKind, RemoveKind, RenameMode};
     use rmpd_core::song::Song;
 
     fn local_song(path: &str) -> Song {
@@ -335,5 +389,95 @@ mod tests {
             Ok(RmpdEvent::SongDeleted { path }) => assert_eq!(path, "song.flac"),
             other => panic!("expected SongDeleted for song.flac, got {other:?}"),
         }
+    }
+
+    /// Shared body for the two vanished-directory tests below: seed `dir/a.flac`,
+    /// `dir/b.flac` and a control row `other/c.flac`, feed `handle_fs_event` a
+    /// synthetic event of `kind` whose path is `music_dir/dir` (a directory that
+    /// does not exist on disk, since nothing was ever created there), and assert
+    /// both rows under `dir/` are gone, the control row survives, and a
+    /// `SongDeleted` was emitted for each pruned row.
+    async fn assert_vanished_directory_prunes_rows_under_it(kind: EventKind) {
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        let music_dir = temp_dir.path().join("music");
+        std::fs::create_dir(&music_dir).expect("create music dir");
+        let db_path = temp_dir.path().join("test.db");
+        let database = Database::open(db_path.to_str().unwrap()).expect("open database");
+        database
+            .add_song(&local_song("dir/a.flac"))
+            .expect("insert dir/a.flac");
+        database
+            .add_song(&local_song("dir/b.flac"))
+            .expect("insert dir/b.flac");
+        database
+            .add_song(&local_song("other/c.flac"))
+            .expect("insert control row other/c.flac");
+        let db = Arc::new(Mutex::new(database));
+        let event_bus = EventBus::new();
+        let mut rx = event_bus.subscribe();
+
+        // `dir` was never created on disk: the directory no longer exists.
+        let event = Event::new(kind).add_path(music_dir.join("dir"));
+        handle_fs_event(&event, &music_dir, &db, &event_bus)
+            .await
+            .expect("handle the synthetic event");
+
+        let db_guard = db.lock().await;
+        assert!(
+            db_guard
+                .get_song_by_path("dir/a.flac")
+                .expect("query")
+                .is_none(),
+            "dir/a.flac should be pruned along with the vanished directory"
+        );
+        assert!(
+            db_guard
+                .get_song_by_path("dir/b.flac")
+                .expect("query")
+                .is_none(),
+            "dir/b.flac should be pruned along with the vanished directory"
+        );
+        assert!(
+            db_guard
+                .get_song_by_path("other/c.flac")
+                .expect("query")
+                .is_some(),
+            "other/c.flac is outside the vanished directory and must survive"
+        );
+        drop(db_guard);
+
+        let mut deleted_paths = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            match event {
+                RmpdEvent::SongDeleted { path } => deleted_paths.push(path),
+                other => panic!("expected only SongDeleted events, got {other:?}"),
+            }
+        }
+        deleted_paths.sort();
+        assert_eq!(
+            deleted_paths,
+            vec!["dir/a.flac".to_string(), "dir/b.flac".to_string()],
+            "a SongDeleted event should be emitted for each pruned row"
+        );
+    }
+
+    /// A directory removed or moved away arrives from `notify` as a modify/rename
+    /// event on the directory's own path (backends differ; inotify reports
+    /// `MOVED_FROM`), not one event per file inside it — `is_audio_file` never
+    /// matches a directory, so without special handling every row under it would
+    /// be left behind (issue #12 follow-up).
+    #[tokio::test]
+    async fn modify_event_for_a_vanished_directory_prunes_rows_under_it() {
+        assert_vanished_directory_prunes_rows_under_it(EventKind::Modify(ModifyKind::Name(
+            RenameMode::From,
+        )))
+        .await;
+    }
+
+    /// Same as above, but for the `Remove` event kind `notify` reports when a
+    /// watched directory is deleted outright (e.g. `IN_DELETE_SELF` on inotify).
+    #[tokio::test]
+    async fn remove_event_for_a_vanished_directory_prunes_rows_under_it() {
+        assert_vanished_directory_prunes_rows_under_it(EventKind::Remove(RemoveKind::Folder)).await;
     }
 }

--- a/rmpd-library/src/watcher.rs
+++ b/rmpd-library/src/watcher.rs
@@ -163,6 +163,16 @@ async fn handle_fs_event(
 
                 let path_str = relative_path.to_string_lossy().to_string();
 
+                // `notify` reports a rename/move-away as a modify (sometimes a
+                // create for the source path), not a remove. If the path is no
+                // longer a regular file (gone, or replaced by a directory),
+                // treat it exactly like `Remove`.
+                if !path.is_file() {
+                    debug!("file moved away: {}", path_str);
+                    remove_song_row(db, event_bus, &path_str).await?;
+                    continue;
+                }
+
                 debug!("file created/modified: {}", path_str);
 
                 // Extract metadata off the async runtime: file I/O and tag parsing block.
@@ -175,6 +185,14 @@ async fn handle_fs_event(
                 let mut song = match extraction {
                     Ok(Ok(song)) => song,
                     Ok(Err(e)) => {
+                        // The file may have vanished between the `is_file` check
+                        // above and the extraction: then it is a removal, not an
+                        // extraction failure.
+                        if !path.is_file() {
+                            debug!("file moved away during extraction: {}", path_str);
+                            remove_song_row(db, event_bus, &path_str).await?;
+                            continue;
+                        }
                         warn!("failed to extract metadata from {}: {}", path_str, e);
                         continue;
                     }
@@ -224,15 +242,7 @@ async fn handle_fs_event(
 
                 debug!("file removed: {}", path_str);
 
-                // Remove from database
-                let db_guard = db.lock().await;
-                db_guard.delete_song_by_path(&path_str)?;
-                drop(db_guard);
-
-                // Emit event
-                event_bus.emit(RmpdEvent::SongDeleted {
-                    path: path_str.clone(),
-                });
+                remove_song_row(db, event_bus, &path_str).await?;
             }
         }
         _ => {
@@ -241,4 +251,89 @@ async fn handle_fs_event(
     }
 
     Ok(())
+}
+
+/// Delete a song's row and emit `SongDeleted`. Shared by the `Remove` branch
+/// and the `Create | Modify` branch's vanished-path check, so a file that
+/// disappears from disk is handled identically regardless of which `notify`
+/// event kind reported it.
+async fn remove_song_row(
+    db: &Arc<Mutex<Database>>,
+    event_bus: &EventBus,
+    path_str: &str,
+) -> Result<()> {
+    let db_guard = db.lock().await;
+    db_guard.delete_song_by_path(path_str)?;
+    drop(db_guard);
+
+    event_bus.emit(RmpdEvent::SongDeleted {
+        path: path_str.to_string(),
+    });
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use notify::event::{ModifyKind, RenameMode};
+    use rmpd_core::song::Song;
+
+    fn local_song(path: &str) -> Song {
+        Song {
+            id: 0,
+            path: path.into(),
+            duration: None,
+            sample_rate: None,
+            channels: None,
+            bits_per_sample: None,
+            bitrate: None,
+            replay_gain_track_gain: None,
+            replay_gain_track_peak: None,
+            replay_gain_album_gain: None,
+            replay_gain_album_peak: None,
+            added_at: 0,
+            last_modified: 0,
+            tags: Vec::new(),
+        }
+    }
+
+    /// A rename/move-away arrives from `notify` as a modify event for a path
+    /// that no longer exists (backends differ; inotify reports `MOVED_FROM`).
+    /// Independently of the backend, that event must delete the row and emit
+    /// `SongDeleted`, exactly like a `Remove` would.
+    #[tokio::test]
+    async fn modify_event_for_a_vanished_path_removes_the_row() {
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        let music_dir = temp_dir.path().join("music");
+        std::fs::create_dir(&music_dir).expect("create music dir");
+        let db_path = temp_dir.path().join("test.db");
+        let database = Database::open(db_path.to_str().unwrap()).expect("open database");
+        database
+            .add_song(&local_song("song.flac"))
+            .expect("insert the row the file used to have");
+        let db = Arc::new(Mutex::new(database));
+        let event_bus = EventBus::new();
+        let mut rx = event_bus.subscribe();
+
+        // The file was never created on disk: the path no longer exists.
+        let event = Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::From)))
+            .add_path(music_dir.join("song.flac"));
+        handle_fs_event(&event, &music_dir, &db, &event_bus)
+            .await
+            .expect("handle the synthetic event");
+
+        assert!(
+            db.lock()
+                .await
+                .get_song_by_path("song.flac")
+                .expect("query")
+                .is_none(),
+            "the row of a vanished path must be deleted"
+        );
+        match rx.try_recv() {
+            Ok(RmpdEvent::SongDeleted { path }) => assert_eq!(path, "song.flac"),
+            other => panic!("expected SongDeleted for song.flac, got {other:?}"),
+        }
+    }
 }

--- a/rmpd-library/tests/scanner_tests.rs
+++ b/rmpd-library/tests/scanner_tests.rs
@@ -343,3 +343,84 @@ async fn watcher_prunes_row_for_file_moved_away() {
          out of the music directory, but it is still in the database"
     );
 }
+
+/// Moving (or deleting) a whole directory reports the filesystem event on the
+/// directory's own path, not one event per file inside it — none of the
+/// contained files' own events ever fire, so the old `is_audio_file` gate
+/// silently dropped the directory path and left every row under it behind
+/// (issue #12 follow-up). The watcher must prune the whole subtree.
+#[tokio::test]
+async fn watcher_prunes_rows_for_directory_moved_away() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    std::fs::create_dir(temp_dir.path().join("music")).expect("create music dir");
+    std::fs::create_dir(temp_dir.path().join("elsewhere")).expect("create elsewhere dir");
+    // Resolve symlinks (macOS puts temp dirs behind /var -> /private/var), so the
+    // watcher's music-dir prefix matches the paths the OS reports for events.
+    let music_dir = std::fs::canonicalize(temp_dir.path().join("music")).expect("canonicalize");
+    let elsewhere_dir =
+        std::fs::canonicalize(temp_dir.path().join("elsewhere")).expect("canonicalize");
+    std::fs::create_dir(music_dir.join("dir")).expect("create music/dir");
+
+    let db_path = temp_dir.path().join("test.db");
+    let database = Database::open(db_path.to_str().unwrap()).expect("open database");
+    let db = Arc::new(Mutex::new(database));
+
+    let mut watcher = FilesystemWatcher::new(music_dir.clone(), db.clone(), EventBus::new())
+        .expect("create watcher");
+    watcher.start().await.expect("start watcher");
+
+    // Let the watcher's spawned event-handler task hook up before the
+    // debounced filesystem event arrives.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/samples/basic.flac");
+    std::fs::copy(&fixture, music_dir.join("dir").join("song.flac"))
+        .expect("copy fixture into music/dir");
+
+    // Debounce is 300ms, but filesystem-event latency varies by backend
+    // (inotify vs FSEvents), so poll instead of sleeping a fixed amount.
+    let mut song = None;
+    for _ in 0..60 {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        song = db
+            .lock()
+            .await
+            .get_song_by_path("dir/song.flac")
+            .expect("query by relative path");
+        if song.is_some() {
+            break;
+        }
+    }
+    assert!(
+        song.is_some(),
+        "dir/song.flac should be in the database before its directory is moved away"
+    );
+
+    // Move the whole directory outside the watched music directory, into
+    // another subdirectory of the same TempDir. `notify` reports this event
+    // on the directory's own path, not on the file inside it.
+    std::fs::rename(music_dir.join("dir"), elsewhere_dir.join("dir"))
+        .expect("move the directory out of the music dir");
+
+    let mut still_present = true;
+    for _ in 0..60 {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        still_present = db
+            .lock()
+            .await
+            .get_song_by_path("dir/song.flac")
+            .expect("query by relative path")
+            .is_some();
+        if !still_present {
+            break;
+        }
+    }
+
+    assert!(
+        !still_present,
+        "the watcher should have pruned dir/song.flac's row once its \
+         directory moved out of the music directory, but it is still \
+         in the database"
+    );
+}

--- a/rmpd-library/tests/scanner_tests.rs
+++ b/rmpd-library/tests/scanner_tests.rs
@@ -265,3 +265,81 @@ fn update_emits_song_deleted_for_pruned_rows() {
          refreshing on the update event already sees the pruned database"
     );
 }
+
+/// `notify` reports a file moved out of the watched tree as a modify/rename,
+/// not a remove — `handle_fs_event`'s `Create | Modify` branch used to try
+/// (and fail) to extract metadata from the now-vanished path and just log a
+/// warning, leaving a ghost row behind. It must instead treat a vanished path
+/// as a removal, the same way the `Remove` branch does.
+#[tokio::test]
+async fn watcher_prunes_row_for_file_moved_away() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    std::fs::create_dir(temp_dir.path().join("music")).expect("create music dir");
+    std::fs::create_dir(temp_dir.path().join("elsewhere")).expect("create elsewhere dir");
+    // Resolve symlinks (macOS puts temp dirs behind /var -> /private/var), so the
+    // watcher's music-dir prefix matches the paths the OS reports for events.
+    let music_dir = std::fs::canonicalize(temp_dir.path().join("music")).expect("canonicalize");
+    let elsewhere_dir =
+        std::fs::canonicalize(temp_dir.path().join("elsewhere")).expect("canonicalize");
+
+    let db_path = temp_dir.path().join("test.db");
+    let database = Database::open(db_path.to_str().unwrap()).expect("open database");
+    let db = Arc::new(Mutex::new(database));
+
+    let mut watcher = FilesystemWatcher::new(music_dir.clone(), db.clone(), EventBus::new())
+        .expect("create watcher");
+    watcher.start().await.expect("start watcher");
+
+    // Let the watcher's spawned event-handler task hook up before the
+    // debounced filesystem event arrives.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/samples/basic.flac");
+    std::fs::copy(&fixture, music_dir.join("song.flac")).expect("copy fixture into music dir");
+
+    // Debounce is 300ms, but filesystem-event latency varies by backend
+    // (inotify vs FSEvents), so poll instead of sleeping a fixed amount.
+    let mut song = None;
+    for _ in 0..60 {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        song = db
+            .lock()
+            .await
+            .get_song_by_path("song.flac")
+            .expect("query by relative path");
+        if song.is_some() {
+            break;
+        }
+    }
+    assert!(
+        song.is_some(),
+        "song.flac should be in the database before it is moved away"
+    );
+
+    // Move the file outside the watched music directory, into another
+    // subdirectory of the same TempDir. `notify` reports this as a
+    // modify/rename on the music-dir side, not a remove.
+    std::fs::rename(music_dir.join("song.flac"), elsewhere_dir.join("song.flac"))
+        .expect("move file out of the music dir");
+
+    let mut still_present = true;
+    for _ in 0..60 {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        still_present = db
+            .lock()
+            .await
+            .get_song_by_path("song.flac")
+            .expect("query by relative path")
+            .is_some();
+        if !still_present {
+            break;
+        }
+    }
+
+    assert!(
+        !still_present,
+        "the watcher should have pruned song.flac's row once its file moved \
+         out of the music directory, but it is still in the database"
+    );
+}

--- a/rmpd-library/tests/scanner_tests.rs
+++ b/rmpd-library/tests/scanner_tests.rs
@@ -1,5 +1,6 @@
 /// Regression tests for `Scanner::collect_audio_files`'s directory-tree walk.
-use rmpd_core::event::EventBus;
+use rmpd_core::event::{Event, EventBus};
+use rmpd_core::song::Song;
 use rmpd_library::database::Database;
 use rmpd_library::scanner::Scanner;
 use rmpd_library::watcher::FilesystemWatcher;
@@ -7,6 +8,28 @@ use std::sync::Arc;
 use std::time::Duration;
 use tempfile::TempDir;
 use tokio::sync::Mutex;
+
+/// Build a minimal remote/virtual song for `Database::add_source_song`, whose
+/// mount-style path convention is `<mount>/<segments>.../<leaf>` (see that
+/// method's doc comment).
+fn remote_song(virtual_path: &str) -> Song {
+    Song {
+        id: 0,
+        path: virtual_path.into(),
+        duration: None,
+        sample_rate: None,
+        channels: None,
+        bits_per_sample: None,
+        bitrate: None,
+        replay_gain_track_gain: None,
+        replay_gain_track_peak: None,
+        replay_gain_album_gain: None,
+        replay_gain_album_peak: None,
+        added_at: 0,
+        last_modified: 0,
+        tags: Vec::new(),
+    }
+}
 
 /// A symlink that points back at an ancestor directory (or otherwise forms a
 /// cycle) must not send the scanner into deep/unbounded recursion when
@@ -103,4 +126,142 @@ async fn watcher_stores_relative_path_for_new_file() {
          path, not the absolute path returned by extract_from_file",
     );
     assert_eq!(song.path.as_str(), "song.flac");
+}
+
+/// A song row whose file has been deleted from disk between two `update`s
+/// must be pruned from the database (issue #12): songs that vanish from disk
+/// were never removed, so `findadd` + `play` would "succeed" and then fail to
+/// open the file. `scan_directory` must delete the row and report it via
+/// `ScanStats::removed`, leaving files that are still present untouched.
+#[test]
+fn update_prunes_songs_whose_files_are_gone() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let music_dir = temp_dir.path().join("music");
+    std::fs::create_dir(&music_dir).expect("create music dir");
+
+    let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/samples/basic.flac");
+    std::fs::copy(&fixture, music_dir.join("a.flac")).expect("copy fixture as a.flac");
+    std::fs::copy(&fixture, music_dir.join("b.flac")).expect("copy fixture as b.flac");
+
+    let db_path = temp_dir.path().join("test.db");
+    let database = Database::open(db_path.to_str().unwrap()).expect("open database");
+    let scanner = Scanner::new(EventBus::new(), false);
+
+    let stats = scanner
+        .scan_directory(&database, &music_dir)
+        .expect("first scan");
+    assert_eq!(
+        stats.added, 2,
+        "both files should be added on the first scan"
+    );
+    assert!(
+        database.get_song_by_path("a.flac").unwrap().is_some(),
+        "a.flac should be in the database after the first scan"
+    );
+    assert!(
+        database.get_song_by_path("b.flac").unwrap().is_some(),
+        "b.flac should be in the database after the first scan"
+    );
+
+    std::fs::remove_file(music_dir.join("b.flac")).expect("remove b.flac");
+
+    let stats = scanner
+        .scan_directory(&database, &music_dir)
+        .expect("second scan");
+
+    assert_eq!(stats.removed, 1, "b.flac's row should be pruned");
+    assert_eq!(stats.added, 0, "no new files were added on the second scan");
+    assert!(
+        database.get_song_by_path("b.flac").unwrap().is_none(),
+        "b.flac's row should be gone after the prune"
+    );
+    assert!(
+        database.get_song_by_path("a.flac").unwrap().is_some(),
+        "a.flac should be untouched since its file is still present"
+    );
+}
+
+/// Remote catalog rows (`Database::add_source_song`) must never be evicted by
+/// the local-filesystem prune, since `list_local_song_paths`/
+/// `delete_song_by_path` are guarded with `source IS NULL`.
+#[test]
+fn update_keeps_remote_source_rows() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let music_dir = temp_dir.path().join("music");
+    std::fs::create_dir(&music_dir).expect("create music dir");
+
+    let db_path = temp_dir.path().join("test.db");
+    let database = Database::open(db_path.to_str().unwrap()).expect("open database");
+
+    let song = remote_song("mymount/Artist/Album/song.flac");
+    database
+        .add_source_song(&song, "subsonic")
+        .expect("add remote song");
+
+    let scanner = Scanner::new(EventBus::new(), false);
+    let stats = scanner
+        .scan_directory(&database, &music_dir)
+        .expect("scan of an empty music dir");
+
+    assert_eq!(
+        stats.removed, 0,
+        "remote rows must not be counted as pruned"
+    );
+    assert!(
+        database
+            .get_song_by_path("mymount/Artist/Album/song.flac")
+            .unwrap()
+            .is_some(),
+        "the remote source row should survive a local scan with no matching file on disk"
+    );
+}
+
+/// Pruning a missing song must emit `Event::SongDeleted` so `idle` clients
+/// pick up the removal the same way they do for the watcher's own deletes.
+#[test]
+fn update_emits_song_deleted_for_pruned_rows() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let music_dir = temp_dir.path().join("music");
+    std::fs::create_dir(&music_dir).expect("create music dir");
+
+    let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/samples/basic.flac");
+    std::fs::copy(&fixture, music_dir.join("b.flac")).expect("copy fixture as b.flac");
+
+    let db_path = temp_dir.path().join("test.db");
+    let database = Database::open(db_path.to_str().unwrap()).expect("open database");
+    let event_bus = EventBus::new();
+    let scanner = Scanner::new(event_bus.clone(), false);
+
+    scanner
+        .scan_directory(&database, &music_dir)
+        .expect("first scan");
+
+    // Subscribe only before the second scan: a new subscriber does not see
+    // events emitted before it subscribed.
+    let mut rx = event_bus.subscribe();
+
+    std::fs::remove_file(music_dir.join("b.flac")).expect("remove b.flac");
+    scanner
+        .scan_directory(&database, &music_dir)
+        .expect("second scan");
+
+    let mut events = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        events.push(event);
+    }
+    let deleted = events
+        .iter()
+        .position(|e| matches!(e, Event::SongDeleted { path } if path == "b.flac"))
+        .expect("pruning b.flac's row should emit Event::SongDeleted");
+    let finished = events
+        .iter()
+        .position(|e| matches!(e, Event::DatabaseUpdateFinished))
+        .expect("the scan should emit Event::DatabaseUpdateFinished");
+    assert!(
+        deleted < finished,
+        "SongDeleted must be emitted before DatabaseUpdateFinished, so a client \
+         refreshing on the update event already sees the pruned database"
+    );
 }

--- a/rmpd-protocol/src/state.rs
+++ b/rmpd-protocol/src/state.rs
@@ -220,10 +220,11 @@ impl AppState {
 
             match result {
                 Ok(Ok(stats)) => tracing::info!(
-                    "library scan complete: {} scanned, {} added, {} updated, {} errors",
+                    "library scan complete: {} scanned, {} added, {} updated, {} removed, {} errors",
                     stats.scanned,
                     stats.added,
                     stats.updated,
+                    stats.removed,
                     stats.errors
                 ),
                 Ok(Err(e)) => tracing::error!("library update failed: {}", e),

--- a/rmpd/src/bin/test_scanner.rs
+++ b/rmpd/src/bin/test_scanner.rs
@@ -32,6 +32,7 @@ fn main() -> anyhow::Result<()> {
     println!("  Files scanned: {}", stats.scanned);
     println!("  Files added: {}", stats.added);
     println!("  Files updated: {}", stats.updated);
+    println!("  Files removed: {}", stats.removed);
     println!("  Errors: {}", stats.errors);
 
     // Show database stats


### PR DESCRIPTION
## Description

Songs whose files disappear from disk stay in the database (#12): `update` has no reconcile
step, and the watcher only deletes on `EventKind::Remove`, while `notify` reports a file or
directory moved away as a modify/rename. Ghost rows show up in `find`/`stats`, can be queued,
and `play` then fails to open the file.

Three commits, one change each:

1. `update` deletes local rows whose file is no longer a regular file (`source IS NULL` rows
   only, so remote catalogs are untouched), counts them in `ScanStats::removed` and emits
   `SongDeleted` before `DatabaseUpdateFinished`.
2. The watcher treats a path that is no longer a regular file as a removal, sharing the
   `Remove` branch's code.
3. The watcher prunes the rows under a directory that vanished (the event arrives on the
   directory path), as MPD does on `IN_DELETE_SELF`/`IN_MOVE_SELF`.

Left out on purpose: empty `directories` rows (still listed by `lsinfo`; small follow-up if
you want it) and the pre-existing scan/watcher race. `prune_missing` assumes the scan root is
the music directory, the only way `scan_directory` is called today (documented).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #12

## Testing

- [x] All existing tests pass (`cargo test --workspace`)
- [x] New tests added for new functionality
- [x] Manual testing performed

Seven new tests in `rmpd-library` (scanner prune, remote rows kept, event order, watcher
rename-away with the real watcher, and synthetic `Modify(Name(From))`/`Remove` events for a
vanished file and a vanished directory). Manually, on a real library with this branch: the
first scan pruned six ghost rows left by `main`; a file renamed away, a file moved to
another filesystem and a whole directory moved away all leave the database within a second
without `update`; `fmt`, `clippy -D warnings` and the workspace tests pass on Debian 12.
