### PR TITLE
fix(library): scope, batch and complete the missing-file prune

### DIFF
--- a/rmpd-library/src/database.rs
+++ b/rmpd-library/src/database.rs
@@ -1110,21 +1110,96 @@ impl Database {
         Ok(())
     }
 
-    /// List the paths of every local song, ordered by path.
+    /// List the paths of every local song at or under `prefix`, ordered by path.
     ///
-    /// `source IS NULL` is the same predicate `delete_song_by_path` guards its
-    /// `DELETE` with, so this only ever returns local filesystem rows — never
-    /// remote catalog rows inserted by `add_source_song`. Used by the scanner to
-    /// find local rows whose file has disappeared from disk. Deliberately not
-    /// `list_all_songs`: that loads tags for every song and includes remote rows.
-    pub fn list_local_song_paths(&self) -> Result<Vec<String>> {
-        let mut stmt = self
-            .conn
-            .prepare("SELECT path FROM songs WHERE source IS NULL ORDER BY path")?;
+    /// `prefix` is a database-relative directory path (`""` means the whole
+    /// library); a row matches when its path equals `prefix` or starts with
+    /// `prefix/`, the same rule as `find_songs_by_prefix`, but only `path` is
+    /// read — no tags are loaded. `source IS NULL` is the predicate
+    /// `delete_songs_by_paths` guards its `DELETE` with, so remote catalog rows
+    /// inserted by `add_source_song` are never returned.
+    pub fn list_local_song_paths_under(&self, prefix: &str) -> Result<Vec<String>> {
+        if prefix.is_empty() {
+            let mut stmt = self
+                .conn
+                .prepare("SELECT path FROM songs WHERE source IS NULL ORDER BY path")?;
+            let paths = stmt
+                .query_map([], |row| row.get::<_, String>(0))?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            return Ok(paths);
+        }
+
+        let dir_prefix = if prefix.ends_with('/') {
+            prefix.to_string()
+        } else {
+            format!("{prefix}/")
+        };
+        let like_prefix = format!("{}%", dir_prefix.replace('%', "\\%").replace('_', "\\_"));
+        let mut stmt = self.conn.prepare(
+            "SELECT path FROM songs
+             WHERE source IS NULL AND (path = ?1 OR path LIKE ?2)
+             ORDER BY path",
+        )?;
+        let paths = stmt
+            .query_map(params![prefix, like_prefix], |row| row.get::<_, String>(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(paths)
+    }
+
+    /// Delete local song rows for `paths` in a single transaction.
+    ///
+    /// One commit for the whole batch instead of one per row, which matters when
+    /// a scan prunes a large number of vanished files. Carries the same
+    /// `source IS NULL` guard as `delete_song_by_path`, so remote catalog rows
+    /// are never evicted. Returns the paths whose row was actually deleted, in
+    /// input order, so the caller can emit one `SongDeleted` per real deletion.
+    pub fn delete_songs_by_paths(&self, paths: &[String]) -> Result<Vec<String>> {
+        let tx = self.conn.unchecked_transaction()?;
+        let mut deleted = Vec::with_capacity(paths.len());
+        {
+            let mut stmt = tx.prepare("DELETE FROM songs WHERE path = ?1 AND source IS NULL")?;
+            for path in paths {
+                if stmt.execute(params![path])? > 0 {
+                    deleted.push(path.clone());
+                }
+            }
+        }
+        tx.commit()?;
+        Ok(deleted)
+    }
+
+    /// Directory rows, deepest first, that hold no songs and no child directory
+    /// rows. The root row (`parent_id IS NULL`) is never returned.
+    ///
+    /// Deepest first so that a caller deleting all of them empties a subtree
+    /// bottom-up in one pass: once a leaf is gone its parent qualifies on the
+    /// next iteration. Emptiness counts songs of any origin, so a mount point
+    /// carrying remote catalog rows is never reported as empty.
+    pub fn list_empty_directory_paths(&self) -> Result<Vec<String>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT d.path FROM directories d
+             WHERE d.parent_id IS NOT NULL
+               AND NOT EXISTS (SELECT 1 FROM songs s WHERE s.directory_id = d.id)
+               AND NOT EXISTS (SELECT 1 FROM directories c WHERE c.parent_id = d.id)
+             ORDER BY length(d.path) DESC, d.path",
+        )?;
         let paths = stmt
             .query_map([], |row| row.get::<_, String>(0))?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(paths)
+    }
+
+    /// Delete the directory row at `path`. A row that still has songs or child
+    /// directories is left alone: the foreign keys would reject it anyway, and
+    /// callers pair this with `list_empty_directory_paths`.
+    pub fn delete_directory_by_path(&self, path: &str) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM directories WHERE path = ?1 AND parent_id IS NOT NULL
+               AND NOT EXISTS (SELECT 1 FROM songs s WHERE s.directory_id = directories.id)
+               AND NOT EXISTS (SELECT 1 FROM directories c WHERE c.parent_id = directories.id)",
+            params![path],
+        )?;
+        Ok(())
     }
 
     /// Ensure the root directory (path="", parent_id=NULL) exists and return its id.

