### PR TITLE
fix(config): stop silently discarding rmpd.toml, generate a starter config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -288,6 +288,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "audio-codec-algorithms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1254ebf6529f3763c491acfb5ab6e960809e3c75a38584cc664f8c5667fb7107"
+
+[[package]]
 name = "audioadapter"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,9 +301,9 @@ checksum = "d1292ef9edf681b7426ed089004b021a42896492f58bd0c909ad44e5faec9ac4"
 
 [[package]]
 name = "audioadapter-buffers"
-version = "5.1.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c972db1b4829c49bc41f2f72d0b57faecd6f2d4732a5127680b734b6a6a35a6"
+checksum = "46289a81a3bfa26d0f8b2415f8ca9decde9a66308a150568af5c102381b3c8ce"
 dependencies = [
  "audioadapter",
  "audioadapter-sample",
@@ -306,10 +312,11 @@ dependencies = [
 
 [[package]]
 name = "audioadapter-sample"
-version = "5.1.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d4daf502185bc4e7ff68dad7c8b7681b30080272498812869764a324dca0ff6"
+checksum = "5258faecf4edbe35ec483bda9b1f7438e6b391891819269c6b5461aeaa0e8d7d"
 dependencies = [
+ "audio-codec-algorithms",
  "num-traits",
 ]
 
@@ -321,9 +328,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -331,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
@@ -366,7 +373,7 @@ dependencies = [
  "clang-sys",
  "itertools 0.13.0",
  "log",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "regex",
@@ -425,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
 dependencies = [
  "async-channel",
  "async-task",
@@ -438,27 +445,25 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.9.3"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+checksum = "9e3fac94a66da67200398458a25412bcc3f9b6443b5119a6cad9cf3ccfcd8cc6"
 dependencies = [
  "bon-macros",
- "rustversion",
 ]
 
 [[package]]
 name = "bon-macros"
-version = "3.9.3"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+checksum = "d4654961ad0494e4774c5c60b4cb4cd0ae9b9d92d039d901638b1dba97ebebf5"
 dependencies = [
  "darling",
  "ident_case",
- "prettyplease",
+ "prettyplease 0.3.0",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -496,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -523,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
+checksum = "fe4ece8474b5f766c63426647e7b4b316b67431ade1036a8313cee24a03ae917"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -545,9 +550,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -624,7 +629,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -650,9 +655,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -752,18 +757,18 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -829,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -839,26 +844,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -948,7 +953,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -965,9 +970,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "encoding_rs"
@@ -1093,18 +1098,19 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1233,7 +1239,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1322,9 +1328,9 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1376,9 +1382,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -1442,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1527,9 +1533,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collator"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59eea194d189ca897bcb960fd2130f9e7d53998460d4d32e85a60b10d5507cf4"
+checksum = "08984ed58ac439ebf3e13d2cf26b0c46a60afcd21721c1d14087c0b240344dda"
 dependencies = [
  "icu_collator_data",
  "icu_collections",
@@ -1644,9 +1650,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1698,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -1868,9 +1874,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1937,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.20"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
  "libc",
 ]
@@ -2024,14 +2030,14 @@ source = "git+https://github.com/M0Rf30/lofty-rs?rev=b0064904dbd09f61fd76c46ba48
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru"
@@ -2081,9 +2087,9 @@ dependencies = [
 
 [[package]]
 name = "mdns-sd"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba97b4c886eea3c2823388120d92063c011ac866919ffc4200a0e4b1642a54a5"
+checksum = "b0a19dd805348943831582c4d9e6921c66de689127d6b27665a4e155c2117799"
 dependencies = [
  "fastrand",
  "flume",
@@ -2141,9 +2147,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -2151,9 +2157,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "log",
@@ -2502,9 +2508,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "5.3.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
 dependencies = [
  "num-traits",
 ]
@@ -2665,6 +2671,16 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
+dependencies = [
+ "proc-macro2",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3038,7 +3054,7 @@ name = "rmpd-macros"
 version = "0.6.1"
 dependencies = [
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3277,9 +3293,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3373,7 +3389,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3397,7 +3413,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3490,9 +3506,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "socket-pktinfo"
@@ -3776,9 +3792,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4043,7 +4059,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4098,9 +4114,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4137,14 +4153,14 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -4166,9 +4182,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4392,7 +4408,7 @@ checksum = "f153acc4e99a5f2a5aefa09fb078be54e26271b2813f6041200b224c098d8328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4462,9 +4478,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -4543,9 +4559,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4556,9 +4572,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4566,9 +4582,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4576,22 +4592,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -4611,9 +4627,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5059,7 +5075,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -5146,9 +5162,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "serde",
  "yoke",
@@ -5158,14 +5174,20 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
@@ -5184,18 +5206,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.4"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+checksum = "64d80649ab6db9d9f6f9c80a40becd948eda4714a0a5ac8c4d157a32231c7882"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
+version = "2.1.0+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+checksum = "0ef0a8027ec3ee71300ab3bcbcd0393f434aa72b91ca6d635a39941deae8eea0"
 dependencies = [
  "cc",
  "pkg-config",
@@ -5225,7 +5247,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
  "zvariant_utils",
 ]
 
@@ -5238,6 +5260,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 3.0.3",
+ "syn 3.0.5",
  "winnow",
 ]

--- a/README.md
+++ b/README.md
@@ -82,51 +82,85 @@ mpc current   # shows the live ICY "now playing" title for streams
 
 ## Configuration
 
-Create `~/.config/rmpd/rmpd.toml`:
+rmpd does not require you to create a config file. On first start, if no
+config file is found, rmpd writes a commented starter config to
+`~/.config/rmpd/rmpd.toml` and logs the path it chose. You can also manage
+this explicitly:
+
+- `--generate-config` writes the starter config on demand and refuses to
+  overwrite an existing file.
+- `--print-config-path` prints the path that would be used, without writing
+  anything.
+- `--no-config` skips file discovery entirely and runs on built-in defaults.
+
+### Search order
+
+When `--config` is not given, rmpd searches these locations in order and
+uses the first one that exists:
+
+1. the path given to `--config`
+2. `$XDG_CONFIG_HOME/rmpd/rmpd.toml` (usually `~/.config/rmpd/rmpd.toml`)
+3. `~/.rmpd.toml`
+4. `~/.rmpd/rmpd.toml`
+5. `/etc/rmpd/rmpd.toml`
+
+This mirrors MPD's own search order (`$XDG_CONFIG_HOME/mpd/mpd.conf`,
+`~/.mpdconf`, `~/.mpd/mpd.conf`, `/etc/mpd.conf`).
+
+Every section and key is optional — anything omitted uses a built-in
+default, so a partial config is valid. Paths beginning with `~` are
+expanded.
+
+A minimal config:
 
 ```toml
 [general]
 music_directory = "~/Music"
-playlist_directory = "~/.config/rmpd/playlists"
-db_file = "~/.config/rmpd/database.db"
 log_level = "info"
 
 [network]
 bind_address = "127.0.0.1"
 port = 6600
-mpris = true
 
 [audio]
 default_output = "alsa"
-gapless = true
 replay_gain = "auto"
-buffer_time = 500
-
-[[output]]
-name = "Local Audio"
-type = "cpal"          # system audio via cpal (ALSA / PulseAudio / PipeWire host)
-enabled = true
-
-[[output]]
-name = "PipeWire"      # native pipewire-rs client; follows the graph rate (build with --features pipewire)
-type = "pipewire"
-enabled = false
-
-[[output]]
-name = "HTTP Stream"   # listen on http://<host>:8000 — play in a browser or another MPD
-type = "httpd"
-enabled = false
-port = 8000
-encoder = "wav"        # "wav" or "pcm"
-
-[[output]]
-name = "Snapcast FIFO" # feed an external snapserver for synchronized multi-room
-type = "fifo"
-enabled = false
-path = "/tmp/snapfifo"
 ```
 
-See [rmpd.toml](rmpd.toml) for a complete configuration example.
+See [rmpd.toml](rmpd.toml) for a complete, annotated configuration example.
+
+### Diagnostics
+
+Unrecognized keys are reported at startup instead of being silently
+ignored, with a suggestion when a typo is likely, for example:
+
+```
+unknown config key `general.msic_directory` (did you mean `music_directory`?)
+```
+
+Keys carried over from `mpd.conf` produce a migration hint pointing at the
+rmpd equivalent. Unknown keys only warn — they never stop the daemon.
+An explicitly passed `--config` file that cannot be read or parsed is
+fatal, since a config you asked for by name should never be silently
+substituted with defaults.
+
+A missing or nonexistent `music_directory` is **not** fatal: rmpd warns,
+starts anyway, and skips library scanning, matching MPD's
+degrade-don't-die behaviour.
+
+`log_level` under `[general]` controls logging (`trace`/`debug`/`info`/
+`warn`/`error`). `--verbose` forces `debug`, and the `RUST_LOG` environment
+variable overrides both.
+
+The following keys were parsed in older versions but never did anything
+and have been removed; a config that still sets them gets a startup
+warning naming each one:
+
+- `audio.gapless` — gapless playback is always on
+- the entire `[decoder]` section, including `decoder.enabled` — decoders
+  come from a compile-time registry
+- `database.cache_size`
+- `database.fts_enabled`
 
 ### Music Sources (OpenSubsonic)
 

--- a/rmpd-core/src/config.rs
+++ b/rmpd-core/src/config.rs
@@ -1,7 +1,7 @@
 use crate::error::{Result, RmpdError};
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct Config {
@@ -15,8 +15,6 @@ pub struct Config {
     pub output: Vec<OutputConfig>,
     #[serde(default)]
     pub source: Vec<SourceConfig>,
-    #[serde(default)]
-    pub decoder: DecoderConfig,
     #[serde(default)]
     pub database: DatabaseConfig,
 }
@@ -83,8 +81,6 @@ pub struct AudioConfig {
     pub replay_gain_missing_preamp: f32,
     #[serde(default)]
     pub volume_normalization: bool,
-    #[serde(default = "default_true")]
-    pub gapless: bool,
     #[serde(default)]
     pub crossfade: f32,
     #[serde(default = "default_mixramp_db")]
@@ -177,22 +173,12 @@ impl SourceConfig {
     }
 }
 
-#[derive(Debug, Default, Clone, Deserialize, Serialize)]
-pub struct DecoderConfig {
-    #[serde(default = "default_enabled_decoders")]
-    pub enabled: Vec<String>,
-}
-
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
 pub struct DatabaseConfig {
     #[serde(default = "default_true")]
     pub auto_update: bool,
     #[serde(default = "default_true")]
     pub filesystem_watch: bool,
-    #[serde(default = "default_cache_size")]
-    pub cache_size: usize,
-    #[serde(default = "default_true")]
-    pub fts_enabled: bool,
 }
 
 impl Default for DatabaseConfig {
@@ -200,8 +186,6 @@ impl Default for DatabaseConfig {
         Self {
             auto_update: true,
             filesystem_watch: true,
-            cache_size: 64,
-            fts_enabled: true,
         }
     }
 }
@@ -265,6 +249,60 @@ pub enum DopMode {
     /// Use DoP only when an explicit output `device` is configured (assumed a
     /// dedicated DAC); otherwise convert to PCM.
     Auto,
+}
+
+/// Where a loaded [`Config`] came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigSource {
+    /// Loaded from an existing file.
+    File(Utf8PathBuf),
+    /// No config existed; this file was written from the template, then loaded.
+    Generated(Utf8PathBuf),
+    /// No config file used (none found and generation skipped/failed, or `no_config`).
+    Defaults,
+}
+
+/// Severity of a [`Diagnostic`] produced while loading a config.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagLevel {
+    Info,
+    Warn,
+}
+
+/// A single human-readable note produced while discovering/parsing a config.
+/// The caller is expected to log these through `tracing` once logging is
+/// initialized (`discover` itself never logs).
+#[derive(Debug, Clone)]
+pub struct Diagnostic {
+    pub level: DiagLevel,
+    pub message: String,
+}
+
+impl Diagnostic {
+    fn warn(message: impl Into<String>) -> Self {
+        Self {
+            level: DiagLevel::Warn,
+            message: message.into(),
+        }
+    }
+}
+
+/// The result of [`Config::discover`]: the parsed config, where it came from,
+/// and every diagnostic produced along the way.
+#[derive(Debug, Clone)]
+pub struct ConfigLoad {
+    pub config: Config,
+    pub source: ConfigSource,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+/// Options controlling [`Config::discover`]'s search behavior.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DiscoverOptions {
+    /// Write a starter config when none is found.
+    pub generate_if_missing: bool,
+    /// Skip file discovery entirely (MPD's `--no-config`).
+    pub no_config: bool,
 }
 
 // Default value functions
@@ -346,58 +384,387 @@ fn default_true() -> bool {
     true
 }
 
-fn default_enabled_decoders() -> Vec<String> {
-    vec!["symphonia".to_owned()]
+// Known-key schema for the unknown-key/removed-key lint pass. `[[output]]`
+// and `[[source]]` tables use `#[serde(flatten)]` for backend-specific
+// settings and are intentionally not covered here beyond `name`/`type`.
+
+const KNOWN_SECTIONS: &[&str] = &[
+    "general", "network", "audio", "output", "source", "database",
+];
+
+const GENERAL_KEYS: &[&str] = &[
+    "music_directory",
+    "playlist_directory",
+    "db_file",
+    "state_file",
+    "log_level",
+    "follow_symlinks",
+    "filesystem_charset",
+];
+
+const NETWORK_KEYS: &[&str] = &[
+    "bind_address",
+    "port",
+    "unix_socket",
+    "max_connections",
+    "connection_timeout",
+    "password",
+    "mpris",
+];
+
+const AUDIO_KEYS: &[&str] = &[
+    "default_output",
+    "buffer_time",
+    "resampler_quality",
+    "dop",
+    "device",
+    "replay_gain",
+    "replay_gain_preamp",
+    "replay_gain_missing_preamp",
+    "volume_normalization",
+    "crossfade",
+    "mixramp_db",
+    "mixramp_delay",
+    "restore_paused",
+];
+
+const DATABASE_KEYS: &[&str] = &["auto_update", "filesystem_watch"];
+
+/// Levenshtein edit distance between two strings (two-row DP, no allocation
+/// beyond the two rows).
+fn edit_distance(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr: Vec<usize> = vec![0; b.len() + 1];
+
+    for i in 1..=a.len() {
+        curr[0] = i;
+        for j in 1..=b.len() {
+            let cost = usize::from(a[i - 1] != b[j - 1]);
+            curr[j] = (prev[j] + 1).min(curr[j - 1] + 1).min(prev[j - 1] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b.len()]
 }
 
-fn default_cache_size() -> usize {
-    64
+/// The closest entry in `known` to `key`, if within edit distance 2.
+fn suggest(key: &str, known: &[&'static str]) -> Option<&'static str> {
+    known
+        .iter()
+        .copied()
+        .map(|k| (k, edit_distance(key, k)))
+        .filter(|(_, d)| *d <= 2)
+        .min_by_key(|(_, d)| *d)
+        .map(|(k, _)| k)
+}
+
+/// Explanation for a config key that was deliberately removed (parsed but
+/// never read), keyed by `(section, key)`.
+fn removed_key_reason(section: &str, key: &str) -> Option<&'static str> {
+    match (section, key) {
+        ("audio", "gapless") => Some("gapless playback is always enabled"),
+        ("database", "cache_size") => Some("it had no effect"),
+        ("database", "fts_enabled") => Some("it had no effect"),
+        _ => None,
+    }
+}
+
+/// mpd.conf-style bare top-level key -> rmpd migration hint message.
+fn mpd_migration_hint(key: &str) -> Option<String> {
+    let target: Option<(&str, &str)> = match key {
+        "music_directory" => Some(("general", "music_directory")),
+        "playlist_directory" => Some(("general", "playlist_directory")),
+        "db_file" => Some(("general", "db_file")),
+        "state_file" => Some(("general", "state_file")),
+        "bind_to_address" => Some(("network", "bind_address")),
+        "port" => Some(("network", "port")),
+        "password" => Some(("network", "password")),
+        "max_connections" => Some(("network", "max_connections")),
+        "connection_timeout" => Some(("network", "connection_timeout")),
+        "filesystem_charset" => Some(("general", "filesystem_charset")),
+        "follow_outside_symlinks" => Some(("general", "follow_symlinks")),
+        "auto_update" => Some(("database", "auto_update")),
+        "replaygain" => Some(("audio", "replay_gain")),
+        "volume_normalization" => Some(("audio", "volume_normalization")),
+        "log_file" => {
+            return Some(
+                "`log_file` is mpd.conf syntax; rmpd logs to stdout via tracing and has no config equivalent"
+                    .to_owned(),
+            );
+        }
+        "pid_file" => {
+            return Some(
+                "`pid_file` is mpd.conf syntax; rmpd does not daemonize and has no config equivalent"
+                    .to_owned(),
+            );
+        }
+        "audio_output" => {
+            return Some(
+                "`audio_output` is mpd.conf syntax; rmpd uses one or more `[[output]]` tables instead"
+                    .to_owned(),
+            );
+        }
+        "zeroconf_enabled" => {
+            return Some(
+                "`zeroconf_enabled` is mpd.conf syntax; rmpd always advertises via mDNS and has no config equivalent"
+                    .to_owned(),
+            );
+        }
+        _ => None,
+    };
+    target.map(|(section, rmpd_key)| {
+        format!("`{key}` is mpd.conf syntax; rmpd uses `{rmpd_key}` in the `[{section}]` section")
+    })
+}
+
+fn lint_section(
+    section: &str,
+    value: &toml::Value,
+    known: &[&'static str],
+    out: &mut Vec<Diagnostic>,
+) {
+    let toml::Value::Table(table) = value else {
+        return;
+    };
+    for key in table.keys() {
+        if known.contains(&key.as_str()) {
+            continue;
+        }
+        if let Some(reason) = removed_key_reason(section, key) {
+            out.push(Diagnostic::warn(format!(
+                "config key `{section}.{key}` was removed: {reason}"
+            )));
+            continue;
+        }
+        out.push(Diagnostic::warn(match suggest(key, known) {
+            Some(s) => format!("unknown config key `{section}.{key}` (did you mean `{s}`?)"),
+            None => format!("unknown config key `{section}.{key}`"),
+        }));
+    }
+}
+
+fn lint_tables(section: &str, value: &toml::Value, out: &mut Vec<Diagnostic>) {
+    let toml::Value::Array(items) = value else {
+        return;
+    };
+    for item in items {
+        let toml::Value::Table(table) = item else {
+            continue;
+        };
+        let has_name = table
+            .get("name")
+            .and_then(toml::Value::as_str)
+            .is_some_and(|s| !s.trim().is_empty());
+        let has_type = table
+            .get("type")
+            .and_then(toml::Value::as_str)
+            .is_some_and(|s| !s.trim().is_empty());
+        if !has_name {
+            out.push(Diagnostic::warn(format!(
+                "a `[[{section}]]` table is missing a non-empty `name`"
+            )));
+        }
+        if !has_type {
+            out.push(Diagnostic::warn(format!(
+                "a `[[{section}]]` table is missing a non-empty `type`"
+            )));
+        }
+    }
+}
+
+fn to_utf8(path: &Path) -> Utf8PathBuf {
+    Utf8PathBuf::from_path_buf(path.to_path_buf())
+        .unwrap_or_else(|p| Utf8PathBuf::from(p.to_string_lossy().into_owned()))
 }
 
 impl Config {
-    pub fn load() -> Result<Self> {
-        let config_path = Self::find_config_file()?;
-        Self::load_from_path(&config_path)
+    /// Search locations for a config file, in priority order, restricted to
+    /// candidates this system can actually resolve (e.g. `dirs::config_dir()`
+    /// is skipped when unavailable). Mirrors MPD's own search order:
+    /// `$XDG_CONFIG_HOME/mpd/mpd.conf`, `~/.mpdconf`, `~/.mpd/mpd.conf`.
+    #[must_use]
+    pub fn search_paths() -> Vec<Utf8PathBuf> {
+        let mut paths = Vec::new();
+        if let Some(p) = dirs::config_dir()
+            .map(|p| p.join("rmpd/rmpd.toml"))
+            .and_then(|p| Utf8PathBuf::try_from(p).ok())
+        {
+            paths.push(p);
+        }
+        if let Some(home) = dirs::home_dir().and_then(|p| Utf8PathBuf::try_from(p).ok()) {
+            paths.push(home.join(".rmpd.toml"));
+            paths.push(home.join(".rmpd/rmpd.toml"));
+        }
+        paths.push(Utf8PathBuf::from("/etc/rmpd/rmpd.toml"));
+        paths
     }
 
-    pub fn load_from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let path = path.as_ref();
+    /// The starter config template, also the single source of truth for
+    /// `rmpd.toml` at the repository root: there is exactly one copy of the
+    /// starter config in the tree.
+    #[must_use]
+    pub fn template_toml() -> &'static str {
+        include_str!("../../rmpd.toml")
+    }
+
+    /// Writes the template to `path`, creating parent directories as needed.
+    /// Errs if `path` already exists so a real user file is never clobbered.
+    pub fn write_template(path: &Path) -> Result<()> {
+        if path.exists() {
+            return Err(RmpdError::Config(format!(
+                "refusing to overwrite existing config file {}",
+                path.display()
+            )));
+        }
+        if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                RmpdError::Config(format!(
+                    "failed to create config directory {}: {e}",
+                    parent.display()
+                ))
+            })?;
+        }
+        std::fs::write(path, Self::template_toml()).map_err(|e| {
+            RmpdError::Config(format!("failed to write config {}: {e}", path.display()))
+        })?;
+        Ok(())
+    }
+
+    /// Discover and load the effective config.
+    ///
+    /// - `explicit` (e.g. from `--config`) is authoritative: a missing,
+    ///   unreadable, or unparseable explicit file is a hard error and is
+    ///   never silently substituted with defaults.
+    /// - Otherwise, with `opts.no_config`, no filesystem search happens at
+    ///   all and built-in defaults are used.
+    /// - Otherwise the first existing entry of [`Self::search_paths`] wins.
+    ///   If none exist and `opts.generate_if_missing`, a starter config is
+    ///   written to `search_paths()[0]` and then loaded. If that generation
+    ///   fails (read-only filesystem, no resolvable home/XDG directory), a
+    ///   `Warn` diagnostic is emitted and defaults are used instead.
+    ///
+    /// This never logs through `tracing` itself: every message is returned in
+    /// `ConfigLoad::diagnostics` so the caller can initialize logging at the
+    /// config-specified level first, then replay them.
+    pub fn discover(explicit: Option<&Path>, opts: DiscoverOptions) -> Result<ConfigLoad> {
+        if let Some(path) = explicit {
+            let (config, diagnostics) = Self::load_file(path)?;
+            return Ok(ConfigLoad {
+                config,
+                source: ConfigSource::File(to_utf8(path)),
+                diagnostics,
+            });
+        }
+
+        if opts.no_config {
+            return Self::defaults_load(Vec::new());
+        }
+
+        let candidates = Self::search_paths();
+        for candidate in &candidates {
+            if candidate.exists() {
+                let (config, diagnostics) = Self::load_file(candidate.as_std_path())?;
+                return Ok(ConfigLoad {
+                    config,
+                    source: ConfigSource::File(candidate.clone()),
+                    diagnostics,
+                });
+            }
+        }
+
+        if opts.generate_if_missing
+            && let Some(target) = candidates.first()
+        {
+            if let Err(e) = Self::write_template(target.as_std_path()) {
+                return Self::defaults_load(vec![Diagnostic::warn(format!(
+                    "could not generate starter config at {target}: {e}"
+                ))]);
+            }
+            return match Self::load_file(target.as_std_path()) {
+                Ok((config, diagnostics)) => Ok(ConfigLoad {
+                    config,
+                    source: ConfigSource::Generated(target.clone()),
+                    diagnostics,
+                }),
+                Err(e) => Self::defaults_load(vec![Diagnostic::warn(format!(
+                    "generated config at {target} failed to load: {e}"
+                ))]),
+            };
+        }
+
+        Self::defaults_load(Vec::new())
+    }
+
+    fn defaults_load(mut diagnostics: Vec<Diagnostic>) -> Result<ConfigLoad> {
+        let mut config = Self::default();
+        config.expand_paths();
+        config.ensure_directories();
+        Self::validate_and_normalize(&mut config, &mut diagnostics)?;
+        Ok(ConfigLoad {
+            config,
+            source: ConfigSource::Defaults,
+            diagnostics,
+        })
+    }
+
+    /// Reads and parses `path`, lints it for unknown/removed keys, expands
+    /// paths, ensures directories, and validates/normalizes values.
+    fn load_file(path: &Path) -> Result<(Self, Vec<Diagnostic>)> {
         let content = std::fs::read_to_string(path).map_err(|e| {
-            RmpdError::Config(format!("Failed to read config {}: {e}", path.display()))
+            RmpdError::Config(format!("failed to read config {}: {e}", path.display()))
         })?;
 
         let mut config: Config = toml::from_str(&content).map_err(|e| {
-            RmpdError::Config(format!("Failed to parse config {}: {e}", path.display()))
+            RmpdError::Config(format!("failed to parse config {}: {e}", path.display()))
         })?;
 
+        let mut diagnostics = Self::lint(&content);
         config.expand_paths();
         config.ensure_directories();
-        config.validate()?;
-        tracing::info!("configuration loaded from {}", path.display());
-        Ok(config)
+        Self::validate_and_normalize(&mut config, &mut diagnostics)?;
+        Ok((config, diagnostics))
     }
 
-    /// Load the first config file found in the standard locations, falling back
-    /// to built-in defaults. The fallback is logged loudly: a silent fallback is
-    /// indistinguishable from a config file that was found but ignored.
-    ///
-    /// The default config goes through the same path expansion and directory
-    /// creation as a loaded one, so a defaults-only start is still usable.
-    #[must_use]
-    pub fn load_or_default() -> Self {
-        match Self::load() {
-            Ok(config) => config,
-            Err(e) => {
-                tracing::warn!("{e}; falling back to built-in defaults");
-                let mut config = Self::default();
-                config.expand_paths();
-                config.ensure_directories();
-                if let Err(e) = config.validate() {
-                    tracing::warn!("{e}");
+    /// Parses `content` as raw TOML and walks it against the known
+    /// section/key schema, producing a `Warn` diagnostic for every
+    /// unrecognized, removed, or mpd.conf-style key. Never fatal: a typo must
+    /// not stop a headless music daemon, but it must be loudly reported.
+    fn lint(content: &str) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+        let Ok(toml::Value::Table(root)) = toml::from_str::<toml::Value>(content) else {
+            return diagnostics;
+        };
+
+        for (key, value) in &root {
+            match key.as_str() {
+                "general" => lint_section("general", value, GENERAL_KEYS, &mut diagnostics),
+                "network" => lint_section("network", value, NETWORK_KEYS, &mut diagnostics),
+                "audio" => lint_section("audio", value, AUDIO_KEYS, &mut diagnostics),
+                "database" => lint_section("database", value, DATABASE_KEYS, &mut diagnostics),
+                "output" => lint_tables("output", value, &mut diagnostics),
+                "source" => lint_tables("source", value, &mut diagnostics),
+                "decoder" => diagnostics.push(Diagnostic::warn(
+                    "config section `[decoder]` was removed: decoders are selected at build time",
+                )),
+                _ => {
+                    if matches!(value, toml::Value::Table(_)) {
+                        diagnostics.push(Diagnostic::warn(match suggest(key, KNOWN_SECTIONS) {
+                            Some(s) => {
+                                format!("unknown config section `[{key}]` (did you mean `[{s}]`?)")
+                            }
+                            None => format!("unknown config section `[{key}]`"),
+                        }));
+                    } else if let Some(hint) = mpd_migration_hint(key) {
+                        diagnostics.push(Diagnostic::warn(hint));
+                    } else {
+                        diagnostics.push(Diagnostic::warn(format!("unknown config key `{key}`")));
+                    }
                 }
-                config
             }
         }
+        diagnostics
     }
 
     /// Effective DoP mode. Prefers `[audio].dop`; if that is the default `No`,
@@ -457,31 +824,6 @@ impl Config {
         None
     }
 
-    fn find_config_file() -> Result<PathBuf> {
-        let candidates: Vec<PathBuf> = [
-            dirs::config_dir().map(|p| p.join("rmpd/rmpd.toml")),
-            Some(PathBuf::from("/etc/rmpd/rmpd.toml")),
-        ]
-        .into_iter()
-        .flatten()
-        .collect();
-
-        for candidate in &candidates {
-            if candidate.exists() {
-                return Ok(candidate.clone());
-            }
-        }
-
-        let searched = candidates
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
-        Err(RmpdError::Config(format!(
-            "Config file not found (searched: {searched})"
-        )))
-    }
-
     fn expand_paths(&mut self) {
         use crate::path::expand_tilde;
 
@@ -494,8 +836,8 @@ impl Config {
     /// Create the directories referenced by the config entries if they do not
     /// already exist. This covers the `playlist_directory` itself and the
     /// parent directories of `db_file` and `state_file`. The `music_directory`
-    /// is intentionally left to `validate`, since it must be supplied by the
-    /// user rather than created automatically.
+    /// is intentionally left alone: a missing library directory is reported as
+    /// a diagnostic rather than created, since it must be supplied by the user.
     fn ensure_directories(&self) {
         let mut dirs: Vec<&camino::Utf8Path> = vec![self.general.playlist_directory.as_path()];
         dirs.extend(self.general.db_file.parent());
@@ -511,13 +853,80 @@ impl Config {
         }
     }
 
-    fn validate(&self) -> Result<()> {
-        if !self.general.music_directory.exists() {
-            return Err(RmpdError::Config(format!(
-                "Music directory not found: {}",
-                self.general.music_directory
+    /// Validates values that would make the daemon unusable (hard errors),
+    /// and clamps/normalizes everything else while recording a `Warn`
+    /// diagnostic. Mirrors MPD, which logs and degrades on most bad values
+    /// rather than refusing to start.
+    fn validate_and_normalize(config: &mut Self, diagnostics: &mut Vec<Diagnostic>) -> Result<()> {
+        if config.network.max_connections == 0 {
+            return Err(RmpdError::Config(
+                "network.max_connections must be greater than 0 (0 accepts no clients)".to_owned(),
+            ));
+        }
+        if config.network.port == 0 {
+            return Err(RmpdError::Config("network.port must be nonzero".to_owned()));
+        }
+
+        if !config.general.music_directory.exists() {
+            diagnostics.push(Diagnostic::warn(format!(
+                "music directory {} does not exist; library scanning is disabled until it exists",
+                config.general.music_directory
             )));
         }
+
+        if config.audio.buffer_time == 0 {
+            config.audio.buffer_time = default_buffer_time();
+            diagnostics.push(Diagnostic::warn(format!(
+                "audio.buffer_time was 0; clamped to {}",
+                config.audio.buffer_time
+            )));
+        }
+
+        if config.audio.crossfade < 0.0 {
+            config.audio.crossfade = 0.0;
+            diagnostics.push(Diagnostic::warn(
+                "audio.crossfade was negative; clamped to 0.0",
+            ));
+        }
+
+        const PREAMP_BOUND: f32 = 60.0;
+        if !(-PREAMP_BOUND..=PREAMP_BOUND).contains(&config.audio.replay_gain_preamp) {
+            let clamped = config
+                .audio
+                .replay_gain_preamp
+                .clamp(-PREAMP_BOUND, PREAMP_BOUND);
+            diagnostics.push(Diagnostic::warn(format!(
+                "audio.replay_gain_preamp {} out of range [-{PREAMP_BOUND}, {PREAMP_BOUND}] dB; clamped to {clamped}",
+                config.audio.replay_gain_preamp
+            )));
+            config.audio.replay_gain_preamp = clamped;
+        }
+        if !(-PREAMP_BOUND..=PREAMP_BOUND).contains(&config.audio.replay_gain_missing_preamp) {
+            let clamped = config
+                .audio
+                .replay_gain_missing_preamp
+                .clamp(-PREAMP_BOUND, PREAMP_BOUND);
+            diagnostics.push(Diagnostic::warn(format!(
+                "audio.replay_gain_missing_preamp {} out of range [-{PREAMP_BOUND}, {PREAMP_BOUND}] dB; clamped to {clamped}",
+                config.audio.replay_gain_missing_preamp
+            )));
+            config.audio.replay_gain_missing_preamp = clamped;
+        }
+
+        let lowered = config.general.log_level.to_lowercase();
+        if matches!(
+            lowered.as_str(),
+            "trace" | "debug" | "info" | "warn" | "error"
+        ) {
+            config.general.log_level = lowered;
+        } else {
+            diagnostics.push(Diagnostic::warn(format!(
+                "general.log_level {:?} is not one of trace/debug/info/warn/error; using \"info\"",
+                config.general.log_level
+            )));
+            config.general.log_level = "info".to_owned();
+        }
+
         Ok(())
     }
 }
@@ -562,7 +971,6 @@ impl Default for AudioConfig {
             replay_gain_preamp: 0.0,
             replay_gain_missing_preamp: 0.0,
             volume_normalization: false,
-            gapless: true,
             crossfade: 0.0,
             mixramp_db: default_mixramp_db(),
             mixramp_delay: 0.0,
@@ -574,6 +982,20 @@ impl Default for AudioConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn unique_temp_dir(tag: &str) -> Utf8PathBuf {
+        let base = std::env::temp_dir().join(format!(
+            "rmpd-cfgtest-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).unwrap();
+        Utf8PathBuf::try_from(base).unwrap()
+    }
 
     fn output_block(enabled: bool) -> OutputConfig {
         let mut settings = toml::Table::new();
@@ -610,7 +1032,7 @@ port = 6611
         assert_eq!(c.network.port, 6611);
         assert_eq!(c.network.bind_address, default_bind_address());
         assert_eq!(c.audio.buffer_time, default_buffer_time());
-        assert!(c.audio.gapless);
+        assert!(c.database.auto_update);
     }
 
     #[test]
@@ -669,12 +1091,9 @@ port = 6611
 
     #[test]
     fn ensure_directories_creates_configured_dirs() {
-        let base = std::env::temp_dir().join(format!("rmpd-cfgtest-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&base);
-        std::fs::create_dir_all(&base).unwrap();
-        let base = Utf8PathBuf::try_from(base).unwrap();
+        let base = unique_temp_dir("ensuredirs");
 
-        // music_directory must already exist (validate requires it).
+        // music_directory must already exist for a clean (no-diagnostic) run.
         let music = base.join("music");
         std::fs::create_dir_all(&music).unwrap();
 
@@ -690,7 +1109,6 @@ port = 6611
         assert!(c.general.playlist_directory.exists());
         assert!(c.general.db_file.parent().unwrap().exists());
         assert!(c.general.state_file.parent().unwrap().exists());
-        assert!(c.validate().is_ok());
 
         let _ = std::fs::remove_dir_all(&base);
     }
@@ -772,5 +1190,287 @@ max_bitrate = 320
         );
         assert!(debug_str.contains("home"));
         assert!(debug_str.contains("subsonic"));
+    }
+
+    #[test]
+    fn template_matches_defaults_and_lints_clean() {
+        // Anti-drift guarantee: adding a key to a struct without documenting
+        // it in rmpd.toml, or leaving a stale/removed key in the template,
+        // fails here via a non-empty lint result.
+        let content = Config::template_toml();
+        let diagnostics = Config::lint(content);
+        assert!(
+            diagnostics.is_empty(),
+            "shipped rmpd.toml produced diagnostics: {diagnostics:?}"
+        );
+
+        let parsed: Config = toml::from_str(content).unwrap();
+        let default = Config::default();
+
+        // music_directory is intentionally "~/Music" in the template rather
+        // than the resolved XDG music dir; everything else must match the
+        // built-in default exactly so a generated file changes no behavior.
+        assert_eq!(
+            parsed.general.playlist_directory,
+            default.general.playlist_directory
+        );
+        assert_eq!(parsed.general.db_file, default.general.db_file);
+        assert_eq!(parsed.general.state_file, default.general.state_file);
+        assert_eq!(parsed.general.log_level, default.general.log_level);
+        assert_eq!(
+            parsed.general.follow_symlinks,
+            default.general.follow_symlinks
+        );
+        assert_eq!(
+            parsed.general.filesystem_charset,
+            default.general.filesystem_charset
+        );
+        assert_eq!(
+            format!("{:?}", parsed.network),
+            format!("{:?}", default.network)
+        );
+        assert_eq!(
+            format!("{:?}", parsed.audio),
+            format!("{:?}", default.audio)
+        );
+        assert_eq!(
+            format!("{:?}", parsed.database),
+            format!("{:?}", default.database)
+        );
+    }
+
+    #[test]
+    fn misspelled_key_produces_single_suggestion() {
+        let diagnostics = Config::lint(
+            r#"
+[general]
+msic_directory = "/srv/music"
+"#,
+        );
+        assert_eq!(diagnostics.len(), 1, "got: {diagnostics:?}");
+        assert_eq!(diagnostics[0].level, DiagLevel::Warn);
+        assert!(
+            diagnostics[0]
+                .message
+                .contains("unknown config key `general.msic_directory`")
+        );
+        assert!(
+            diagnostics[0]
+                .message
+                .contains("did you mean `music_directory`?")
+        );
+    }
+
+    #[test]
+    fn unknown_section_produces_suggestion() {
+        let diagnostics = Config::lint(
+            r#"
+[netwrk]
+port = 6600
+"#,
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message.contains("unknown config section `[netwrk]`")
+                    && d.message.contains("did you mean `[network]`?"))
+        );
+    }
+
+    #[test]
+    fn removed_key_gets_specific_removal_message() {
+        let diagnostics = Config::lint(
+            r#"
+[audio]
+gapless = true
+"#,
+        );
+        assert_eq!(diagnostics.len(), 1, "got: {diagnostics:?}");
+        assert_eq!(
+            diagnostics[0].message,
+            "config key `audio.gapless` was removed: gapless playback is always enabled"
+        );
+    }
+
+    #[test]
+    fn removed_decoder_section_gets_specific_message() {
+        let diagnostics = Config::lint(
+            r#"
+[decoder]
+enabled = ["symphonia"]
+"#,
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message.contains("`[decoder]` was removed"))
+        );
+    }
+
+    #[test]
+    fn removed_database_keys_get_specific_messages() {
+        let diagnostics = Config::lint(
+            r#"
+[database]
+cache_size = 64
+fts_enabled = true
+"#,
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message
+                    == "config key `database.cache_size` was removed: it had no effect")
+        );
+        assert!(diagnostics.iter().any(
+            |d| d.message == "config key `database.fts_enabled` was removed: it had no effect"
+        ));
+    }
+
+    #[test]
+    fn mpd_conf_bare_key_produces_migration_hint() {
+        let diagnostics = Config::lint("bind_to_address = \"0.0.0.0\"\n");
+        assert_eq!(diagnostics.len(), 1, "got: {diagnostics:?}");
+        assert_eq!(
+            diagnostics[0].message,
+            "`bind_to_address` is mpd.conf syntax; rmpd uses `bind_address` in the `[network]` section"
+        );
+    }
+
+    #[test]
+    fn output_table_missing_name_or_type_warns() {
+        let diagnostics = Config::lint(
+            r#"
+[[output]]
+type = "alsa"
+"#,
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.message.contains("missing a non-empty `name`"))
+        );
+    }
+
+    #[test]
+    fn output_table_flattened_keys_not_flagged() {
+        let diagnostics = Config::lint(
+            r#"
+[[output]]
+name = "DAC"
+type = "alsa"
+device = "hw:CARD=1,DEV=0"
+some_backend_specific_key = 1
+"#,
+        );
+        assert!(diagnostics.is_empty(), "got: {diagnostics:?}");
+    }
+
+    #[test]
+    fn discover_explicit_missing_path_is_hard_error() {
+        let base = unique_temp_dir("explicit-missing");
+        let missing = base.join("does-not-exist.toml");
+        let result = Config::discover(Some(missing.as_std_path()), DiscoverOptions::default());
+        assert!(result.is_err());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn discover_explicit_unparseable_path_is_hard_error() {
+        let base = unique_temp_dir("explicit-badtoml");
+        let bad = base.join("bad.toml");
+        std::fs::write(&bad, "not = [valid toml").unwrap();
+        let result = Config::discover(Some(bad.as_std_path()), DiscoverOptions::default());
+        assert!(result.is_err());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn discover_no_config_skips_search_and_uses_defaults() {
+        let load = Config::discover(
+            None,
+            DiscoverOptions {
+                generate_if_missing: false,
+                no_config: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(load.source, ConfigSource::Defaults);
+    }
+
+    #[test]
+    fn write_template_then_discover_explicit_reports_file_source() {
+        // Exercises the write_template -> load -> ConfigSource::File path
+        // that backs discover(None, generate_if_missing). We drive it through
+        // an explicit path rather than mutating process-global XDG/HOME env
+        // vars, which would race other tests running concurrently in this
+        // binary.
+        let base = unique_temp_dir("generated");
+        let target = base.join("rmpd.toml");
+        assert!(!target.exists());
+
+        Config::write_template(target.as_std_path()).unwrap();
+        assert!(target.exists());
+
+        // Writing again must fail: generation never clobbers an existing file.
+        assert!(Config::write_template(target.as_std_path()).is_err());
+
+        let load =
+            Config::discover(Some(target.as_std_path()), DiscoverOptions::default()).unwrap();
+        assert_eq!(load.source, ConfigSource::File(target.clone()));
+        assert!(
+            load.diagnostics
+                .iter()
+                .all(|d| d.message.contains("music directory")),
+            "unexpected diagnostics from a freshly generated template: {:?}",
+            load.diagnostics
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn max_connections_zero_is_hard_error() {
+        let base = unique_temp_dir("maxconn0");
+        let path = base.join("rmpd.toml");
+        std::fs::write(&path, "[network]\nmax_connections = 0\n").unwrap();
+        let result = Config::discover(Some(path.as_std_path()), DiscoverOptions::default());
+        assert!(result.is_err());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn port_zero_is_hard_error() {
+        let base = unique_temp_dir("port0");
+        let path = base.join("rmpd.toml");
+        std::fs::write(&path, "[network]\nport = 0\n").unwrap();
+        let result = Config::discover(Some(path.as_std_path()), DiscoverOptions::default());
+        assert!(result.is_err());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn invalid_log_level_normalizes_to_info_with_warning() {
+        let base = unique_temp_dir("loglevel");
+        let music = base.join("music");
+        std::fs::create_dir_all(&music).unwrap();
+        let path = base.join("rmpd.toml");
+        std::fs::write(
+            &path,
+            format!("[general]\nmusic_directory = \"{music}\"\nlog_level = \"verbose\"\n",),
+        )
+        .unwrap();
+
+        let load = Config::discover(Some(path.as_std_path()), DiscoverOptions::default()).unwrap();
+        assert_eq!(load.config.general.log_level, "info");
+        assert!(
+            load.diagnostics
+                .iter()
+                .any(|d| d.level == DiagLevel::Warn && d.message.contains("log_level")),
+            "got: {:?}",
+            load.diagnostics
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/rmpd-core/src/config.rs
+++ b/rmpd-core/src/config.rs
@@ -3,10 +3,13 @@ use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct Config {
+    #[serde(default)]
     pub general: GeneralConfig,
+    #[serde(default)]
     pub network: NetworkConfig,
+    #[serde(default)]
     pub audio: AudioConfig,
     #[serde(default)]
     pub output: Vec<OutputConfig>,
@@ -20,6 +23,7 @@ pub struct Config {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GeneralConfig {
+    #[serde(default = "default_music_dir")]
     pub music_directory: Utf8PathBuf,
     #[serde(default = "default_playlist_dir")]
     pub playlist_directory: Utf8PathBuf,
@@ -264,32 +268,42 @@ pub enum DopMode {
 }
 
 // Default value functions
+
+/// Join `rel` onto the user's home directory. Used only as a fallback when the
+/// XDG lookup fails (headless systems without `xdg-user-dirs`), so the result
+/// must still be an absolute, usable path rather than a literal `~/…`.
+fn home_join(rel: &str) -> Utf8PathBuf {
+    dirs::home_dir()
+        .and_then(|p| Utf8PathBuf::try_from(p).ok())
+        .map_or_else(|| Utf8PathBuf::from(rel), |home| home.join(rel))
+}
+
 fn default_music_dir() -> Utf8PathBuf {
     // Honor $XDG_MUSIC_DIR (e.g. ~/Musica) when set, else fall back to ~/Music.
     dirs::audio_dir()
         .and_then(|p| Utf8PathBuf::try_from(p).ok())
-        .unwrap_or_else(|| Utf8PathBuf::from("~/Music"))
+        .unwrap_or_else(|| home_join("Music"))
 }
 
 fn default_playlist_dir() -> Utf8PathBuf {
     dirs::config_dir()
         .map(|p| p.join("rmpd/playlists"))
         .and_then(|p| Utf8PathBuf::try_from(p).ok())
-        .unwrap_or_else(|| Utf8PathBuf::from("~/.config/rmpd/playlists"))
+        .unwrap_or_else(|| home_join(".config/rmpd/playlists"))
 }
 
 fn default_db_file() -> Utf8PathBuf {
     dirs::config_dir()
         .map(|p| p.join("rmpd/database.db"))
         .and_then(|p| Utf8PathBuf::try_from(p).ok())
-        .unwrap_or_else(|| Utf8PathBuf::from("~/.config/rmpd/database.db"))
+        .unwrap_or_else(|| home_join(".config/rmpd/database.db"))
 }
 
 fn default_state_file() -> Utf8PathBuf {
     dirs::config_dir()
         .map(|p| p.join("rmpd/state"))
         .and_then(|p| Utf8PathBuf::try_from(p).ok())
-        .unwrap_or_else(|| Utf8PathBuf::from("~/.config/rmpd/state"))
+        .unwrap_or_else(|| home_join(".config/rmpd/state"))
 }
 
 fn default_log_level() -> String {
@@ -347,21 +361,43 @@ impl Config {
     }
 
     pub fn load_from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let content = std::fs::read_to_string(path.as_ref())
-            .map_err(|e| RmpdError::Config(format!("Failed to read config: {e}")))?;
+        let path = path.as_ref();
+        let content = std::fs::read_to_string(path).map_err(|e| {
+            RmpdError::Config(format!("Failed to read config {}: {e}", path.display()))
+        })?;
 
-        let mut config: Config = toml::from_str(&content)
-            .map_err(|e| RmpdError::Config(format!("Failed to parse config: {e}")))?;
+        let mut config: Config = toml::from_str(&content).map_err(|e| {
+            RmpdError::Config(format!("Failed to parse config {}: {e}", path.display()))
+        })?;
 
         config.expand_paths();
         config.ensure_directories();
         config.validate()?;
+        tracing::info!("configuration loaded from {}", path.display());
         Ok(config)
     }
 
+    /// Load the first config file found in the standard locations, falling back
+    /// to built-in defaults. The fallback is logged loudly: a silent fallback is
+    /// indistinguishable from a config file that was found but ignored.
+    ///
+    /// The default config goes through the same path expansion and directory
+    /// creation as a loaded one, so a defaults-only start is still usable.
     #[must_use]
     pub fn load_or_default() -> Self {
-        Self::load().unwrap_or_else(|_| Self::default())
+        match Self::load() {
+            Ok(config) => config,
+            Err(e) => {
+                tracing::warn!("{e}; falling back to built-in defaults");
+                let mut config = Self::default();
+                config.expand_paths();
+                config.ensure_directories();
+                if let Err(e) = config.validate() {
+                    tracing::warn!("{e}");
+                }
+                config
+            }
+        }
     }
 
     /// Effective DoP mode. Prefers `[audio].dop`; if that is the default `No`,
@@ -422,18 +458,28 @@ impl Config {
     }
 
     fn find_config_file() -> Result<PathBuf> {
-        let candidates = [
+        let candidates: Vec<PathBuf> = [
             dirs::config_dir().map(|p| p.join("rmpd/rmpd.toml")),
             Some(PathBuf::from("/etc/rmpd/rmpd.toml")),
-        ];
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
 
-        for candidate in candidates.into_iter().flatten() {
+        for candidate in &candidates {
             if candidate.exists() {
-                return Ok(candidate);
+                return Ok(candidate.clone());
             }
         }
 
-        Err(RmpdError::Config("Config file not found".to_owned()))
+        let searched = candidates
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        Err(RmpdError::Config(format!(
+            "Config file not found (searched: {searched})"
+        )))
     }
 
     fn expand_paths(&mut self) {
@@ -476,47 +522,51 @@ impl Config {
     }
 }
 
-impl Default for Config {
+impl Default for GeneralConfig {
     fn default() -> Self {
         Self {
-            general: GeneralConfig {
-                music_directory: default_music_dir(),
-                playlist_directory: default_playlist_dir(),
-                db_file: default_db_file(),
-                state_file: default_state_file(),
-                log_level: default_log_level(),
-                follow_symlinks: false,
-                filesystem_charset: default_charset(),
-            },
-            network: NetworkConfig {
-                bind_address: default_bind_address(),
-                port: default_port(),
-                unix_socket: None,
-                max_connections: default_max_connections(),
-                connection_timeout: default_connection_timeout(),
-                password: None,
-                mpris: true,
-            },
-            audio: AudioConfig {
-                default_output: default_output(),
-                buffer_time: default_buffer_time(),
-                resampler_quality: ResamplerQuality::default(),
-                dop: DopMode::default(),
-                device: None,
-                replay_gain: ReplayGainMode::default(),
-                replay_gain_preamp: 0.0,
-                replay_gain_missing_preamp: 0.0,
-                volume_normalization: false,
-                gapless: true,
-                crossfade: 0.0,
-                mixramp_db: default_mixramp_db(),
-                mixramp_delay: 0.0,
-                restore_paused: false,
-            },
-            output: vec![],
-            source: Vec::new(),
-            decoder: DecoderConfig::default(),
-            database: DatabaseConfig::default(),
+            music_directory: default_music_dir(),
+            playlist_directory: default_playlist_dir(),
+            db_file: default_db_file(),
+            state_file: default_state_file(),
+            log_level: default_log_level(),
+            follow_symlinks: false,
+            filesystem_charset: default_charset(),
+        }
+    }
+}
+
+impl Default for NetworkConfig {
+    fn default() -> Self {
+        Self {
+            bind_address: default_bind_address(),
+            port: default_port(),
+            unix_socket: None,
+            max_connections: default_max_connections(),
+            connection_timeout: default_connection_timeout(),
+            password: None,
+            mpris: true,
+        }
+    }
+}
+
+impl Default for AudioConfig {
+    fn default() -> Self {
+        Self {
+            default_output: default_output(),
+            buffer_time: default_buffer_time(),
+            resampler_quality: ResamplerQuality::default(),
+            dop: DopMode::default(),
+            device: None,
+            replay_gain: ReplayGainMode::default(),
+            replay_gain_preamp: 0.0,
+            replay_gain_missing_preamp: 0.0,
+            volume_normalization: false,
+            gapless: true,
+            crossfade: 0.0,
+            mixramp_db: default_mixramp_db(),
+            mixramp_delay: 0.0,
+            restore_paused: false,
         }
     }
 }
@@ -537,6 +587,50 @@ mod tests {
             output_type: "alsa".to_owned(),
             enabled,
             settings,
+        }
+    }
+
+    #[test]
+    fn partial_config_keeps_defaults_for_absent_sections() {
+        // A config listing only the sections a user cares about must still
+        // deserialize; requiring [network]/[audio] silently discarded the whole
+        // file and fell back to defaults.
+        let c: Config = toml::from_str(
+            r#"
+[general]
+music_directory = "/srv/music"
+
+[network]
+port = 6611
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(c.general.music_directory, "/srv/music");
+        assert_eq!(c.network.port, 6611);
+        assert_eq!(c.network.bind_address, default_bind_address());
+        assert_eq!(c.audio.buffer_time, default_buffer_time());
+        assert!(c.audio.gapless);
+    }
+
+    #[test]
+    fn empty_config_deserializes_to_defaults() {
+        let c: Config = toml::from_str("").unwrap();
+        assert_eq!(c.general.music_directory, default_music_dir());
+        assert_eq!(c.network.port, default_port());
+    }
+
+    #[test]
+    fn default_paths_are_absolute() {
+        // A literal "~/Music" fallback is never usable: nothing expands it on
+        // the defaults path, so the daemon scanned a directory named "~".
+        for p in [
+            default_music_dir(),
+            default_playlist_dir(),
+            default_db_file(),
+            default_state_file(),
+        ] {
+            assert!(!p.as_str().starts_with('~'), "unexpanded default: {p}");
         }
     }
 

--- a/rmpd.toml
+++ b/rmpd.toml
@@ -2,6 +2,15 @@
 #
 # Every section and key is optional; anything omitted falls back to a built-in
 # default. Paths starting with "~" are expanded to your home directory.
+#
+# rmpd searches for this file, in order, at:
+#   $XDG_CONFIG_HOME/rmpd/rmpd.toml   (usually ~/.config/rmpd/rmpd.toml)
+#   ~/.rmpd.toml
+#   ~/.rmpd/rmpd.toml
+#   /etc/rmpd/rmpd.toml
+# The first one found wins. This file is also the shipped starter config: every
+# uncommented value below matches rmpd's built-in default, except
+# music_directory (set here to a sample path since it has no safe default).
 
 [general]
 # Path to your music library. Defaults to $XDG_MUSIC_DIR, else ~/Music.
@@ -50,9 +59,8 @@ replay_gain = "off"
 replay_gain_preamp = 0.0
 replay_gain_missing_preamp = 0.0
 volume_normalization = false
-gapless = true
 crossfade = 0
-mixramp_db = -17.0
+mixramp_db = 0.0
 mixramp_delay = 0.0
 
 [[output]]
@@ -77,14 +85,9 @@ enabled = true
 # type = "pipewire"
 # enabled = true
 
-[decoder]
-enabled = ["symphonia"]
-
 [database]
 auto_update = true
 filesystem_watch = true
-cache_size = 64
-fts_enabled = true
 
 # ── Music Sources ────────────────────────────────────────────────────────────
 # Remote catalogs are declared as [[source]] blocks. Each enabled source is

--- a/rmpd.toml
+++ b/rmpd.toml
@@ -1,7 +1,10 @@
 # rmpd configuration file
+#
+# Every section and key is optional; anything omitted falls back to a built-in
+# default. Paths starting with "~" are expanded to your home directory.
 
 [general]
-# Path to your music library (required; "~" is expanded).
+# Path to your music library. Defaults to $XDG_MUSIC_DIR, else ~/Music.
 music_directory = "~/Music"
 # The following default to your XDG config dir (~/.config/rmpd/…) when omitted:
 # playlist_directory = "~/.config/rmpd/playlists"

--- a/rmpd/src/app.rs
+++ b/rmpd/src/app.rs
@@ -133,10 +133,20 @@ pub async fn run(bind_address: String, config: Config) -> Result<()> {
         None
     };
 
+    // A missing music_directory is not fatal (config warns about it), but the
+    // scanner and the watcher both need a real directory. Skipping them here is
+    // what makes that warning honest: without this the daemon would immediately
+    // log a scan failure and a watch failure for a path we already reported.
+    let music_dir_exists = std::path::Path::new(&music_dir).is_dir();
+
     // Trigger an initial library scan on startup when auto-update is enabled.
     if config.database.auto_update {
-        info!("auto-update enabled: scanning music directory");
-        state.spawn_library_update(false).await;
+        if music_dir_exists {
+            info!("auto-update enabled: scanning music directory");
+            state.spawn_library_update(false).await;
+        } else {
+            warn!("skipping library scan: music directory {music_dir} does not exist");
+        }
     }
 
     // Sync enabled music sources (ping first; unreachable sources are skipped).
@@ -148,7 +158,7 @@ pub async fn run(bind_address: String, config: Config) -> Result<()> {
     // Start the filesystem watcher so the database stays in sync with on-disk
     // changes. Kept alive (`_watcher`) for the lifetime of the server; dropping
     // it would stop watching.
-    let _watcher = if config.database.filesystem_watch {
+    let _watcher = if config.database.filesystem_watch && music_dir_exists {
         match start_filesystem_watch(&state, &db_path, &music_dir).await {
             Ok(w) => Some(w),
             Err(e) => {

--- a/rmpd/src/main.rs
+++ b/rmpd/src/main.rs
@@ -150,7 +150,6 @@ async fn main() -> Result<()> {
 
     let full_address = make_bind_addr(&bind_address, port);
 
-    info!("configuration loaded");
     info!("music directory: {}", config.general.music_directory);
     info!("database: {}", config.general.db_file);
 

--- a/rmpd/src/main.rs
+++ b/rmpd/src/main.rs
@@ -1,6 +1,7 @@
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use clap::Parser;
-use tracing::info;
+use rmpd_core::config::{Config, ConfigSource, DiagLevel, DiscoverOptions};
+use tracing::{info, warn};
 
 mod app;
 
@@ -66,6 +67,18 @@ struct Args {
     /// Log to syslog/journald instead of stdout (useful when running as a daemon)
     #[arg(long)]
     syslog: bool,
+
+    /// Skip configuration file discovery entirely and use built-in defaults
+    #[arg(long)]
+    no_config: bool,
+
+    /// Write a starter configuration file to the default search location and exit
+    #[arg(long)]
+    generate_config: bool,
+
+    /// Print the configuration file path that would be used and exit
+    #[arg(long)]
+    print_config_path: bool,
 }
 
 fn make_bind_addr(addr: &str, port: u16) -> String {
@@ -97,13 +110,53 @@ fn default_env_filter(level: &str) -> tracing_subscriber::EnvFilter {
 async fn main() -> Result<()> {
     let args = Args::parse();
 
+    if args.generate_config {
+        let search_paths = Config::search_paths();
+        let path = &search_paths[0];
+        return match Config::write_template(path.as_std_path()) {
+            Ok(()) => {
+                println!("{path}");
+                Ok(())
+            }
+            Err(e) => Err(anyhow!(e)),
+        };
+    }
+
+    if args.print_config_path {
+        let path = Config::search_paths()
+            .into_iter()
+            .find(|p| p.exists())
+            .unwrap_or_else(|| Config::search_paths()[0].clone());
+        println!("{path}");
+        return Ok(());
+    }
+
+    // Load configuration before any logging is set up, so the effective log
+    // level (from config or --verbose) can drive the tracing filter from the
+    // very first line of output.
+    let discover_opts = DiscoverOptions {
+        generate_if_missing: !args.no_config,
+        no_config: args.no_config,
+    };
+    // anyhow prints the error to stderr on exit, which is the only channel
+    // available here: the tracing subscriber is not up yet, by design.
+    let load = Config::discover(
+        args.config.as_ref().map(std::path::Path::new),
+        discover_opts,
+    )?;
+    let config = load.config;
+
     // Initialize logging
-    let log_level = if args.verbose { "debug" } else { "info" };
+    let log_level = if args.verbose {
+        "debug".to_owned()
+    } else {
+        config.general.log_level.clone()
+    };
     if args.syslog || args.daemonize {
         #[cfg(target_os = "linux")]
         {
             use tracing_subscriber::prelude::*;
-            let env_filter = default_env_filter(log_level);
+            let env_filter = default_env_filter(&log_level);
             match tracing_journald::layer() {
                 Ok(journald) => {
                     tracing_subscriber::registry()
@@ -125,22 +178,34 @@ async fn main() -> Result<()> {
         tracing_subscriber::fmt()
             .with_ansi(false)
             .with_writer(std::io::stderr)
-            .with_env_filter(default_env_filter(log_level))
+            .with_env_filter(default_env_filter(&log_level))
             .init();
     } else {
         tracing_subscriber::fmt()
-            .with_env_filter(default_env_filter(log_level))
+            .with_env_filter(default_env_filter(&log_level))
             .init();
     }
 
     info!("starting rmpd v{}", env!("CARGO_PKG_VERSION"));
 
-    // Load configuration
-    let config = if let Some(config_path) = args.config {
-        rmpd_core::config::Config::load_from_path(config_path)?
-    } else {
-        rmpd_core::config::Config::load_or_default()
-    };
+    // Replay diagnostics collected during config discovery now that the
+    // subscriber is up; discover() never logs directly so nothing is lost.
+    for d in &load.diagnostics {
+        match d.level {
+            DiagLevel::Warn => warn!("{}", d.message),
+            DiagLevel::Info => info!("{}", d.message),
+        }
+    }
+
+    match &load.source {
+        ConfigSource::File(p) => info!("configuration loaded from {p}"),
+        ConfigSource::Generated(p) => {
+            info!("no configuration file found; wrote a starter config to {p}")
+        }
+        ConfigSource::Defaults => {
+            warn!("no configuration file in use; running with built-in defaults")
+        }
+    }
 
     // Override with CLI arguments
     let bind_address = args


### PR DESCRIPTION
## Why

On a headless Arch ARM server, a user's `rmpd.toml` appeared to be ignored entirely:

```
INFO rmpd: music directory: ~/Music
INFO rmpd: database: /home/alarm/.config/rmpd/database.db
ERROR rmpd_protocol::state: library update failed: Failed to read directory: No such file or directory (os error 2)
WARN rmpd::app: filesystem watch disabled: Failed to watch directory: No path was found.
```

The tell is that `database:` is absolute while `music directory:` is a literal `~/Music`. Those two can only disagree on the **defaults** path — the config had been thrown away and `Config::default()` silently substituted.

Three compounding defects, all in `rmpd-core/src/config.rs`:

1. `general`, `network` and `audio` were **required** TOML sections and `music_directory` a required field, so any partial config died on ``missing field `audio` `` — an error `load_or_default()` discarded with `unwrap_or_else(|_| Self::default())`. No log, no exit.
2. `default_music_dir()` fell back to a **literal** `"~/Music"` when `dirs::audio_dir()` returns `None` (headless hosts without `xdg-user-dirs`). Nothing expands `~` on the defaults path, so rmpd scanned a directory literally named `~`.
3. That path also skipped `ensure_directories()`, leaving the database directory uncreated.

## What changed

### Config is never silently ignored

- Sections and `music_directory` are `#[serde(default)]` with per-section `Default` impls, so partial configs parse.
- Default paths resolve against the home directory instead of emitting a literal tilde.
- The fallback config runs the same expansion, directory creation and validation as a loaded one.
- The config source is **always** logged: `configuration loaded from <path>`, `no configuration file found; wrote a starter config to <path>`, or `no configuration file in use; running with built-in defaults`.

### Discovery mirrors mpd(1), generation does not

Search order, first match wins: `--config`, `$XDG_CONFIG_HOME/rmpd/rmpd.toml`, `~/.rmpd.toml`, `~/.rmpd/rmpd.toml`, `/etc/rmpd/rmpd.toml` — the direct analogue of MPD's `$XDG_CONFIG_HOME/mpd/mpd.conf`, `~/.mpdconf`, `~/.mpd/mpd.conf`, `/etc/mpd.conf`.

Where this **deliberately departs** from MPD: MPD never writes a config file. rmpd now writes the annotated starter config on first run and says so, because a daemon silently running on invisible defaults is precisely how this report started. `--no-config` opts out, `--generate-config` writes on demand (refusing to clobber), `--print-config-path` reports the file that would be used.

`rmpd.toml` is the single source of truth: `template_toml()` is `include_str!`-ed from it, and a test asserts it lints clean and matches the built-in defaults section by section — so a key added to the struct but left undocumented, or a stale key left in the file, fails the build instead of rotting.

### Typos are reported, not swallowed

```
WARN unknown config key `general.msic_directory` (did you mean `music_directory`?)
WARN unknown config section `[netwrk]` (did you mean `[network]`?)
WARN `bind_to_address` is mpd.conf syntax; rmpd uses `bind_address` in the `[network]` section
WARN config key `audio.gapless` was removed: gapless playback is always enabled
WARN config section `[decoder]` was removed: decoders are selected at build time
```

MPD makes an unknown parameter **fatal**. rmpd warns instead: a typo should not leave a headless music daemon silent after an upgrade. Keys inside `[[output]]`/`[[source]]` stay free-form, since backends flatten their own settings. Suggestions come from a hand-rolled Levenshtein — no new dependency.

### `log_level` finally works

Config loading moved **ahead** of tracing subscriber setup, which is why `general.log_level` had never had any effect. Diagnostics are collected during discovery (`discover` does no logging of its own) and replayed once logging exists at the configured level. Precedence: `RUST_LOG` > `--verbose` > `general.log_level`.

### Missing `music_directory` degrades instead of dying

It warns and the daemon serves normally, matching MPD's behaviour. `app.rs` now skips the scan and the watcher rather than immediately logging a scan failure and a watch failure for the path just reported — the warning had been promising something the code didn't do.

### Validation

Hard errors only where the daemon would be unusable (`max_connections = 0`, `port = 0`). Recoverable nonsense is clamped with a warning: `buffer_time = 0`, negative `crossfade`, out-of-range ReplayGain preamps, unknown `log_level`.

### Dead keys removed

Parsed but read by nothing, verified across the workspace: `audio.gapless` (gapless is unconditional in `rmpd-player/src/engine.rs`), the `[decoder]` section, `database.cache_size`, `database.fts_enabled`. Configs still containing them get a warning naming each, rather than the daemon pretending to honour them.

## Verification

Reproduced the original failure in a synthetic headless environment (no config, no `xdg-user-dirs`), then confirmed each behaviour end to end:

| Case | Result |
|---|---|
| First run, no config | Generates file, byte-identical to shipped `rmpd.toml`; scan completes |
| Second run | `configuration loaded from …` — loads what it generated |
| `--no-config` | Built-in defaults, no file written |
| Typo + removed + mpd.conf key | 5 warnings with correct suggestions |
| `log_level = "debug"` | 30 DEBUG lines (previously 0 — the key was dead) |
| Missing `music_directory` | Warns, skips scan/watch, still listens |
| `max_connections = 0` | Fatal, single error line, exit 1 |
| `--config /does/not/exist` | Fatal — an explicit path is never silently substituted |
| `--generate-config` twice | Refuses to overwrite, exit 1 |

MPD protocol handshake against the running daemon still returns `OK MPD 0.24.0` with a full `status`/`commands` response.

`cargo test --workspace`: **0 failures** (rmpd-core 108 tests, +27 new). `cargo clippy --workspace --all-targets`: clean. `cargo fmt --all --check`: clean.

Also refreshes `Cargo.lock` (52 transitive crates); the pinned M0Rf30 forks — `lofty-rs`, `Symphonia`, `opensubsonic-rs` — are rev-pinned and verified unchanged.