--- a/rmpd-library/src/scanner.rs
+++ b/rmpd-library/src/scanner.rs
@@ -78,14 +78,23 @@ impl Scanner {
         let mut stats = ScanStats::default();
 
         // Build a scanner variant that knows the music directory so that make_relative_path
-        // can strip the root prefix from absolute paths during the scan.
-        let music_dir = Utf8PathBuf::try_from(root_path.to_path_buf())
+        // can strip the root prefix from absolute paths during the scan. If `self` already
+        // has one configured (a scan of one of its own subtrees), keep it — `root_path` is
+        // then a subtree root, not the library root, and prune_missing/file_is_present need
+        // the real root to resolve database-relative paths back to disk.
+        let utf8_root = Utf8PathBuf::try_from(root_path.to_path_buf())
             .map_err(|_| RmpdError::Library("Music directory path is not valid UTF-8".into()))?;
-        let scanner_with_dir = self.with_music_dir(music_dir);
+        let scanner_with_dir = self.with_music_dir(
+            self.music_directory
+                .clone()
+                .unwrap_or_else(|| utf8_root.clone()),
+        );
 
         scanner_with_dir.scan_recursive(db, root_path, &mut stats)?;
 
-        self.prune_missing(db, root_path, &mut stats);
+        let prefix = scanner_with_dir.make_relative_path(&utf8_root)?;
+        scanner_with_dir.prune_missing(db, prefix.as_str(), &mut stats);
+        scanner_with_dir.prune_empty_directories(db, &mut stats);
 
         info!(
             "scan complete: {} files scanned, {} added, {} updated, {} removed, {} errors",
@@ -97,22 +106,25 @@ impl Scanner {
         Ok(stats)
     }
 
-    /// Delete local song rows whose file is no longer present on disk.
+    /// Delete local song rows at or under `prefix` whose file is no longer present on disk.
     ///
-    /// Iterates `Database::list_local_song_paths` (already scoped to
-    /// `source IS NULL`, so remote catalog rows from `add_source_song` are never
-    /// considered) and removes any row whose file `root_path.join(path)` does not
-    /// resolve to an existing regular file. A symlink counts as present only when
-    /// the scanner follows symlinks, mirroring the walk in `collect_audio_files`
-    /// (a row for a symlinked file is pruned by a scan configured not to follow
-    /// them, as MPD does).
-    ///
-    /// Assumes `root_path` is the music directory itself (the only way
-    /// `scan_directory` is called today). A scoped update of a subdirectory
-    /// would have to restrict the candidates to rows under that subtree first,
-    /// otherwise every row outside it would look missing.
-    fn prune_missing(&self, db: &Database, root_path: &Path, stats: &mut ScanStats) {
-        let paths = match db.list_local_song_paths() {
+    /// `prefix` is the scanned subtree's database-relative path (`""` for a whole-library
+    /// scan, which is what every caller passes today), computed by `scan_directory` from the
+    /// scanner's `music_directory` and the scan root — so a scan rooted at a subdirectory only
+    /// ever considers rows under that subdirectory, never every row outside it.
+    /// `Database::list_local_song_paths_under` is already scoped to `source IS NULL`, so remote
+    /// catalog rows from `add_source_song` are never candidates. A row is missing when
+    /// `music_directory.join(path)` does not resolve to an existing regular file; a symlink
+    /// counts as present only when the scanner follows symlinks, mirroring the walk in
+    /// `collect_audio_files` (a row for a symlinked file is pruned by a scan configured not to
+    /// follow them, as MPD does). Vanished rows are all deleted in a single transaction.
+    fn prune_missing(&self, db: &Database, prefix: &str, stats: &mut ScanStats) {
+        let music_dir = self
+            .music_directory
+            .as_ref()
+            .expect("prune_missing is only called on a scanner with music_directory set");
+
+        let paths = match db.list_local_song_paths_under(prefix) {
             Ok(paths) => paths,
             Err(e) => {
                 warn!("failed to list local songs for prune: {}", e);
@@ -121,34 +133,94 @@ impl Scanner {
             }
         };
 
-        for path in paths {
-            if self.file_is_present(&root_path.join(&path)) {
-                continue;
-            }
+        let missing: Vec<String> = paths
+            .into_iter()
+            .filter(|path| !self.file_is_present(music_dir.join(path).as_std_path()))
+            .collect();
 
-            match db.delete_song_by_path(&path) {
-                Ok(()) => {
-                    stats.removed += 1;
+        if missing.is_empty() {
+            return;
+        }
+
+        match db.delete_songs_by_paths(&missing) {
+            Ok(deleted) => {
+                stats.removed += deleted.len() as u32;
+                for path in deleted {
                     debug!("pruned missing song: {}", path);
                     self.event_bus.emit(Event::SongDeleted { path });
                 }
-                Err(e) => {
-                    warn!("failed to prune missing song {}: {}", path, e);
-                    stats.errors += 1;
-                }
+            }
+            Err(e) => {
+                warn!("failed to prune missing songs: {}", e);
+                stats.errors += 1;
             }
         }
+    }
+
+    /// Delete directory rows that hold no songs and no child directories once their on-disk
+    /// location is gone (e.g. `prune_missing` above just emptied it, or the whole directory was
+    /// removed directly). Re-lists `Database::list_empty_directory_paths` after every pass:
+    /// deleting a leaf can make its now-childless parent qualify on the next pass, so a vanished
+    /// subtree collapses bottom-up within this one call. A row for a directory still present on
+    /// disk is always kept even if empty, and a remote mount point's row is never a candidate —
+    /// it holds remote songs, so it is never reported as empty.
+    fn prune_empty_directories(&self, db: &Database, stats: &mut ScanStats) {
+        let music_dir = self
+            .music_directory
+            .as_ref()
+            .expect("prune_empty_directories is only called on a scanner with music_directory set");
+
+        loop {
+            let candidates = match db.list_empty_directory_paths() {
+                Ok(paths) => paths,
+                Err(e) => {
+                    warn!("failed to list empty directories for prune: {}", e);
+                    stats.errors += 1;
+                    return;
+                }
+            };
+
+            let mut pruned = 0u32;
+            for path in candidates {
+                if self.dir_is_present(music_dir.join(&path).as_std_path()) {
+                    continue;
+                }
+
+                match db.delete_directory_by_path(&path) {
+                    Ok(()) => {
+                        pruned += 1;
+                        debug!("pruned missing directory: {}", path);
+                    }
+                    Err(e) => {
+                        warn!("failed to prune missing directory {}: {}", path, e);
+                        stats.errors += 1;
+                    }
+                }
+            }
+
+            if pruned == 0 {
+                break;
+            }
+        }
+    }
+
+    /// Whether `path` is excluded because it's a symlink and the scan doesn't follow them,
+    /// mirroring the entry-skip in `collect_audio_files`.
+    fn is_symlink_excluded(&self, path: &Path) -> bool {
+        !self.follow_symlinks
+            && fs::symlink_metadata(path).is_ok_and(|m| m.file_type().is_symlink())
     }
 
     /// Whether `path` is a regular file the scan would have visited: symlinks
     /// only count when `follow_symlinks` is set, like `collect_audio_files`.
     fn file_is_present(&self, path: &Path) -> bool {
-        if !self.follow_symlinks
-            && fs::symlink_metadata(path).is_ok_and(|m| m.file_type().is_symlink())
-        {
-            return false;
-        }
-        path.is_file()
+        !self.is_symlink_excluded(path) && path.is_file()
+    }
+
+    /// Whether `path` is a directory the scan would have visited: symlinks
+    /// only count when `follow_symlinks` is set, like `collect_audio_files`.
+    fn dir_is_present(&self, path: &Path) -> bool {
+        !self.is_symlink_excluded(path) && path.is_dir()
     }
 
     /// Convert absolute path to relative path (relative to music_directory)

--- a/rmpd-library/src/watcher.rs
+++ b/rmpd-library/src/watcher.rs
@@ -283,6 +283,11 @@ async fn remove_song_row(
 /// and `is_audio_file` never sees them. Prune every local row under it.
 /// A path that still exists (e.g. a directory that is untouched, or some
 /// other non-audio file) is left alone — the caller already skips it.
+/// If `path` *is* the music directory itself, `strip_prefix` yields `""`,
+/// and pruning `""` would delete every local row in the library — but the
+/// music directory can be a transiently-unmounted mount point, so a watcher
+/// event on it is not proof the whole library is gone. Refuse to prune in
+/// that case instead of trusting it.
 async fn prune_if_vanished_directory(
     path: &Path,
     music_dir: &Path,
@@ -299,29 +304,39 @@ async fn prune_if_vanished_directory(
     };
     let rel_str = relative_path.to_string_lossy().to_string();
 
+    if rel_str.is_empty() {
+        warn!(
+            "music directory {:?} vanished; refusing to prune the entire library",
+            music_dir
+        );
+        return Ok(());
+    }
+
     debug!("directory vanished, pruning rows under: {}", rel_str);
     remove_rows_under(db, event_bus, &rel_str).await
 }
 
 /// Delete every local row whose path is `rel` itself or starts with `rel/`,
-/// emitting `SongDeleted` for each — used when `rel` denotes a directory that
-/// vanished from disk. Reuses `remove_song_row` per matching row so each
-/// deletion still respects `delete_song_by_path`'s `source IS NULL` guard
-/// (remote catalog rows are never evicted) and still emits the same event a
-/// single vanished file would. A `rel` under which nothing matches (e.g. a
-/// non-audio file that vanished) is a no-op.
+/// in one lock acquisition and one transaction, then emit `SongDeleted` for
+/// each row actually deleted — used when `rel` denotes a directory that
+/// vanished from disk. `list_local_song_paths_under` and
+/// `delete_songs_by_paths` are both already scoped to local rows
+/// (`source IS NULL`), so remote catalog rows are never touched. A `rel`
+/// under which nothing matches (e.g. a non-audio file that vanished) is a
+/// no-op.
 async fn remove_rows_under(
     db: &Arc<Mutex<Database>>,
     event_bus: &EventBus,
     rel: &str,
 ) -> Result<()> {
-    let rows = {
+    let deleted = {
         let db_guard = db.lock().await;
-        db_guard.find_songs_by_prefix(rel)?
+        let paths = db_guard.list_local_song_paths_under(rel)?;
+        db_guard.delete_songs_by_paths(&paths)?
     };
 
-    for song in rows {
-        remove_song_row(db, event_bus, song.path.as_str()).await?;
+    for path in deleted {
+        event_bus.emit(RmpdEvent::SongDeleted { path });
     }
 
     Ok(())
@@ -479,5 +494,46 @@ mod tests {
     #[tokio::test]
     async fn remove_event_for_a_vanished_directory_prunes_rows_under_it() {
         assert_vanished_directory_prunes_rows_under_it(EventKind::Remove(RemoveKind::Folder)).await;
+    }
+
+    /// A watcher event on the music directory path itself must never wipe the
+    /// whole library: `strip_prefix` yields `""` for that path, which without
+    /// the guard in `prune_if_vanished_directory` would match every local row.
+    #[tokio::test]
+    async fn modify_event_for_the_music_directory_itself_leaves_all_rows() {
+        let temp_dir = tempfile::TempDir::new().expect("create temp dir");
+        let music_dir = temp_dir.path().join("music");
+        std::fs::create_dir(&music_dir).expect("create music dir");
+        let db_path = temp_dir.path().join("test.db");
+        let database = Database::open(db_path.to_str().unwrap()).expect("open database");
+        database
+            .add_song(&local_song("dir/a.flac"))
+            .expect("insert dir/a.flac");
+        let db = Arc::new(Mutex::new(database));
+        let event_bus = EventBus::new();
+        let mut rx = event_bus.subscribe();
+
+        // Simulate the music directory itself vanishing (e.g. an unmounted
+        // mount point): the event path is the music directory, so its
+        // relative path is "".
+        std::fs::remove_dir(&music_dir).expect("remove music dir to simulate vanish");
+        let event = Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::From)))
+            .add_path(music_dir.clone());
+        handle_fs_event(&event, &music_dir, &db, &event_bus)
+            .await
+            .expect("handle the synthetic event");
+
+        assert!(
+            db.lock()
+                .await
+                .get_song_by_path("dir/a.flac")
+                .expect("query")
+                .is_some(),
+            "a vanished music directory must not wipe the library"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "no SongDeleted should be emitted when refusing to prune the whole library"
+        );
     }
 }

--- a/rmpd-library/tests/scanner_tests.rs
+++ b/rmpd-library/tests/scanner_tests.rs
@@ -1,4 +1,5 @@
 /// Regression tests for `Scanner::collect_audio_files`'s directory-tree walk.
+use camino::Utf8PathBuf;
 use rmpd_core::event::{Event, EventBus};
 use rmpd_core::song::Song;
 use rmpd_library::database::Database;
@@ -29,6 +30,12 @@ fn remote_song(virtual_path: &str) -> Song {
         last_modified: 0,
         tags: Vec::new(),
     }
+}
+
+/// Build a minimal local song with a relative path (no `source`), for
+/// seeding rows directly via `Database::add_song` without a real file on disk.
+fn local_song(path: &str) -> Song {
+    remote_song(path)
 }
 
 /// A symlink that points back at an ancestor directory (or otherwise forms a
@@ -183,8 +190,8 @@ fn update_prunes_songs_whose_files_are_gone() {
 }
 
 /// Remote catalog rows (`Database::add_source_song`) must never be evicted by
-/// the local-filesystem prune, since `list_local_song_paths`/
-/// `delete_song_by_path` are guarded with `source IS NULL`.
+/// the local-filesystem prune, since `list_local_song_paths_under`/
+/// `delete_songs_by_paths` are guarded with `source IS NULL`.
 #[test]
 fn update_keeps_remote_source_rows() {
     let temp_dir = TempDir::new().expect("create temp dir");
@@ -422,5 +429,131 @@ async fn watcher_prunes_rows_for_directory_moved_away() {
         "the watcher should have pruned dir/song.flac's row once its \
          directory moved out of the music directory, but it is still \
          in the database"
+    );
+}
+
+/// A scan rooted at a subdirectory must only prune local song rows under that
+/// subdirectory. `prune_missing` used to list every local row regardless of
+/// `root_path`, so a scoped `update <uri>` scanning just `inside/` would have
+/// deleted `outside/y.flac`'s row too, even though that file's presence was
+/// never checked.
+#[test]
+fn scoped_scan_does_not_prune_rows_outside_its_subtree() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let music_dir = temp_dir.path().join("music");
+    std::fs::create_dir(&music_dir).expect("create music dir");
+    std::fs::create_dir(music_dir.join("inside")).expect("create inside dir");
+
+    let db_path = temp_dir.path().join("test.db");
+    let database = Database::open(db_path.to_str().unwrap()).expect("open database");
+    database
+        .add_song(&local_song("inside/x.flac"))
+        .expect("seed inside/x.flac");
+    database
+        .add_song(&local_song("outside/y.flac"))
+        .expect("seed outside/y.flac");
+
+    let scanner = Scanner::new(EventBus::new(), false)
+        .with_music_dir(Utf8PathBuf::try_from(music_dir.clone()).expect("music dir is utf8"));
+    let stats = scanner
+        .scan_directory(&database, &music_dir.join("inside"))
+        .expect("scoped scan of inside/");
+
+    assert_eq!(
+        stats.removed, 1,
+        "only inside/x.flac, the row under the scanned subtree, should be pruned"
+    );
+    assert!(
+        database
+            .get_song_by_path("inside/x.flac")
+            .unwrap()
+            .is_none(),
+        "inside/x.flac should be pruned: it is under the scanned subtree and its file is gone"
+    );
+    assert!(
+        database
+            .get_song_by_path("outside/y.flac")
+            .unwrap()
+            .is_some(),
+        "outside/y.flac must survive a scan scoped to inside/, even though its file is also gone"
+    );
+}
+
+/// Once a directory and every file under it are removed from disk, a
+/// subsequent scan must also drop its now-empty `directories` row — `lsinfo`
+/// used to keep listing a directory whose contents (and the directory
+/// itself) no longer exist.
+#[test]
+fn scan_prunes_directory_row_once_its_files_and_dir_are_gone() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let music_dir = temp_dir.path().join("music");
+    std::fs::create_dir(&music_dir).expect("create music dir");
+    let gone_dir = music_dir.join("gone");
+    std::fs::create_dir(&gone_dir).expect("create gone dir");
+
+    let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/samples/basic.flac");
+    std::fs::copy(&fixture, gone_dir.join("x.flac")).expect("copy fixture as gone/x.flac");
+
+    let db_path = temp_dir.path().join("test.db");
+    let database = Database::open(db_path.to_str().unwrap()).expect("open database");
+    let scanner = Scanner::new(EventBus::new(), false);
+
+    scanner
+        .scan_directory(&database, &music_dir)
+        .expect("first scan");
+    assert!(
+        database
+            .list_directory("")
+            .unwrap()
+            .directories
+            .iter()
+            .any(|(path, _)| path == "gone"),
+        "gone/ should have a directory row after the first scan"
+    );
+
+    std::fs::remove_dir_all(&gone_dir).expect("remove gone dir and its file");
+
+    scanner
+        .scan_directory(&database, &music_dir)
+        .expect("second scan");
+
+    assert!(
+        !database
+            .list_directory("")
+            .unwrap()
+            .directories
+            .iter()
+            .any(|(path, _)| path == "gone"),
+        "gone/'s directory row should be pruned once both its file and the directory itself \
+         are gone from disk"
+    );
+}
+
+/// An empty directory that is still present on disk must keep its
+/// `directories` row: emptiness alone is not grounds for pruning it.
+#[test]
+fn scan_keeps_directory_row_for_directory_still_on_disk() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let music_dir = temp_dir.path().join("music");
+    std::fs::create_dir(&music_dir).expect("create music dir");
+    std::fs::create_dir(music_dir.join("empty")).expect("create empty dir");
+
+    let db_path = temp_dir.path().join("test.db");
+    let database = Database::open(db_path.to_str().unwrap()).expect("open database");
+    let scanner = Scanner::new(EventBus::new(), false);
+
+    scanner
+        .scan_directory(&database, &music_dir)
+        .expect("scan with an empty subdirectory");
+
+    assert!(
+        database
+            .list_directory("")
+            .unwrap()
+            .directories
+            .iter()
+            .any(|(path, _)| path == "empty"),
+        "empty/'s directory row must survive since the directory itself is still on disk"
     );
 }


### PR DESCRIPTION
Follow-up to #13 (merged as 18c07e9), which fixed #12. Four review points from that PR, one commit each for the first three.

## Changes

1. **The scan prune is scoped to the subtree it scanned.** `Scanner::prune_missing` listed *every* local row and deleted any whose file was gone, which is only safe because `scan_directory` is always called with the music directory itself. It now derives the scanned subtree's database-relative prefix from the scanner's `music_directory` and passes it to `Database::list_local_song_paths_under`, so a scan rooted at a subdirectory cannot consider rows outside it. Every current caller scans the library root, where the prefix is `""` and behaviour is unchanged — but a scoped `update <uri>` can no longer turn into a whole-library wipe.

2. **One transaction instead of one commit per row.** `delete_songs_by_paths` deletes a batch under a single transaction, keeping the `source IS NULL` guard and returning the rows actually deleted so exactly one `SongDeleted` is emitted per real deletion. Both the scanner prune and the watcher's vanished-directory prune use it.

3. **The watcher's directory prune no longer takes N locks.** `remove_rows_under` called `find_songs_by_prefix` (which loads tags for every row, though only `path` is used, and includes remote rows) and then re-acquired the `Mutex<Database>` once per row. It now takes the lock once: one path-only query, one batched delete. It also refuses the empty relative path — an event on the music directory itself would otherwise have matched every local row and wiped the database, which a watcher should not do for a directory that may just be a transiently unavailable mount point.

4. **Stale `directories` rows are pruned.** Left out of #13 on purpose: a directory removed from disk kept its row, so `lsinfo` still listed it after its songs were gone. A scan now drops directory rows whose on-disk location is gone once they hold no songs and no children, re-listing after each pass so a whole vanished subtree collapses bottom-up in one scan. Directories that still exist on disk keep their row even when empty, and a remote mount point is never a candidate (it holds remote songs, so it is never reported empty).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] `cargo test --workspace` — all suites pass, no failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --all --check` clean
- [x] New tests

Four new tests on top of the seven from #13, all of which keep passing unchanged:

- `scoped_scan_does_not_prune_rows_outside_its_subtree` — the regression test for point 1: rows exist for `inside/x.flac` and `outside/y.flac`, neither file is on disk, a scan rooted at `inside/` prunes only its own row.
- `scan_prunes_directory_row_once_its_files_and_dir_are_gone` and `scan_keeps_directory_row_for_directory_still_on_disk` — point 4, asserted through `Database::list_directory`.
- `watcher::tests::modify_event_for_the_music_directory_itself_leaves_all_rows` — the regression test for the wipe in point 3.

Commits are unsigned: the signing key is agent-held and requires interactive confirmation, which was unavailable in the environment that produced them.
